### PR TITLE
Fix generate bootstrap

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 ### Removed
 
 ### Fixed
+ - Bootstrap seed creation working with cli: `ad4m dev generate-bootstrap` [PR#247](https://github.com/perspect3vism/ad4m/pull/247)
  
 
 

--- a/cli/src/bootstrap_publish.rs
+++ b/cli/src/bootstrap_publish.rs
@@ -1,5 +1,5 @@
+use ad4m_client::Ad4mClient;
 use anyhow::Result;
-use clap::Parser;
 use colour::{blue_ln, green_ln};
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader};
@@ -7,8 +7,6 @@ use std::path::PathBuf;
 use std::process::exit;
 use std::sync::mpsc::Sender;
 use std::{fs, process::Stdio};
-
-use crate::{get_ad4m_client, ClapApp};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SeedProto {
@@ -118,9 +116,11 @@ pub async fn start_publishing(
     seed_proto: SeedProto,
     language_language_bundle: String,
 ) {
-    let ad4m_client = get_ad4m_client(&ClapApp::parse())
-        .await
-        .expect("Could not get ad4m client");
+    let ad4m_client = Ad4mClient::new(
+        "http://localhost:4000/graphql".to_string(),
+        "".to_string()
+    );
+
     let agent = ad4m_client
         .agent
         .unlock(passphrase)

--- a/cli/src/bootstrap_publish.rs
+++ b/cli/src/bootstrap_publish.rs
@@ -127,6 +127,11 @@ pub async fn start_publishing(
         .await
         .expect("could not unlock agent");
 
+    if let Some(error) = agent.error {
+        println!("Error unlocking agent: {}", error);
+        exit(1);
+    }
+    
     green_ln!("Unlocked agent\n");
 
     let mut languages = vec![];

--- a/cli/src/dev.rs
+++ b/cli/src/dev.rs
@@ -1,0 +1,125 @@
+
+use anyhow::{Result};
+use clap::Subcommand;
+use colour::{self, blue_ln, green_ln};
+use std::fs;
+use std::sync::mpsc::channel;
+
+use crate::bootstrap_publish::*;
+
+#[derive(Debug, Subcommand)]
+pub enum DevFunctions {
+    /// Generate bootstrap seed from a local prototype JSON file declaring languages to be published
+    GenerateBootstrap {
+        agent_path: String,
+        passphrase: String,
+        ad4m_host_path: String,
+        seed_proto: String,
+    },
+}
+
+pub async fn run(command: DevFunctions) -> Result<()> {
+    match command {
+        DevFunctions::GenerateBootstrap {
+            agent_path,
+            passphrase,
+            ad4m_host_path,
+            seed_proto,
+        } => {
+            green_ln!(
+                "Attempting to generate a new bootstrap seed using ad4m-host path: {:?} and agent path: {:?}\n",
+                ad4m_host_path,
+                agent_path
+            );
+
+            //Load the seed proto first so we know that works before making new agent path
+            let seed_proto = fs::read_to_string(seed_proto)?;
+            let seed_proto: SeedProto = serde_json::from_str(&seed_proto)?;
+            green_ln!("Loaded seed prototype file!\n");
+
+            //Create a new ~/.ad4m-publish path with agent.json file supplied
+            let data_path = dirs::home_dir()
+                .expect("Could not get home directory")
+                .join(".ad4m-publish");
+            let data_path_files = std::fs::read_dir(&data_path);
+            if data_path_files.is_ok() {
+                fs::remove_dir_all(&data_path)?;
+            }
+            //Create the ad4m directory
+            fs::create_dir(&data_path)?;
+            let ad4m_data_path = data_path.join("ad4m");
+            fs::create_dir(&ad4m_data_path)?;
+            let data_data_path = data_path.join("data");
+            fs::create_dir(&data_data_path)?;
+
+            //Read the agent file
+            let agent_file = fs::read_to_string(agent_path)?;
+            //Copy the agent file to correct directory
+            fs::write(ad4m_data_path.join("agent.json"), agent_file)?;
+            fs::write(data_data_path.join("DIDCache.json"), String::from("{}"))?;
+            green_ln!("Publishing agent directory setup\n");
+
+            green_ln!("Creating temporary bootstrap seed for publishing purposes...\n");
+            let lang_lang_source = fs::read_to_string(&seed_proto.language_language_ref)?;
+            let temp_bootstrap_seed = BootstrapSeed {
+                trusted_agents: vec![],
+                known_link_languages: vec![],
+                language_language_bundle: lang_lang_source.clone(),
+                direct_message_language: String::from(""),
+                agent_language: String::from(""),
+                perspective_language: String::from(""),
+                neighbourhood_language: String::from(""),
+            };
+            let temp_publish_bootstrap_path = data_path.join("publishing_bootstrap.json");
+            fs::write(
+                &temp_publish_bootstrap_path,
+                serde_json::to_string(&temp_bootstrap_seed)?,
+            )?;
+
+            //start ad4m-host with publishing bootstrap
+            let ad4m_host_init = std::process::Command::new(&ad4m_host_path)
+                .arg("init")
+                .arg("--networkBootstrapSeed")
+                .arg(&temp_publish_bootstrap_path)
+                .arg("--dataPath")
+                .arg(&data_path)
+                .arg("--overrideConfig")
+                .output()?;
+
+            blue_ln!(
+                "ad4m-host init output: {}\n",
+                String::from_utf8_lossy(&ad4m_host_init.stdout)
+            );
+
+            green_ln!(
+                "Starting publishing with bootstrap path: {}\n",
+                temp_publish_bootstrap_path.to_str().unwrap()
+            );
+
+            let (tx, rx) = channel();
+            serve_ad4m_host(ad4m_host_path, data_path, tx)?;
+
+            for line in &rx {
+                println!("{}", line);
+                if line.contains("GraphQL server started, Unlock the agent to start holohchain") {
+                    green_ln!("AD4M Host ready for publishing\n");
+                    //Spawn in a new thread so we can continue reading logs in loop below, whilst publishing is happening
+                    tokio::spawn(async move {
+                        start_publishing(
+                            passphrase.clone(),
+                            seed_proto.clone(),
+                            lang_lang_source.clone(),
+                        )
+                        .await;
+                    });
+                    break;
+                }
+            }
+
+            for line in rx {
+                println!("{}", line);
+            }
+        }
+    };
+    Ok(())
+}

--- a/cli/src/languages.rs
+++ b/cli/src/languages.rs
@@ -173,7 +173,7 @@ pub async fn run(ad4m_client: Ad4mClient, command: Option<LanguageFunctions>) ->
         }
         LanguageFunctions::Source { address } => {
             let source = ad4m_client.languages.source(address).await?;
-            println!("{}", source);
+            print!("{}", source);
         }
         LanguageFunctions::Remove { address } => {
             ad4m_client.languages.remove(address).await?;

--- a/cli/src/languages.rs
+++ b/cli/src/languages.rs
@@ -1,12 +1,7 @@
 use ad4m_client::Ad4mClient;
 use anyhow::{Context, Result};
 use clap::Subcommand;
-use colour::{self, blue_ln, green_ln};
 use rustyline::Editor;
-use std::fs;
-use std::sync::mpsc::channel;
-
-use crate::bootstrap_publish::*;
 
 #[derive(Debug, Subcommand)]
 pub enum LanguageFunctions {
@@ -48,13 +43,6 @@ pub enum LanguageFunctions {
     Source { address: String },
     /// Uninstall given language
     Remove { address: String },
-    /// Generate bootstrap seed from a local prototype JSON file declaring languages to be published
-    GenerateBootstrap {
-        agent_path: String,
-        passphrase: String,
-        ad4m_host_path: String,
-        seed_proto: String,
-    },
 }
 
 pub async fn run(ad4m_client: Ad4mClient, command: Option<LanguageFunctions>) -> Result<()> {
@@ -190,106 +178,6 @@ pub async fn run(ad4m_client: Ad4mClient, command: Option<LanguageFunctions>) ->
         LanguageFunctions::Remove { address } => {
             ad4m_client.languages.remove(address).await?;
             println!("Language removed");
-        }
-        LanguageFunctions::GenerateBootstrap {
-            agent_path,
-            passphrase,
-            ad4m_host_path,
-            seed_proto,
-        } => {
-            green_ln!(
-                "Attempting to generate a new bootstrap seed using ad4m-host path: {:?} and agent path: {:?}\n",
-                ad4m_host_path,
-                agent_path
-            );
-
-            //Load the seed proto first so we know that works before making new agent path
-            let seed_proto = fs::read_to_string(seed_proto)?;
-            let seed_proto: SeedProto = serde_json::from_str(&seed_proto)?;
-            green_ln!("Loaded seed prototype file!\n");
-
-            //Create a new ~/.ad4m-publish path with agent.json file supplied
-            let data_path = dirs::home_dir()
-                .expect("Could not get home directory")
-                .join(".ad4m-publish");
-            let data_path_files = std::fs::read_dir(&data_path);
-            if data_path_files.is_ok() {
-                fs::remove_dir_all(&data_path)?;
-            }
-            //Create the ad4m directory
-            fs::create_dir(&data_path)?;
-            let ad4m_data_path = data_path.join("ad4m");
-            fs::create_dir(&ad4m_data_path)?;
-            let data_data_path = data_path.join("data");
-            fs::create_dir(&data_data_path)?;
-
-            //Read the agent file
-            let agent_file = fs::read_to_string(agent_path)?;
-            //Copy the agent file to correct directory
-            fs::write(ad4m_data_path.join("agent.json"), agent_file)?;
-            fs::write(data_data_path.join("DIDCache.json"), String::from("{}"))?;
-            green_ln!("Publishing agent directory setup\n");
-
-            green_ln!("Creating temporary bootstrap seed for publishing purposes...\n");
-            let lang_lang_source = fs::read_to_string(&seed_proto.language_language_ref)?;
-            let temp_bootstrap_seed = BootstrapSeed {
-                trusted_agents: vec![],
-                known_link_languages: vec![],
-                language_language_bundle: lang_lang_source.clone(),
-                direct_message_language: String::from(""),
-                agent_language: String::from(""),
-                perspective_language: String::from(""),
-                neighbourhood_language: String::from(""),
-            };
-            let temp_publish_bootstrap_path = data_path.join("publishing_bootstrap.json");
-            fs::write(
-                &temp_publish_bootstrap_path,
-                serde_json::to_string(&temp_bootstrap_seed)?,
-            )?;
-
-            //start ad4m-host with publishing bootstrap
-            let ad4m_host_init = std::process::Command::new(&ad4m_host_path)
-                .arg("init")
-                .arg("--networkBootstrapSeed")
-                .arg(&temp_publish_bootstrap_path)
-                .arg("--dataPath")
-                .arg(&data_path)
-                .arg("--overrideConfig")
-                .output()?;
-
-            blue_ln!(
-                "ad4m-host init output: {}\n",
-                String::from_utf8_lossy(&ad4m_host_init.stdout)
-            );
-
-            green_ln!(
-                "Starting publishing with bootstrap path: {}\n",
-                temp_publish_bootstrap_path.to_str().unwrap()
-            );
-
-            let (tx, rx) = channel();
-            serve_ad4m_host(ad4m_host_path, data_path, tx)?;
-
-            for line in &rx {
-                println!("{}", line);
-                if line.contains("GraphQL server started, Unlock the agent to start holohchain") {
-                    green_ln!("AD4M Host ready for publishing\n");
-                    //Spawn in a new thread so we can continue reading logs in loop below, whilst publishing is happening
-                    tokio::spawn(async move {
-                        start_publishing(
-                            passphrase.clone(),
-                            seed_proto.clone(),
-                            lang_lang_source.clone(),
-                        )
-                        .await;
-                    });
-                    break;
-                }
-            }
-
-            for line in rx {
-                println!("{}", line);
-            }
         }
     };
     Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,6 +14,7 @@ mod util;
 
 mod agent;
 mod bootstrap_publish;
+mod dev;
 mod expression;
 mod languages;
 mod neighbourhoods;
@@ -22,7 +23,7 @@ mod repl;
 mod runtime;
 
 use crate::{
-    agent::*, expression::*, languages::*, neighbourhoods::*, perspectives::*, runtime::*,
+    agent::*, dev::*, expression::*, languages::*, neighbourhoods::*, perspectives::*, runtime::*,
 };
 use ad4m_client::*;
 use anyhow::{Context, Result};
@@ -105,6 +106,10 @@ enum Domain {
     },
     /// Print the executor log
     Log,
+    Dev {
+        #[command(subcommand)]
+        command: DevFunctions,
+    },
 }
 
 async fn get_ad4m_client(args: &ClapApp) -> Result<Ad4mClient> {
@@ -138,6 +143,11 @@ async fn get_ad4m_client(args: &ClapApp) -> Result<Ad4mClient> {
 async fn main() -> Result<()> {
     let args = ClapApp::parse();
 
+    if let Domain::Dev { command } = args.domain {
+        dev::run(command).await?;
+        return Ok(());
+    }
+
     let ad4m_client = get_ad4m_client(&args).await?;
 
     match args.domain {
@@ -157,6 +167,7 @@ async fn main() -> Result<()> {
             })?;
             println!("{}", log);
         }
+        Domain::Dev{ command: _ } => unreachable!(),
     }
 
     Ok(())

--- a/executor/src/core/graphQL-interface/GraphQL.ts
+++ b/executor/src/core/graphQL-interface/GraphQL.ts
@@ -364,11 +364,11 @@ function createResolvers(core: PerspectivismCore, config: OuterConfig) {
                   await core.initHolochain({ hcPortAdmin, hcPortApp, hcUseLocalProxy, hcUseMdns, hcUseProxy, hcUseBootstrap, passphrase: args.passphrase });
                 }
 
+                await core.waitForAgent();
+                core.initControllers()
+                await core.initLanguages()
 
                 if (!config.languageLanguageOnly) {
-                    await core.waitForAgent();
-                    core.initControllers()
-                    await core.initLanguages()
                     await core.initializeAgentsDirectMessageLanguage()
                 }
 


### PR DESCRIPTION
Move CLI command `generate-bootstrap` from `language` domain to new `dev` domain, which works without Ad4mClient, so we can run this command without running ad4m-executor.

Some fixes to make it actually work with that newly spawned executor instead of mixing use with a potentially already running production executor.