### PR TITLE
Show Connection error screen if localhost blocked - closes #69

### DIFF
--- a/connect/src/components/CouldNotMakeRequest.ts
+++ b/connect/src/components/CouldNotMakeRequest.ts
@@ -6,15 +6,19 @@ export default function CouldNotMakeRequest() {
       <div class="text-center">
         <h1 class="heading">Request to AD4M blocked</h1>
         <div class="body">
-          Its possible your browser is blocking requests to your local machine. Please remove any browser shields/protection that may be running for this page.
-          Alternatively allow requests to localhost:3000 in your browser settings.
+          Its possible your browser is blocking requests to your local machine.
+          Please remove any browser shields/protection that may be running for
+          this page. Alternatively allow requests to localhost in your browser
+          settings.
         </div>
       </div>
 
       <div class="buttons">
-        <button class="button button--full button--secondary" @click=${() =>
-            location.reload()}>
-            Try again
+        <button
+          class="button button--full button--secondary"
+          @click=${() => location.reload()}
+        >
+          Try again
         </button>
       </div>
     </div>

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -48,6 +48,7 @@ export type ClientStates =
   | "not_connected"
   | "loading"
   | "disconnected"
+  | "connection-error"
   | "remote_url";
 
 export type ConfigStates = "port" | "url" | "token";
@@ -242,6 +243,9 @@ class Client {
             if (this.isFullyInitialized) {
               this.notifyStateChange("disconnected");
             }
+          },
+          error: (error) => {
+            this.notifyStateChange("connection-error");
           },
         },
       })

--- a/connect/src/web.ts
+++ b/connect/src/web.ts
@@ -11,6 +11,7 @@ import AgentLocked from "./components/AgentLocked";
 import RequestCapability from "./components/RequestCapability";
 import InvalidToken from "./components/InvalidToken";
 import VerifyCode from "./components/VerifyCode";
+import CouldNotMakeRequest from "./components/CouldNotMakeRequest";
 import Header from "./components/Header";
 import { ClientStates } from "./core";
 import autoBind from "auto-bind";
@@ -529,10 +530,10 @@ export default class Ad4mConnect extends LitElement {
     };
 
     const cancelBtn = document.getElementById("stop-scan");
-    cancelBtn.addEventListener("click", function() {
+    cancelBtn.addEventListener("click", function () {
       html5QrCode.stop();
       ele.style.display = "none";
-    })
+    });
 
     html5QrCode.start(
       { facingMode: "environment" },
@@ -611,6 +612,8 @@ export default class Ad4mConnect extends LitElement {
         });
       case "disconnected":
         return Disconnected({ connectToPort: this.connectToPort });
+      case "connection-error":
+        return CouldNotMakeRequest();
       case "verify_code":
         return VerifyCode({
           code: this._code,


### PR DESCRIPTION
After some debugging I believe GraphQLWsLink -> on.error is the place to hook into these connection errors.

This needs to be tested, but locally I get the following results:

- localhost unblocked: Normal flow
- localhost blocked: New screen
- network disconnected: No change

@jdeepee - The below used to specify `localhost:3000` as the URL to be unblocked, but I think `ws://localhost:12000/graphql` is the actual URL requested. Do we specify this or leave it as 'localhost'?

![image](https://user-images.githubusercontent.com/4840600/211576487-7c68c782-0680-4a05-88d9-e4bd26d8a55e.png)
