### PR TITLE
Fix literal encoding

### DIFF
--- a/core/src/Literal.test.ts
+++ b/core/src/Literal.test.ts
@@ -16,8 +16,8 @@ describe("Literal", () => {
     })
 
     it("can handle objects", () => {
-        const testObject = {testString: "test", testNumber: "1337"}
-        const testUrl = "literal://json:%7B%22testString%22%3A%22test%22%2C%22testNumber%22%3A%221337%22%7D"
+        const testObject = {testNumber: "1337", testString: "test"}
+        const testUrl = "literal://json:%7B%22testNumber%22%3A%221337%22%2C%22testString%22%3A%22test%22%7D"
         expect(Literal.from(testObject).toUrl()).toBe(testUrl)
         expect(Literal.fromUrl(testUrl).get()).toStrictEqual(testObject)
     })

--- a/core/src/Literal.test.ts
+++ b/core/src/Literal.test.ts
@@ -17,8 +17,15 @@ describe("Literal", () => {
 
     it("can handle objects", () => {
         const testObject = {testString: "test", testNumber: "1337"}
-        const testUrl = "literal://json:%7B%22testString%22:%22test%22,%22testNumber%22:%221337%22%7D"
+        const testUrl = "literal://json:%7B%22testString%22%3A%22test%22%2C%22testNumber%22%3A%221337%22%7D"
         expect(Literal.from(testObject).toUrl()).toBe(testUrl)
         expect(Literal.fromUrl(testUrl).get()).toStrictEqual(testObject)
+    })
+
+    it("can handle special characters", () => {
+        const testString = "message(X) :- triple('ad4m://self', _, X)."
+        const testUrl = "literal://string:message%28X%29%20%3A-%20triple%28%27ad4m%3A%2F%2Fself%27%2C%20_%2C%20X%29."
+        expect(Literal.from(testString).toUrl()).toBe(testUrl)
+        expect(Literal.fromUrl(testUrl).get()).toBe(testString)
     })
 })

--- a/rust-client/src/literal.rs
+++ b/rust-client/src/literal.rs
@@ -60,8 +60,7 @@ impl Literal {
                 }
                 LiteralValue::Json(json) => {
                     let encoded = urlencoding::encode(&json.to_string()).to_string();
-                    let fixed = encoded.replace("%3A", ":").replace("%2C", ",");
-                    Ok(format!("literal://json:{}", fixed))
+                    Ok(format!("literal://json:{}", encoded))
                 }
             }
         } else {
@@ -84,8 +83,7 @@ impl Literal {
                 } else if literal.starts_with("json:") {
                     let json = literal.replace("json:", "");
                     let decoded = urlencoding::decode(&json)?;
-                    let decoded_json_string = decoded.to_string().replace("\\'", "'");
-                    let parsed = serde_json::from_str::<serde_json::Value>(&decoded_json_string)?;
+                    let parsed = serde_json::from_str::<serde_json::Value>(&decoded)?;
                     Ok(LiteralValue::Json(parsed))
                 } else {
                     Err(anyhow!("Unknown literal type"))
@@ -158,10 +156,10 @@ mod test {
     #[test]
     fn can_handle_objects() {
         let test_object = json!({
-            "testNumber": "1337",
             "testString": "test", 
+            "testNumber": "1337",
         });
-        let test_url = "literal://json:%7B%22testNumber%22:%221337%22,%22testString%22:%22test%22%7D";
+        let test_url = "literal://json:%7B%22testNumber%22%3A%221337%22%2C%22testString%22%3A%22test%22%7D";
 
         let literal = super::Literal::from_json(test_object.clone());
         assert_eq!(literal.to_url().unwrap(), test_url);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2141,11 +2141,6 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@iarna/toml@^2.2.5":
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
-  integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
-
 "@ipld/car@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@ipld/car/-/car-5.0.0.tgz#457b20e79d45912d1ba11b0999512b93079b073d"


### PR DESCRIPTION
Different url-encoding implementation in Rust Literal revealed that the JS Literal code produced Literal URLs that were not valid URLs. With this Literals escape all special characters and both implementations en- and decode the same.