### PR TITLE
JS Subject decorator improvements

### DIFF
--- a/core/src/Ad4mClient.ts
+++ b/core/src/Ad4mClient.ts
@@ -32,6 +32,7 @@ export class Ad4mClient {
         this.#languageClient = new LanguageClient(client)
         this.#neighbourhoodClient = new NeighbourhoodClient(client)
         this.#perspectiveClient = new PerspectiveClient(client, subscribe)
+        this.#perspectiveClient.setExpressionClient(this.#expressionClient)
         this.#runtimeClient = new RuntimeClient(client, subscribe)
     }
 

--- a/core/src/perspectives/PerspectiveClient.ts
+++ b/core/src/perspectives/PerspectiveClient.ts
@@ -1,4 +1,7 @@
 import { ApolloClient, gql } from "@apollo/client/core";
+import { Expression, ExpressionRendered } from "../expression/Expression";
+import { ExpressionClient } from "../expression/ExpressionClient";
+import { ExpressionRef } from "../expression/ExpressionRef";
 import { Link, LinkExpressionInput, LinkExpression, LinkInput, LinkMutations, LinkExpressionMutations } from "../links/Links";
 import unwrapApolloResult from "../unwrapApolloResult";
 import { LinkQuery } from "./LinkQuery";
@@ -39,6 +42,7 @@ export class PerspectiveClient {
     #perspectiveAddedCallbacks: PerspectiveHandleCallback[]
     #perspectiveUpdatedCallbacks: PerspectiveHandleCallback[]
     #perspectiveRemovedCallbacks: UuidCallback[]
+    #expressionClient?: ExpressionClient
 
     constructor(client: ApolloClient<any>, subscribe: boolean = true) {
         this.#apolloClient = client
@@ -51,6 +55,10 @@ export class PerspectiveClient {
             this.subscribePerspectiveUpdated()
             this.subscribePerspectiveRemoved()
         }
+    }
+
+    setExpressionClient(client: ExpressionClient) {
+        this.#expressionClient = client
     }
 
     async all(): Promise<PerspectiveProxy[]> {
@@ -253,6 +261,15 @@ export class PerspectiveClient {
             }`,
             variables: { uuid, link }
         }))
+    }
+
+    // ExpressionClient functions, needed for Subjects:
+    async getExpression(expressionURI: string): Promise<ExpressionRendered> {
+        return await this.#expressionClient.get(expressionURI)
+    }
+
+    async createExpression(content: any, languageAddress: string): Promise<string> {
+        return await this.#expressionClient.create(content, languageAddress)
     }
 
     // Subscriptions:

--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -6,6 +6,8 @@ import { PerspectiveHandle } from './PerspectiveHandle'
 import { Perspective } from "./Perspective";
 import { Literal } from "../Literal";
 import { Subject } from "../subject/Subject";
+import { ExpressionClient } from "../expression/ExpressionClient";
+import { ExpressionRendered } from "../expression/Expression";
 
 type PerspectiveListenerTypes = "link-added" | "link-removed"
 
@@ -137,6 +139,14 @@ export class PerspectiveProxy {
 
     async remove(link: LinkExpressionInput) {
         return await this.#client.removeLink(this.#handle.uuid, link)
+    }
+
+    async getExpression(expressionURI: string): Promise<ExpressionRendered> {
+        return await this.#client.getExpression(expressionURI)
+    }
+
+    async createExpression(content: any, languageAddress: string): Promise<string> {
+        return await this.#client.createExpression(content, languageAddress)
     }
 
     /** Adds a link listener

--- a/core/src/subject/SDNADecorators.ts
+++ b/core/src/subject/SDNADecorators.ts
@@ -48,7 +48,6 @@ export function instanceQuery(options?: InstanceQueryParams) {
             let results = await perspective.infer(query)
             for(let result of results) {
                 let instance = result.Instance
-                console.log("Instance: " + instance)
                 let subject = new Subject(perspective, instance, subjectClassName)
                 await subject.init()
                 instances.push(subject as T)

--- a/core/src/subject/SDNADecorators.ts
+++ b/core/src/subject/SDNADecorators.ts
@@ -23,7 +23,7 @@ export function hasLink(predicate: string): string {
 }
 
 interface InstanceQueryParams {
-    where?: string;
+    where?: object;
 }
 
 export function instanceQuery(options?: InstanceQueryParams) {
@@ -39,7 +39,10 @@ export function instanceQuery(options?: InstanceQueryParams) {
             let subjectClassName = target.name
             let query = `subject_class("${subjectClassName}", c), instance(c, Instance)`
             if(options && options.where) {
-                query += `, ${options.where}`
+                for(let prop in options.where) {
+                    let value = options.where[prop]
+                    query += `, property_getter(c, Instance, "${prop}", "${value}")`
+                }
             }
 
             let results = await perspective.infer(query)

--- a/core/src/subject/SDNADecorators.ts
+++ b/core/src/subject/SDNADecorators.ts
@@ -24,6 +24,7 @@ export function hasLink(predicate: string): string {
 
 interface InstanceQueryParams {
     where?: object;
+    condition?: string;
 }
 
 export function instanceQuery(options?: InstanceQueryParams) {
@@ -45,7 +46,17 @@ export function instanceQuery(options?: InstanceQueryParams) {
                 }
             }
 
+            if(options && options.condition) {
+                query += ', ' + options.condition
+            }
+
             let results = await perspective.infer(query)
+            if(results == false) {
+                return instances
+            }
+            if(typeof results == "string") {
+                throw results
+            }
             for(let result of results) {
                 let instance = result.Instance
                 let subject = new Subject(perspective, instance, subjectClassName)

--- a/core/src/subject/Subject.ts
+++ b/core/src/subject/Subject.ts
@@ -35,7 +35,12 @@ export class Subject {
                     if(results && results.length > 0) {
                         let expressionURI = results[0].Value
                         if(resolveExpressionURI) {
-                            return await this.#perspective.getExpression(expressionURI)
+                            const expression = await this.#perspective.getExpression(expressionURI)
+                            try {
+                                return JSON.parse(expression.data)
+                            } catch(e) {
+                                return expression.data
+                            }
                         } else {
                             return expressionURI
                         }

--- a/core/src/subject/util.ts
+++ b/core/src/subject/util.ts
@@ -7,6 +7,11 @@ export function propertyNameToSetterName(property: string): string {
     return `set${capitalize(property)}`
 }
 
+// e.g. "setName" -> "name"
+export function setterNameToPropertyName(setter: string): string {
+    return setter.replace("set", "").replace(/^[A-Z]/, (m) => m.toLowerCase())
+}
+
 export function singularToPlural(singular: string): string {
     if(singular.endsWith("y")) {
         return singular.slice(0, -1) + "ies"
@@ -29,6 +34,7 @@ export function pluralToSingular(plural: string): string {
 export function collectionToAdderName(collection: string): string {
     return `add${capitalize(pluralToSingular(collection))}`
 }
+
 
 export function stringifyObjectLiteral(obj) {
     if(Array.isArray(obj)) {

--- a/tests/js/integration.test.ts
+++ b/tests/js/integration.test.ts
@@ -6,7 +6,8 @@ import { HttpLink } from "@apollo/client/link/http/index.js";
 import Websocket from "ws";
 import { createClient } from "graphql-ws";
 import { Ad4mClient, Link, LinkQuery, Literal, PerspectiveProxy, 
-    SmartLiteral, SMART_LITERAL_CONTENT_PREDICATE, Subject, subjectProperty, subjectCollection, sdnaOutput,
+    SmartLiteral, SMART_LITERAL_CONTENT_PREDICATE, 
+    instanceQuery, Subject, subjectProperty, subjectCollection, sdnaOutput,
 } from "@perspect3vism/ad4m";
 import { rmSync, readFileSync } from "node:fs";
 import fetch from 'node-fetch';
@@ -313,6 +314,10 @@ describe("Integration", () => {
                 // isSubjectInstance = [hasLink("todo://state")]
 
                 //@ts-ignore
+                @instanceQuery()
+                static async all(perspective: PerspectiveProxy): Promise<Todo[]> { return [] }
+
+                //@ts-ignore
                 @subjectProperty({
                     through: "todo://state", 
                     initial:"todo://ready",
@@ -366,6 +371,11 @@ describe("Integration", () => {
                 let comment = Literal.from("new comment").toUrl()
                 await todo.addComment(comment)
                 expect(await todo.comments).to.deep.equal([comment])
+            })
+
+            it("can retrieve instances through instaceQuery decorator (all(), finished()..)", async () => {
+                let todos = await Todo.all(perspective!)
+                expect(todos.length).to.equal(3)
             })
         })
     })

--- a/tests/js/integration.test.ts
+++ b/tests/js/integration.test.ts
@@ -323,6 +323,9 @@ describe("Integration", () => {
                 @instanceQuery({where: { state: "todo://done" }})
                 static async allDone(perspective: PerspectiveProxy): Promise<Todo[]> { return [] }
 
+                @instanceQuery({condition: 'triple("ad4m://self", _, Instance)'})
+                static async allSelf(perspective: PerspectiveProxy): Promise<Todo[]> { return [] }
+
                 //@ts-ignore
                 @subjectProperty({
                     through: "todo://state", 
@@ -392,6 +395,19 @@ describe("Integration", () => {
                 todos = await Todo.allDone(perspective!)
                 expect(todos.length).to.equal(1)
                 expect(await todos[0].state).to.equal("todo://done")
+            })
+
+            it("can retrieve matching instance through instanceQuery(condition: ..)", async () => {
+                let todos = await Todo.allSelf(perspective!)
+                expect(todos.length).to.equal(0)
+
+                todos = await Todo.all(perspective!)
+                let todo = todos[0]
+                //@ts-ignore
+                perspective!.add(new Link({source: "ad4m://self", target: todo.baseExpression}))
+                
+                todos = await Todo.allSelf(perspective!)
+                expect(todos.length).to.equal(1)
             })
         })
     })

--- a/tests/js/integration.test.ts
+++ b/tests/js/integration.test.ts
@@ -169,9 +169,7 @@ describe("Integration", () => {
                 //@ts-ignore
                 await subject.setTitle(title)
                 //@ts-ignore
-                let retrieved = await subject.title
-                //@ts-ignore
-                expect(JSON.parse(retrieved.data)).to.equal(title)
+                expect(await subject.title).to.equal(title)
             })
 
             it("should be able to get collections as arrays", async () => {
@@ -426,10 +424,7 @@ describe("Integration", () => {
                 expect(await todo.title).to.equal(undefined)
 
                 await todo.setTitle("new title")
-
-                const title = await todo.title
-                //@ts-ignore
-                expect(title.data).to.equal(JSON.stringify("new title"))
+                expect(await todo.title).to.equal("new title")
 
                 //@ts-ignore
                 let links = await perspective!.get(new LinkQuery({source: todo.baseExpression, predicate: "todo://has_title"}))

--- a/tests/js/integration.test.ts
+++ b/tests/js/integration.test.ts
@@ -7,7 +7,8 @@ import Websocket from "ws";
 import { createClient } from "graphql-ws";
 import { Ad4mClient, Link, LinkQuery, Literal, PerspectiveProxy, 
     SmartLiteral, SMART_LITERAL_CONTENT_PREDICATE, 
-    instanceQuery, Subject, subjectProperty, subjectCollection, sdnaOutput,
+    instanceQuery, Subject, subjectProperty, subjectPropertySetter,
+    subjectCollection, sdnaOutput,
 } from "@perspect3vism/ad4m";
 import { rmSync, readFileSync } from "node:fs";
 import fetch from 'node-fetch';
@@ -343,8 +344,15 @@ describe("Integration", () => {
                 setState(state: string) {}
 
                 //@ts-ignore
-                @subjectProperty({through: "todo://has_title"})
+                @subjectProperty({
+                    through: "todo://has_title",
+                    resolve: true,
+                })
                 title: string = ""
+
+                @subjectPropertySetter({
+                    resolveLanguage: 'literal'
+                })
                 setTitle(title: string) {}
 
                 //@ts-ignore

--- a/tests/js/integration.test.ts
+++ b/tests/js/integration.test.ts
@@ -317,6 +317,12 @@ describe("Integration", () => {
                 @instanceQuery()
                 static async all(perspective: PerspectiveProxy): Promise<Todo[]> { return [] }
 
+                @instanceQuery({where: {state: "todo://ready"}})
+                static async allReady(perspective: PerspectiveProxy): Promise<Todo[]> { return [] }
+
+                @instanceQuery({where: { state: "todo://done" }})
+                static async allDone(perspective: PerspectiveProxy): Promise<Todo[]> { return [] }
+
                 //@ts-ignore
                 @subjectProperty({
                     through: "todo://state", 
@@ -373,9 +379,19 @@ describe("Integration", () => {
                 expect(await todo.comments).to.deep.equal([comment])
             })
 
-            it("can retrieve instances through instaceQuery decorator (all(), finished()..)", async () => {
+            it("can retrieve all instances through instaceQuery decoratored all()", async () => {
                 let todos = await Todo.all(perspective!)
                 expect(todos.length).to.equal(3)
+            })
+
+            it("can retrieve all mathching instance through instanceQuery(where: ..)", async () => {
+                let todos = await Todo.allReady(perspective!)
+                expect(todos.length).to.equal(1)
+                expect(await todos[0].state).to.equal("todo://ready")
+
+                todos = await Todo.allDone(perspective!)
+                expect(todos.length).to.equal(1)
+                expect(await todos[0].state).to.equal("todo://done")
             })
         })
     })

--- a/tests/js/subject.pl
+++ b/tests/js/subject.pl
@@ -7,6 +7,8 @@ property_getter(c, Base, "state", Value) :- triple(Base, "todo://state", Value).
 property_setter(c, "state", '[{action: "setSingleTarget", source: "this", predicate: "todo://state", target: "value"}]').
 
 property(c, "title").
+property_resolve(c, "title").
+property_resolve_language(c, "title", "literal").
 property_getter(c, Base, "title", Value) :- triple(Base, "todo://has_title", Value).
 property_setter(c, "title", '[{action: "setSingleTarget", source: "this", predicate: "todo://has_title", target: "value"}]').
 


### PR DESCRIPTION
- [x] `@instanceQuery(where: { <prop>: <value> }` decorator to generate class methods like `Todo.getAll()`, `Todo.getAllDone()`, etc.
- [ ] Easy callback registration for instance created, updated, deleted
- [x] `resolve` flag on auto-generated property getters for returning the expression instead of the URI
