### PR TITLE
Bard/connection errors

### DIFF
--- a/connect/src/components/AgentLocked.ts
+++ b/connect/src/components/AgentLocked.ts
@@ -11,7 +11,9 @@ export default function AgentLocked({ unlockAgent, connectToPort }) {
             continue.
           </p>
         </div>
-        <button class="button" @click=${() => connectToPort()}>Connect</button>
+        <button class="button" @click=${() => connectToPort()}>
+          Reconnect
+        </button>
       </div>
     </div>
   `;

--- a/connect/src/components/Disconnected.ts
+++ b/connect/src/components/Disconnected.ts
@@ -1,15 +1,13 @@
 import { html } from "lit";
 
-export default function Disconnected({ connectToPort }) {
+export default function Disconnected({ reconnect }) {
   return html`
     <div class="items items--small">
       <div class="text-center">
         <h1 class="heading">Disconnected</h1>
       </div>
       <div class="text-center">
-        <button class="button" @click=${() => connectToPort()}>
-          Reconnect
-        </button>
+        <button class="button" @click=${() => reconnect()}>Reconnect</button>
       </div>
     </div>
   `;

--- a/connect/src/components/Start.ts
+++ b/connect/src/components/Start.ts
@@ -67,7 +67,7 @@ export default function Start({
             </div>`
         : html`<div class="text-center">
             <a class="button" target="_blank" @click=${() => connectToPort()}>
-              Reconnect
+              Connect
             </a>
             <p>
               Please click reconnect once you have downloaded and setup your

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -68,7 +68,6 @@ class Client {
   capabilities: { [x: string]: any }[];
   stateListeners: Function[];
   configListeners: Function[];
-  hasUserInteracted: boolean;
 
   // @fayeed - params
   constructor({
@@ -90,7 +89,6 @@ class Client {
     this.token = token || this.token;
     this.stateListeners = [];
     this.configListeners = [];
-    this.hasUserInteracted = false;
 
     this.buildClient();
 
@@ -146,10 +144,6 @@ class Client {
   }
 
   async connect(url?: string) {
-    console.log("Calling connect");
-
-    this.hasUserInteracted = true;
-
     if (url) {
       this.setUrl(url);
     }

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -68,6 +68,7 @@ class Client {
   capabilities: { [x: string]: any }[];
   stateListeners: Function[];
   configListeners: Function[];
+  hasUserInteracted: boolean;
 
   // @fayeed - params
   constructor({
@@ -89,6 +90,7 @@ class Client {
     this.token = token || this.token;
     this.stateListeners = [];
     this.configListeners = [];
+    this.hasUserInteracted = false;
 
     this.buildClient();
 
@@ -144,6 +146,10 @@ class Client {
   }
 
   async connect(url?: string) {
+    console.log("Calling connect");
+
+    this.hasUserInteracted = true;
+
     if (url) {
       this.setUrl(url);
     }
@@ -198,6 +204,8 @@ class Client {
       // show no open port error & ask to retry
       this.setPortSearchState("not_found");
       this.notifyStateChange("not_connected");
+    } else if (message === "The user aborted a request.") {
+      this.notifyStateChange("connection-error");
     } else {
       this.notifyStateChange("not_connected");
     }
@@ -243,9 +251,6 @@ class Client {
             if (this.isFullyInitialized) {
               this.notifyStateChange("disconnected");
             }
-          },
-          error: (error) => {
-            this.notifyStateChange("connection-error");
           },
         },
       })

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -199,11 +199,11 @@ class Client {
       this.notifyStateChange("invalid_token");
     } else if (message.includes("Failed to fetch")) {
       // wrong agent error
-      this.notifyStateChange("not_connected");
+      this.notifyStateChange("connection-error");
     } else if (message === "Couldn't find an open port") {
       // show no open port error & ask to retry
       this.setPortSearchState("not_found");
-      this.notifyStateChange("not_connected");
+      this.notifyStateChange("connection-error");
     } else if (message === "The user aborted a request.") {
       this.notifyStateChange("connection-error");
     } else {

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -130,7 +130,7 @@ class Client {
   }
 
   setUrl(url: string) {
-    if (this.url === url) return;
+    // if (this.url === url) return;
     this.url = url;
     this.notifyConfigChange("url", url);
     this.buildClient();
@@ -147,6 +147,13 @@ class Client {
     if (url) {
       this.setUrl(url);
     }
+
+    this.notifyStateChange("loading");
+    this.checkConnection();
+  }
+
+  async reconnect() {
+    this.buildClient();
     this.notifyStateChange("loading");
     this.checkConnection();
   }

--- a/connect/src/web.ts
+++ b/connect/src/web.ts
@@ -429,6 +429,10 @@ export default class Ad4mConnect extends LitElement {
     this._client.connect();
   }
 
+  reconnect() {
+    this._client.reconnect();
+  }
+
   async connected() {
     try {
       await this.getAd4mClient().agent.status();
@@ -620,7 +624,7 @@ export default class Ad4mConnect extends LitElement {
           appiconpath: this.appiconpath,
         });
       case "disconnected":
-        return Disconnected({ connectToPort: this.connectToPort });
+        return Disconnected({ reconnect: this.reconnect });
       case "connection-error":
         return CouldNotMakeRequest();
       case "verify_code":


### PR DESCRIPTION
- FIX: Text change on the "Connect" button (after clicking "Install AD4M")
- FIX: Reverted text change to agent_locked screen (made in error)
- Moved the "Cannot connect" screen so that it appears after clicking "connect" or "reconnect", if the request fails
- Also show "Cannot connect" screen if no open ports (This check had no UI effects previously)
- New "reconnect" method triggered by the "Disconnected" screen