### PR TITLE
Fix missed "ad4m" process calls after AD4Min -> AD4M renaming

### DIFF
--- a/ui/src-tauri/src/main.rs
+++ b/ui/src-tauri/src/main.rs
@@ -81,7 +81,7 @@ fn main() {
     find_and_kill_processes("lair-keystore");
     if !holochain_binary_path().exists() {
         log::info!("init command by copy holochain binary");
-        let status = Command::new_sidecar("ad4m")
+        let status = Command::new_sidecar("ad4m-host")
             .expect("Failed to create ad4m command")
             .args(["init"])
             .status()

--- a/ui/src-tauri/src/system_tray.rs
+++ b/ui/src-tauri/src/system_tray.rs
@@ -43,7 +43,7 @@ pub fn handle_system_tray_event(app: &AppHandle<Wry>, event_id: String) {
             }
         }
         "quit" => {
-            find_and_kill_processes("ad4m");
+            find_and_kill_processes("ad4m-host");
 
             find_and_kill_processes("holochain");
 


### PR DESCRIPTION
that only happen when new agent is generated