### PR TITLE
Temporary fix the trust agent exception popup

### DIFF
--- a/ui/src/components/TrustAgent.tsx
+++ b/ui/src/components/TrustAgent.tsx
@@ -36,7 +36,7 @@ const TrustAgent = (props: Props) => {
       <j-modal
         size="fullscreen"
         open={opened}
-        onToggle={(e: any) => e.target.open && closeModal()}
+        onToggle={(e: any) => setOpened(e.target.open)}
       >
         <j-box p="400">
           <j-flex gap="200" direction="column">


### PR DESCRIPTION
`onToggle` is fired twice when the component is rendered, 
- 1st it set the `opened` to false,
- 2ed it set the `opened` to true

With this behaviour, the `closeModal` here is always called, that's why the popup is broken. 
For this temporary fix, user can use close button to cancel the add trust agent request.

Need a better fix for `onToggle` behaviour, maybe @leifriksheim knows more about it.