### PR TITLE
add check if neighbourhood is already installed

### DIFF
--- a/executor/src/core/PerspectivismCore.ts
+++ b/executor/src/core/PerspectivismCore.ts
@@ -240,6 +240,11 @@ export default class PerspectivismCore {
     }
 
     async installNeighbourhood(url: Address): Promise<PerspectiveHandle> {
+        const perspectives = this.#perspectivesController!.allPerspectiveHandles();
+        if (perspectives.some(p => p.sharedUrl === url)) {
+            throw Error(`Neighbourhood with URL ${url} already installed`);
+        }
+
         let neighbourHoodExp = await this.languageController.getPerspective(parseExprUrl(url).expression);
         if (neighbourHoodExp == null) {
             throw Error(`Could not find neighbourhood with URL ${url}`);

--- a/executor/src/tests/neighbourhood.ts
+++ b/executor/src/tests/neighbourhood.ts
@@ -37,12 +37,8 @@ export default function neighbourhoodTests(testContext: TestContext) {
 
                 const perspective = await ad4mClient.perspective.byUUID(create.uuid);
                 expect(perspective?.neighbourhood).not.to.be.undefined;
-
-                const join = await ad4mClient.neighbourhood.joinFromUrl(publishPerspective );
-                expect(join.sharedUrl).to.be.equal(publishPerspective);
-                expect(join.neighbourhood).not.to.be.undefined;
-                expect(join.neighbourhood!.linkLanguage).to.be.equal(socialContext.address);
-                expect(join.neighbourhood!.meta.links.length).to.be.equal(1);
+                expect(perspective?.neighbourhood!.linkLanguage).to.be.equal(socialContext.address);
+                expect(perspective?.neighbourhood!.meta.links.length).to.be.equal(1);
             })
 
             it('can be created by Alice and joined by Bob', async () => {


### PR DESCRIPTION
I did not need to implement holochain DNA deletion logic for languages since we now install DNA's provided by languages at the holochain app level, with each language having its own app & internal DNA's. 

Since it is not possible to install multiple languages, it should not be possible to install duplicate holochain apps. It may however be possible to have two different languages expose the same underlying holochain DNA, in this case maybe it would be best to have the two languages share one app / dna. We can address this later if it arrises as a common pattern.

closes #201 