### PR TITLE
Block spawning duplicate AD4M launcher instances

### DIFF
--- a/ui/src-tauri/src/main.rs
+++ b/ui/src-tauri/src/main.rs
@@ -39,6 +39,7 @@ use crate::commands::app::{close_application, close_main_window, clear_state};
 use crate::config::data_path;
 use crate::util::find_port;
 use crate::menu::{handle_menu_event, open_logs_folder};
+use crate::util::has_process_running;
 use crate::util::{find_and_kill_processes, create_main_window, save_executor_port};
 
 // the payload type must implement `Serialize` and `Clone`.
@@ -60,6 +61,11 @@ pub struct AppState {
 }
 
 fn main() {
+    if has_process_running("AD4M") {
+        println!("AD4M is already running");
+        return;
+    }
+
     if data_path().exists() && !data_path().join("ad4m").join("agent.json").exists() {
         let _ = remove_dir_all(data_path());
     }

--- a/ui/src-tauri/src/util.rs
+++ b/ui/src-tauri/src/util.rs
@@ -4,6 +4,7 @@ use crate::menu::open_logs_folder;
 use std::fs::remove_file;
 use std::fs::File;
 use std::io::prelude::*;
+use sysinfo::Process;
 use sysinfo::{ProcessExt, Signal, System, SystemExt};
 use tauri::{AppHandle, Manager, WindowBuilder, WindowEvent, WindowUrl, Wry};
 
@@ -32,6 +33,18 @@ pub fn find_and_kill_processes(name: &str) {
     }
 }
 
+pub fn has_process_running(name: &str) -> bool {
+    let processes = System::new_all();
+    let processes_by_name: Vec<&Process> = processes.processes_by_exact_name(name).collect();
+    let mut running = false;
+
+    for process in processes_by_name {
+        log::info!("Prosses running: {} {}", process.pid(), process.name());
+        running = true;
+    }
+    running
+}
+
 pub fn create_main_window(app: &AppHandle<Wry>) {
     let url = app_url();
 
@@ -49,7 +62,11 @@ pub fn create_main_window(app: &AppHandle<Wry>) {
     //let _ = tray_window.move_window(Position::TrayCenter);
 
     let _id = tray_window.listen("copyLogs", |event| {
-        log::info!("got window event-name with payload {:?} {:?}", event, event.payload());
+        log::info!(
+            "got window event-name with payload {:?} {:?}",
+            event,
+            event.payload()
+        );
 
         open_logs_folder();
     });
@@ -64,7 +81,6 @@ pub fn create_main_window(app: &AppHandle<Wry>) {
             }
         }
     });
-
 }
 
 pub fn save_executor_port(port: u16) {


### PR DESCRIPTION
Closes: #168. Does not refocus existing window since I dont think tauri exposes an API for this, maybe we can make our own solution @lucksus ?