### PR TITLE
Convenient SDNA handling: ensureSDNASubjectClass

### DIFF
--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -417,7 +417,7 @@ export class PerspectiveProxy {
      */
     async subjectClassesByTemplate(obj: object): Promise<string[]> {
         // Collect all string properties of the object in a list
-        let properties = Object.keys(obj).filter(key => typeof obj[key] === "string")
+        let properties = Object.keys(obj).filter(key => !Array.isArray(obj[key]))
 
         // Collect all collections of the object in a list
         let collections = Object.keys(obj).filter(key => Array.isArray(obj[key]))

--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -465,4 +465,19 @@ export class PerspectiveProxy {
             return result.map(x => x.Class)
         }
     }
+
+    /** Takes a JS class (its constructor) and assumes that it was decorated by
+     * the @subjectClass etc. decorators. It then tests if there is a subject class
+     * already present in the perspective's SDNA that matches the given class.
+     * If there is no such class, it gets the JS class's SDNA by calling its
+     * static generateSDNA() function and adds it to the perspective's SDNA.
+     */
+    async ensureSDNASubjectClass(jsClass: any): Promise<void> {
+        if((await this.subjectClassesByTemplate(new jsClass)).length > 0) {
+            return
+        }
+        
+        await this.addSdna(jsClass.generateSDNA())
+    }
+
 }

--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -224,14 +224,16 @@ export class PerspectiveProxy {
     async setSingleTarget(link: Link) {
         const query = new LinkQuery({source: link.source, predicate: link.predicate})
         const foundLinks = await this.get(query)
+        const removals = [];
         for(const l of foundLinks){
             delete l.__typename
             delete l.data.__typename
             delete l.proof.__typename
-            await this.remove(l)
+            removals.push(l);
         }
-            
-        await this.add(link)
+        const additions = [link];
+
+        await this.linkMutations({additions, removals})
     }
 
     /** Returns all the Social DNA flows defined in this perspective */

--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -303,6 +303,15 @@ export class PerspectiveProxy {
         return links.map(link => link.data.target).map(t => Literal.fromUrl(t).get())
     }
 
+    /** Adds the given Social DNA code to the perspective's SDNA code */
+    async addSdna(sdnaCode: string) {
+        await this.add(new Link({
+            source: "ad4m://self",
+            predicate: "ad4m://has_zome",
+            target: Literal.from(sdnaCode).toUrl()
+        }))
+    }
+
     /** Returns all the Subject classes defined in this perspectives SDNA */
     async subjectClasses(): Promise<string[]> {
         try {

--- a/tests/js/integration.test.ts
+++ b/tests/js/integration.test.ts
@@ -448,7 +448,7 @@ describe("Integration", () => {
                 await perspective!.ensureSDNASubjectClass(Test)
 
                 expect(await perspective!.getSdna()).to.have.lengthOf(2)
-                console.log(await perspective!.getSdna()[1])
+                console.log((await perspective!.getSdna())[1])
             })
         })
     })

--- a/tests/js/integration.test.ts
+++ b/tests/js/integration.test.ts
@@ -361,11 +361,11 @@ describe("Integration", () => {
                 addComment(comment: string) {}
 
                 @sdnaOutput
-                static generateSdna(): string { return "" }
+                static generateSDNA(): string { return "" }
             }
 
             it("should generate correct SDNA from a JS class", async () => {
-                let sdna = Todo.generateSdna()
+                let sdna = Todo.generateSDNA()
                 expect(sdna).to.equal(readFileSync("./subject.pl").toString())
             })
 
@@ -431,6 +431,24 @@ describe("Integration", () => {
                 expect(links.length).to.equal(1)
                 let literal = Literal.fromUrl(links[0].data.target).get()
                 expect(literal.data).to.equal("new title")
+            })
+
+            it("can easily be initialized with PerspectiveProxy.ensureSDNASubjectClass()", async () => {
+                expect(await perspective!.getSdna()).to.have.lengthOf(1)
+
+                class Test {
+                    @subjectProperty({through: "test://test_numer"})
+                    number: number = 0
+
+
+                    @sdnaOutput
+                    static generateSDNA(): string { return "" }
+                }
+
+                await perspective!.ensureSDNASubjectClass(Test)
+
+                expect(await perspective!.getSdna()).to.have.lengthOf(2)
+                console.log(await perspective!.getSdna()[1])
             })
         })
     })


### PR DESCRIPTION
New function `PerspectiveProxy.ensureSDNASubjectClass(jsClass)` builds upon the SDNA decorators and makes it super easy to use SDNA Subject classes. We just need to pass in a decorated class into this function. It will check if we already have a Subject class definition in the perspective's SDNA that matches all properties and collections of the provided class. If yes -> do nothing. If no -> get the auto-generated SDNA definition for that class and add it to the perspectives SDNA.