### PR TITLE
Fix already-running-check and Neighbourhood initial sync

### DIFF
--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -121,7 +121,7 @@ export default class Perspective {
                             // ...publish them...
                             await this.callLinksAdapter('commit', batchedMutations);
                             // ...and clear the temporary storage
-                            this.#db.clearPendingDiffs()
+                            this.#db.clearPendingDiffs(this.uuid)
                         }
                         
                         //If we are fast polling (since we have not seen any changes) and we see changes, we can slow down the polling

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -103,7 +103,6 @@ export default class Perspective {
                     if (this.isFastPolling && currentRevision) {
                         this.isFastPolling = false;
                         clearInterval(this.#pollingInterval);
-                        this.#pollingInterval = this.setupPolling(30000);
 
                         //Lets also publish the links we have commited but not pushed since we were not connected
                         const mutations = this.#db.getPendingDiffs(this.uuid);
@@ -118,6 +117,7 @@ export default class Perspective {
                             batchedMutations.removals.push(removal);
                         }
                         await this.callLinksAdapter('commit', batchedMutations);
+                        this.#pollingInterval = this.setupPolling(30000);
                     }
 
                     let links = await this.callLinksAdapter("pull");

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -103,7 +103,7 @@ export default class Perspective {
                     if (currentRevision) {
                         //Let's check if we have unpublished diffs:
                         const mutations = this.#db.getPendingDiffs(this.uuid);
-                        if(mutations.length > 0) {
+                        if(mutations && mutations.length > 0) {
                             // If we do, collect them...
                             const batchedMutations = {
                                 additions: [],

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -232,7 +232,7 @@ export default class Perspective {
         })
     }
 
-    private getCurrentRevision(): Promise<String | null> {
+    private getCurrentRevision(): Promise<string | null> {
         if(!this.neighbourhood || !this.neighbourhood.linkLanguage) {
             return Promise.resolve(null)
         }
@@ -243,7 +243,13 @@ export default class Perspective {
                 const address = this.neighbourhood!.linkLanguage;
                 const linksAdapter = await this.#languageController?.getLinksAdapter({address} as LanguageRef);
                 if(linksAdapter) {
-                    const result = await linksAdapter.currentRevision();
+                    let result: string|null = await linksAdapter.currentRevision();
+                    if(typeof(result) == 'string') {
+                        result = result.trim()
+                        if(result.length == 0) {
+                            result = null
+                        }
+                    }
                     resolve(result)
                 } else {
                     console.error("LinksSharingLanguage", address, "set in perspective '"+this.name+"' not installed!")
@@ -268,8 +274,8 @@ export default class Perspective {
             canCommit = true;
         } else {
             //We did not create the neighbourhood, so we should check if we already have some data sync'd before making a commit
-            const currentRevision = this.getCurrentRevision();
-            if (currentRevision != null) {
+            const currentRevision: string|null = await this.getCurrentRevision();
+            if (typeof(currentRevision) == 'string' && currentRevision!.trim().length > 0) {
                 canCommit = true;
             }
         }

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -243,14 +243,25 @@ export default class Perspective {
                 const address = this.neighbourhood!.linkLanguage;
                 const linksAdapter = await this.#languageController?.getLinksAdapter({address} as LanguageRef);
                 if(linksAdapter) {
-                    let result: string|null = await linksAdapter.currentRevision();
-                    if(typeof(result) == 'string') {
-                        result = result.trim()
-                        if(result.length == 0) {
-                            result = null
-                        }
+                    let currentRevisionString = await linksAdapter.currentRevision();
+
+                    if(!currentRevisionString) {
+                        resolve(null)
+                        return
                     }
-                    resolve(result)
+
+                    if(typeof(currentRevisionString) != 'string') {
+                        //@ts-ignore
+                        currentRevisionString = currentRevisionString.toString()
+                    }
+
+                    currentRevisionString = currentRevisionString.trim()
+                    if(currentRevisionString.length == 0) {
+                        resolve(null)
+                    } else {
+                        resolve(currentRevisionString)
+                    }
+
                 } else {
                     console.error("LinksSharingLanguage", address, "set in perspective '"+this.name+"' not installed!")
                     // TODO: request install
@@ -274,8 +285,7 @@ export default class Perspective {
             canCommit = true;
         } else {
             //We did not create the neighbourhood, so we should check if we already have some data sync'd before making a commit
-            const currentRevision: string|null = await this.getCurrentRevision();
-            if (typeof(currentRevision) == 'string' && currentRevision!.trim().length > 0) {
+            if (await this.getCurrentRevision()) {
                 canCommit = true;
             }
         }

--- a/executor/src/core/db.test.ts
+++ b/executor/src/core/db.test.ts
@@ -2,6 +2,7 @@ import { PerspectivismDb } from './db'
 import Memory from 'lowdb/adapters/Memory'
 import { v4 as uuidv4 } from 'uuid';
 import { expect } from "chai";
+import { LinkExpression, PerspectiveDiff } from '@perspect3vism/ad4m';
 
 describe('PerspectivismDb', () => {
     let db: PerspectivismDb | undefined
@@ -162,5 +163,12 @@ describe('PerspectivismDb', () => {
         const result2 = db!.getLinksByTarget(pUUID!, '1')
 
         expect(result2).to.be.deep.equal([])
+    })
+
+    it('can get & remove pendingDiffs()', () => {
+        db?.addPendingDiff(pUUID!, {additions: [], removals: []} as PerspectiveDiff);
+        const get = db?.getPendingDiffs(pUUID!);
+        expect(get?.length).to.be.equal(1);
+        expect(get).to.be.deep.equal([{additions: [], removals: []} as PerspectiveDiff]);
     })
 })

--- a/executor/src/core/db.test.ts
+++ b/executor/src/core/db.test.ts
@@ -170,5 +170,8 @@ describe('PerspectivismDb', () => {
         const get = db?.getPendingDiffs(pUUID!);
         expect(get?.length).to.be.equal(1);
         expect(get).to.be.deep.equal([{additions: [], removals: []} as PerspectiveDiff]);
+        db!.clearPendingDiffs(pUUID!)
+        const get2 = db?.getPendingDiffs(pUUID!);
+        expect(get2?.length).to.be.equal(0);
     })
 })

--- a/executor/src/core/db.ts
+++ b/executor/src/core/db.ts
@@ -153,6 +153,11 @@ export class PerspectivismDb {
         const key = this.pendingLinkKey(pUUID);
         return this.#db.get(key).value()
     }
+
+    clearPendingDiffs(pUUID: string): void {
+        const key = this.pendingLinkKey(pUUID);
+        this.#db.set(key, []).write()
+    }
 }
 
 export function init(dbFilePath: string): PerspectivismDb {

--- a/executor/src/core/storage-services/Holochain/HolochainService.ts
+++ b/executor/src/core/storage-services/Holochain/HolochainService.ts
@@ -413,12 +413,13 @@ export default class HolochainService {
             })
             const result = await this.#appWebsocket!.callZome(signedZomeCall)
             if (typeof result === "string") {
-                console.debug("\x1b[32m", new Date().toISOString(),"HolochainService zome function result:", result.substring(50), "... \x1b[0m")
+                console.debug("\x1b[32m", new Date().toISOString(),"HolochainService zome function result (string):", result.substring(0, 50), "... \x1b[0m")
             } else if (typeof result === "object") {
                 let resultString = JSON.stringify(result);
-                console.debug("\x1b[32m", new Date().toISOString(),"HolochainService zome function result:", resultString.substring(50), "... \x1b[0m")
+                let endingLog = resultString.length > 50 ? "... \x1b[0m" : "\x1b[0m";
+                console.debug("\x1b[32m", new Date().toISOString(),"HolochainService zome function result (object):", resultString.substring(0, 50), endingLog)
             } else {
-                console.debug("\x1b[32m", new Date().toISOString(),"HolochainService zome function result:", result, "\x1b[0m")
+                console.debug("\x1b[32m", new Date().toISOString(),"HolochainService zome function result (other):", result, "\x1b[0m")
             }
             return result
         } catch(e) {

--- a/ui/src-tauri/src/main.rs
+++ b/ui/src-tauri/src/main.rs
@@ -39,7 +39,7 @@ use crate::commands::app::{close_application, close_main_window, clear_state};
 use crate::config::data_path;
 use crate::util::find_port;
 use crate::menu::{handle_menu_event, open_logs_folder};
-use crate::util::has_process_running;
+use crate::util::has_processes_running;
 use crate::util::{find_and_kill_processes, create_main_window, save_executor_port};
 
 // the payload type must implement `Serialize` and `Clone`.
@@ -61,7 +61,7 @@ pub struct AppState {
 }
 
 fn main() {
-    if has_process_running("AD4M") {
+    if has_processes_running("AD4M") > 1 {
         println!("AD4M is already running");
         return;
     }

--- a/ui/src-tauri/src/util.rs
+++ b/ui/src-tauri/src/util.rs
@@ -33,16 +33,10 @@ pub fn find_and_kill_processes(name: &str) {
     }
 }
 
-pub fn has_process_running(name: &str) -> bool {
+pub fn has_processes_running(name: &str) -> usize {
     let processes = System::new_all();
     let processes_by_name: Vec<&Process> = processes.processes_by_exact_name(name).collect();
-    let mut running = false;
-
-    for process in processes_by_name {
-        log::info!("Prosses running: {} {}", process.pid(), process.name());
-        running = true;
-    }
-    running
+    processes_by_name.len()
 }
 
 pub fn create_main_window(app: &AppHandle<Wry>) {


### PR DESCRIPTION
Several fixes:
1. Initial check in the launcher bailing when AD4M runs already doesn't count itself in - which made it always bail
2. Neighbourhood joining code, that waits for the LinkLanguage to successfully pull before committing diffs works now
  a) `linksAdapter.currentRevision()` does not return `null` when there is no revision yet, but empty-string. This is handled correctly now
  b) delayed publishing of `pendingDiffs` was only working when the executor was not restarted between initial joining and actually having synced. now we only rely on the information that there are pendingDiffs in the DB. therefore added `clearPendingDiffs()` to the DB to cleanup after publishing pending diffs.
  c) polling loop is now pulling first and then publishing pending diffs to avoid merge loop