### PR TITLE
Add try/catch to perspective remove handler

### DIFF
--- a/executor/src/core/PerspectivesController.ts
+++ b/executor/src/core/PerspectivesController.ts
@@ -129,15 +129,20 @@ export default class PerspectivesController {
     }
 
     remove(uuid: string) {
-        let perspective = this.#perspectiveInstances.get(uuid);
-        perspective?.clearPolling();
-        if (perspective?.neighbourhood) {
-            this.#context.languageController?.languageRemove(perspective.neighbourhood.linkLanguage);
+        try {
+            let perspective = this.#perspectiveInstances.get(uuid);
+            perspective?.clearPolling();
+            if (perspective?.neighbourhood) {
+                this.#context.languageController?.languageRemove(perspective.neighbourhood.linkLanguage);
+            }
+            this.#perspectiveHandles.delete(uuid)
+            this.#perspectiveInstances.delete(uuid)
+            this.save()
+            this.pubsub.publish(PubSub.PERSPECTIVE_REMOVED_TOPIC, { uuid })
+        } catch (e) {
+            console.error("Error removing perspective:", e);
+            throw new Error(`Error removing perspective: ${e}`);
         }
-        this.#perspectiveHandles.delete(uuid)
-        this.#perspectiveInstances.delete(uuid)
-        this.save()
-        this.pubsub.publish(PubSub.PERSPECTIVE_REMOVED_TOPIC, { uuid })
     }
 
     update(uuid: string, name: string) {


### PR DESCRIPTION
@leifriksheim has reported crashing of ad4min when deleting a perspective. This should stop the crashing and give us a log report when deleting a perspective.