### PR TITLE
SDNA collection "where"

### DIFF
--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -8,6 +8,7 @@ import { Literal } from "../Literal";
 import { Subject } from "../subject/Subject";
 import { ExpressionClient } from "../expression/ExpressionClient";
 import { ExpressionRendered } from "../expression/Expression";
+import { collectionAdderToName } from "../subject/util";
 
 type PerspectiveListenerTypes = "link-added" | "link-removed"
 
@@ -345,7 +346,7 @@ export class PerspectiveProxy {
         let className = await this.stringOrTemplateObjectToSubjectClass(subjectClass)
         let result = await this.infer(`subject_class("${className}", C), constructor(C, Actions)`)
         if(!result.length) {
-            throw "No constructor found for given subject class"
+            throw "No constructor found for given subject class: " + className 
         }
 
         let actions = result.map(x => eval(x.Actions))
@@ -451,10 +452,7 @@ export class PerspectiveProxy {
             query += `, property_setter(c, "${property}", _)`
         }
         for(let addFunction of addFunctions) {
-            // e.g. "addComment" -> "comments"
-            let property = addFunction.substring(3)
-            property = property.charAt(0).toLowerCase() + property.slice(1) + "s"
-            query += `, collection_adder(c, "${property}", _)`
+            query += `, collection_adder(c, "${collectionAdderToName(addFunction)}", _)`
         }
 
         query += "."

--- a/core/src/subject/SDNADecorators.ts
+++ b/core/src/subject/SDNADecorators.ts
@@ -85,7 +85,15 @@ export function subjectProperty(opts: PropertyOptions) {
     };
 }
 
-export function subjectCollection(opts: PropertyOptions) {
+interface WhereOptions {
+    isInstance: any
+}
+interface CollectionOptions {
+    through: string,
+    where?: WhereOptions,
+}
+
+export function subjectCollection(opts: CollectionOptions) {
     return function <T>(target: T, key: keyof T) {
         target["__collections"] = target["__collections"] || {};
         target["__collections"][key] = opts;

--- a/core/src/subject/util.ts
+++ b/core/src/subject/util.ts
@@ -35,6 +35,13 @@ export function collectionToAdderName(collection: string): string {
     return `add${capitalize(pluralToSingular(collection))}`
 }
 
+// e.g. "addEntry" -> "entries"
+export function collectionAdderToName(adderName: string): string {
+    let singular = adderName.substring(3)
+    let plural = singularToPlural(singular)
+    return plural.charAt(0).toLowerCase() + plural.slice(1)
+}
+
 
 export function stringifyObjectLiteral(obj) {
     if(Array.isArray(obj)) {

--- a/tests/js/integration.test.ts
+++ b/tests/js/integration.test.ts
@@ -297,6 +297,25 @@ describe("Integration", () => {
         })
 
         describe("SDNA creation decorators", () => {
+            class Message {
+                //@ts-ignore
+                @subjectProperty({
+                    through: "todo://state", 
+                    initial:"todo://ready",
+                    required: true,
+                    resolve: true,
+                })
+                body: string = ""
+
+                @subjectPropertySetter({
+                    resolveLanguage: 'literal'
+                })
+                setBody(title: string) {}
+
+                @sdnaOutput
+                static generateSDNA(): string { return "" }
+            }
+
             // This class matches the SDNA in ./subject.pl
             // and this test proves the decorators create the exact same SDNA code
             class Todo {
@@ -359,6 +378,18 @@ describe("Integration", () => {
                 @subjectCollection({through: "todo://comment"})
                 comments: string[] = []
                 addComment(comment: string) {}
+
+                //@ts-ignore
+                @subjectCollection({through: "flux://entry_type"})
+                entries: string[] = []
+                addEntry(entry: string) {}
+
+                //@ts-ignore
+                @subjectCollection({
+                    through: "flux://entry_type",
+                    where: {isInstance: Message}
+                })
+                messages: string[] = []
 
                 @sdnaOutput
                 static generateSDNA(): string { return "" }
@@ -449,6 +480,27 @@ describe("Integration", () => {
 
                 expect(await perspective!.getSdna()).to.have.lengthOf(2)
                 console.log((await perspective!.getSdna())[1])
+            })
+
+            it("can constrain collection entries through 'where' clause", async () => {
+                perspective!.addSdna(Message.generateSDNA())
+                let root = Literal.from("Collection where test").toUrl()
+                let todo = await perspective!.createSubject(new Todo(), root)
+
+                let messageEntry = Literal.from("test message").toUrl()
+
+                await todo.addEntry(messageEntry)
+
+                let entries = await todo.entries
+                expect(entries.length).to.equal(1)
+
+                let messageEntries = await todo.messages
+                expect(entries.length).to.equal(0)
+
+                await perspective!.createSubject(new Message(), messageEntry)
+
+                messageEntries = await todo.messages
+                expect(entries.length).to.equal(1)
             })
         })
     })

--- a/tests/js/integration.test.ts
+++ b/tests/js/integration.test.ts
@@ -479,7 +479,7 @@ describe("Integration", () => {
                 await perspective!.ensureSDNASubjectClass(Test)
 
                 expect(await perspective!.getSdna()).to.have.lengthOf(2)
-                console.log((await perspective!.getSdna())[1])
+                //console.log((await perspective!.getSdna())[1])
             })
 
             it("can constrain collection entries through 'where' clause", async () => {

--- a/tests/js/integration.test.ts
+++ b/tests/js/integration.test.ts
@@ -375,19 +375,19 @@ describe("Integration", () => {
                 setTitle(title: string) {}
 
                 //@ts-ignore
-                @subjectCollection({through: "todo://comment"})
+                @subjectCollection({ through: "todo://comment" })
                 comments: string[] = []
                 addComment(comment: string) {}
 
                 //@ts-ignore
-                @subjectCollection({through: "flux://entry_type"})
+                @subjectCollection({ through: "flux://entry_type" })
                 entries: string[] = []
                 addEntry(entry: string) {}
 
                 //@ts-ignore
                 @subjectCollection({
                     through: "flux://entry_type",
-                    where: {isInstance: Message}
+                    where: { isInstance: Message }
                 })
                 messages: string[] = []
 

--- a/tests/js/integration.test.ts
+++ b/tests/js/integration.test.ts
@@ -495,12 +495,12 @@ describe("Integration", () => {
                 expect(entries.length).to.equal(1)
 
                 let messageEntries = await todo.messages
-                expect(entries.length).to.equal(0)
+                expect(messageEntries.length).to.equal(0)
 
                 await perspective!.createSubject(new Message(), messageEntry)
 
                 messageEntries = await todo.messages
-                expect(entries.length).to.equal(1)
+                expect(messageEntries.length).to.equal(1)
             })
         })
     })

--- a/tests/js/subject.pl
+++ b/tests/js/subject.pl
@@ -21,4 +21,4 @@ collection_getter(c, Base, "entries", List) :- findall(C, triple(Base, "flux://e
 collection_adder(c, "entries", '[{action: "addLink", source: "this", predicate: "flux://entry_type", target: "value"}]').
 
 collection(c, "messages").
-collection_getter(c, Base, "messages", List) :- findall(C, triple(Base, "flux://entry_type", C), List).
+collection_getter(c, Base, "messages", List) :- setof(C, (triple(Base, "flux://entry_type", C), instance(OtherClass, C), subject_class("Message", OtherClass)), List).

--- a/tests/js/subject.pl
+++ b/tests/js/subject.pl
@@ -15,3 +15,10 @@ property_setter(c, "title", '[{action: "setSingleTarget", source: "this", predic
 collection(c, "comments").
 collection_getter(c, Base, "comments", List) :- findall(C, triple(Base, "todo://comment", C), List).
 collection_adder(c, "comments", '[{action: "addLink", source: "this", predicate: "todo://comment", target: "value"}]').
+
+collection(c, "entries").
+collection_getter(c, Base, "entries", List) :- findall(C, triple(Base, "flux://entry_type", C), List).
+collection_adder(c, "entries", '[{action: "addLink", source: "this", predicate: "flux://entry_type", target: "value"}]').
+
+collection(c, "messages").
+collection_getter(c, Base, "messages", List) :- findall(C, triple(Base, "flux://entry_type", C), List).


### PR DESCRIPTION
This adds a `where` option to the `@subjectCollection()` decorator which currently only takes an `isInstance` value which can either be a class or a string. The auto-created Prolog code will then filter the collection values by adding the `instance` predicate for the provided class.

The test here shows how to use it with another JS Subject class.