### PR TITLE
fix joined neighbourhood not setting isJoined value

### DIFF
--- a/executor/src/core/PerspectivismCore.ts
+++ b/executor/src/core/PerspectivismCore.ts
@@ -248,7 +248,7 @@ export default class PerspectivismCore {
         let neighbourhood: Neighbourhood = neighbourHoodExp.data;
         await this.languageController.languageByRef({address: neighbourhood.linkLanguage} as LanguageRef)
 
-        return this.#perspectivesController!.add("", url, neighbourhood);
+        return this.#perspectivesController!.add("", url, neighbourhood, true);
     }
 
     async languageApplyTemplateAndPublish(sourceLanguageHash: string, templateData: object): Promise<LanguageRef> {


### PR DESCRIPTION
This PR ensure that the executor will wait to receive changes before it publishes any commits! 1 line fix, yay!