### PR TITLE
WIP: Fix release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
       run: yarn run build-linux
     
     - name: "Upload built AD4M launcher"
-      uses: tauri-apps/tauri-action@v0
+      uses: tauri-apps/tauri-action@v0.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,24 +39,24 @@ jobs:
     - name: Yarn Install
       run: yarn install
 
-    - name: Build AD4M-Host & build AD4MIN binary (macos-latest)
+    - name: Build AD4M-Host & build AD4M launcher binary (macos-latest)
       if: matrix.platform == 'macos-latest'
       run: yarn run build-macos
 
-    - name: Build AD4M-Host & build AD4MIN binary (windows-latest)
+    - name: Build AD4M-Host & build AD4M launcher binary (windows-latest)
       if: matrix.platform == 'windows-latest'
       run: yarn run build-windows
 
-    - name: Build AD4M-Host & build AD4MIN binary (linux-latest)
+    - name: Build AD4M-Host & build AD4M launcher binary (linux-latest)
       if: matrix.platform == 'ubuntu-latest'
       run: yarn run build-linux
     
-    - name: "Upload built AD4MIN"
+    - name: "Upload built AD4M launcher"
       uses: tauri-apps/tauri-action@v0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tagName: v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
-        releaseName: "Ad4min v__VERSION__"
+        releaseName: "AD4M launcher v__VERSION__"
         releaseBody: "See the assets to download this version and install."
         projectPath: "./ui"


### PR DESCRIPTION
After renaming AD4Min to AD4M, the artifact names have changed as well. The Tauri publish action did turn "ad4min" into "ad4-min" only on Linux. Now it creates files called "ad4m.deb.." etc. but still expects "ad4-min.deb..". Just had a quick look and not sure how to fix this. Just leaving this WIP here for later..