### PR TITLE
AD4Min -> AD4M: also change name of files in ad4m-connects download links

### DIFF
--- a/connect/src/components/Start.ts
+++ b/connect/src/components/Start.ts
@@ -3,9 +3,9 @@ import { version } from "../../package.json";
 import { detectOS } from "../utils";
 
 function downloadAd4m() {
-  const windowsLink = `https://github.com/perspect3vism/ad4m/releases/download/v${version}/AD4Min_${version}_x64_en-US.msi`;
-  const macLink = `https://github.com/perspect3vism/ad4m/releases/download/v${version}/AD4Min_${version}_x64.dmg`;
-  const linuxLink = `https://github.com/perspect3vism/ad4m/releases/download/v${version}/ad4-min_${version}_amd64.deb`;
+  const windowsLink = `https://github.com/perspect3vism/ad4m/releases/download/v${version}/AD4M_${version}_x64_en-US.msi`;
+  const macLink = `https://github.com/perspect3vism/ad4m/releases/download/v${version}/AD4M_${version}_x64.dmg`;
+  const linuxLink = `https://github.com/perspect3vism/ad4m/releases/download/v${version}/ad4m_${version}_amd64.deb`;
   const OSName = detectOS();
   const link = document.createElement("a");
   console.log({ OSName, link });


### PR DESCRIPTION
The Tauri action in our publish workflow picks up the filenames from the project, right?
Is there anything more to do here?