### PR TITLE
Update button text on download - closes #161

### DIFF
--- a/connect/src/components/AgentLocked.ts
+++ b/connect/src/components/AgentLocked.ts
@@ -11,9 +11,7 @@ export default function AgentLocked({ unlockAgent, connectToPort }) {
             continue.
           </p>
         </div>
-        <button class="button" @click=${() => connectToPort()}>
-          Reconnect
-        </button>
+        <button class="button" @click=${() => connectToPort()}>Connect</button>
       </div>
     </div>
   `;

--- a/connect/src/components/Start.ts
+++ b/connect/src/components/Start.ts
@@ -26,40 +26,59 @@ function downloadAd4m() {
 export default function Start({
   connectToPort,
   isMobile,
+  hasClickedDownload,
+  onDownloaded,
   changeState,
   scanQrcode,
 }) {
   return html`
     <div class="items">
-      <div class="text-center">
-        ${!isMobile
-          ? html`<a
-              class="button"
-              target="_blank"
-              @click=${() => downloadAd4m()}
-            >
-              Install AD4M
-            </a>`
-          : html`<button class="button" @click=${() => scanQrcode()}>
-              Connect with QR
-            </button> `}
-      </div>
+      ${!hasClickedDownload
+        ? html`<div class="text-center">
+              ${!isMobile
+                ? html`<a
+                    class="button"
+                    target="_blank"
+                    @click=${() => {
+                      downloadAd4m();
+                      onDownloaded();
+                    }}
+                  >
+                    Install AD4M
+                  </a>`
+                : html`<button class="button" @click=${() => scanQrcode()}>
+                    Connect with QR
+                  </button> `}
+            </div>
+            <div class="text-center">
+              <button
+                class="button button--link "
+                @click=${() => connectToPort()}
+              >
+                Reconnect
+              </button>
+              or
+              <button
+                class="button button--link "
+                @click=${() => changeState("remote_url")}
+              >
+                Connect to a remote host
+              </button>
+            </div>`
+        : html`<div class="text-center">
+            <a class="button" target="_blank" @click=${() => connectToPort()}>
+              Reconnect
+            </a>
+            <p>
+              Please click reconnect once you have downloaded and setup your
+              AD4M agent
+            </p>
+          </div>`}
 
       <div class="text-center">
-        <button class="button button--link " @click=${() => connectToPort()}>
-          Reconnect
-        </button>
-        or
-        <button
-          class="button button--link "
-          @click=${() => changeState("remote_url")}
+        <a class="button button--link" _target="blank" href="https://ad4m.dev"
+          >Learn more about AD4M</a
         >
-          Connect to a remote host
-        </button>
-      </div>
-
-      <div class="text-center">
-          <a class="button button--link" _target="blank" href="https://ad4m.dev">Learn more about AD4M</a>
       </div>
     </div>
   `;

--- a/connect/src/web.ts
+++ b/connect/src/web.ts
@@ -350,6 +350,9 @@ export default class Ad4mConnect extends LitElement {
   @state()
   private _isMobile = null;
 
+  @state()
+  private _hasClickedDownload = null;
+
   @property({ type: String, reflect: true })
   appname = null;
 
@@ -529,10 +532,10 @@ export default class Ad4mConnect extends LitElement {
     };
 
     const cancelBtn = document.getElementById("stop-scan");
-    cancelBtn.addEventListener("click", function() {
+    cancelBtn.addEventListener("click", function () {
       html5QrCode.stop();
       ele.style.display = "none";
-    })
+    });
 
     html5QrCode.start(
       { facingMode: "environment" },
@@ -570,6 +573,10 @@ export default class Ad4mConnect extends LitElement {
     this._code = code;
   }
 
+  onDownloaded() {
+    this._hasClickedDownload = true;
+  }
+
   verifyCode(code) {
     this._client.verifyCode(code);
   }
@@ -590,6 +597,8 @@ export default class Ad4mConnect extends LitElement {
           scanQrcode: this.scanQrcode,
           connectToPort: this.connectToPort,
           isMobile: this._isMobile,
+          hasClickedDownload: this._hasClickedDownload,
+          onDownloaded: this.onDownloaded,
           changeState: this.changeState,
         });
       case "agent_locked":


### PR DESCRIPTION
I've made it so that the bottom texts "Reconnect or Connect to a remote host" is hidden after download, but this can be changed. It seemed a bit crowded with two "reconnect" triggers and the extra text.

Before/after trigger

![image](https://user-images.githubusercontent.com/4840600/211516560-c70467f6-e978-475e-93b0-f061df4c1bfa.png)

![image](https://user-images.githubusercontent.com/4840600/211516513-2c017dcc-58f4-4895-973c-99ef865407f6.png)
