### PR TITLE
Remove .appimage build targets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,18 +97,6 @@ jobs:
         asset_name: ad4m_${{ steps.extract_version.outputs.version }}_amd64.deb
         asset_content_type: application/octet-stream
 
-    - name: Upload Release AppImage Asset
-      id: upload-release-appimage-asset
-      if: matrix.platform == 'ubuntu-latest'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: /home/runner/work/ad4m/ad4m/target/release/bundle/appimage/ad4m_${{ steps.extract_version.outputs.version }}_amd64.AppImage
-        asset_name: ad4m_${{ steps.extract_version.outputs.version }}_amd64.AppImage
-        asset_content_type: application/octet-stream
-
     - name: Upload Release Macos Asset
       id: upload-release-macos-asset
       if: matrix.platform == 'macos-latest'

--- a/ui/src-tauri/tauri.conf.json
+++ b/ui/src-tauri/tauri.conf.json
@@ -17,7 +17,7 @@
     },
     "bundle": {
       "active": true,
-      "targets": ["deb", "msi", "app", "dmg", "updater"],
+      "targets": ["deb", "msi", "dmg", "updater"],
       "identifier": "dev.ad4m.ad4min",
       "icon": [
         "icons/32x32.png",

--- a/ui/src-tauri/tauri.conf.json
+++ b/ui/src-tauri/tauri.conf.json
@@ -17,7 +17,7 @@
     },
     "bundle": {
       "active": true,
-      "targets": "all",
+      "targets": ["deb", "msi", "app", "dmg", "updater"],
       "identifier": "dev.ad4m.ad4min",
       "icon": [
         "icons/32x32.png",


### PR DESCRIPTION
Closes #163. This should be done right now since vercel pkg breaks our ad4m-host binary, @fayeed has an issue open for this: https://github.com/tauri-apps/tauri/issues/5189