### PR TITLE
Wait for repo.lock to disappear before running ad4m-host startup

### DIFF
--- a/ui/src-tauri/src/main.rs
+++ b/ui/src-tauri/src/main.rs
@@ -64,8 +64,9 @@ fn main() {
         let _ = remove_dir_all(data_path());
     }
 
-    if data_path().join("ad4m").join("ipfs").join("repo.lock").exists() {
-        let _ = remove_dir_all(data_path().join("ad4m").join("ipfs").join("repo.lock"));
+    while data_path().join("ad4m").join("ipfs").join("repo.lock").exists() {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        println!("IPFS repo.lock exists, waiting...");
     }
     
     if let Err(err) = setup_logs() {


### PR DESCRIPTION
Closes: #167. 

Right now if you open AD4M launcher, quit and then quickly re-open another window, IPFS init will error due since the old IPFS node is still shutting down. It seems that the previous implementation of deleting the file did not work... here we will just wait until the lock is release and then open the launcher.