### PR TITLE
LinkLanguage refactoring: replace objective latest-revision with gossip of agents' current revision

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 ### Added
 
 ### Changed
+ - Main LinkLanguage (Perspective Diff Sync) refactored to replace global/objective latest-revision with a simple gossip algorithm, where agents broadcast their revision and merge in revision of others as they are gossiped. Improves speed and resilience a lot. [PR#12 in PDiff-Sync](https://github.com/perspect3vism/perspective-diff-sync/pull/12) [PR#271](https://github.com/perspect3vism/ad4m/pull/271)
 
 ### Deprecated
 

--- a/executor/scripts/get-builtin-test-langs.js
+++ b/executor/scripts/get-builtin-test-langs.js
@@ -14,7 +14,7 @@ const languages = {
     bundle: "https://github.com/perspect3vism/local-neighbourhood-persistence/releases/download/0.0.2/bundle.js",
   },
   "perspective-diff-sync": {
-    bundle: "https://github.com/perspect3vism/perspective-diff-sync/releases/download/v0.2.2-test/bundle.js",
+    bundle: "https://github.com/perspect3vism/perspective-diff-sync/releases/download/v0.3.0/bundle.js",
   },
   "note-ipfs": {
     bundle: "https://github.com/perspect3vism/lang-note-ipfs/releases/download/0.0.4/bundle.js",

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -98,6 +98,7 @@ export default class Perspective {
                         // make use of snapshots
                         if(!revision) {
                             this.updatePerspectiveState(PerspectiveState.LinkLanguageInstalledButNotSynced);
+                            this.setupPendingDiffsPublishing(5000);
                         } else {
                             this.updatePerspectiveState(PerspectiveState.Synced);
                         }
@@ -111,7 +112,6 @@ export default class Perspective {
 
             // setup polling loop for Perspectives with a linkLanguage
             this.setupSyncSingals(1000);
-            this.setupPendingDiffsPublishing(5000);
             this.setupFullRenderSync(20000);
         }
 

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -90,7 +90,7 @@ export default class Perspective {
 
         if (this.neighbourhood) {
             // setup polling loop for Perspectives with a linkLanguage
-            this.setupSyncSingals(1000);
+            this.setupSyncSingals(3000);
             //this.setupFullRenderSync(20000);
 
             // Handle join differently so we wait before publishing diffs until we have seen

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -91,7 +91,7 @@ export default class Perspective {
         if (this.neighbourhood) {
             // setup polling loop for Perspectives with a linkLanguage
             this.setupSyncSingals(1000);
-            this.setupFullRenderSync(20000);
+            //this.setupFullRenderSync(20000);
 
             // Handle join differently so we wait before publishing diffs until we have seen
             // a first foreign revision. Otherwise we will never use snaphshots and make the

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -103,7 +103,7 @@ export default class Perspective {
                         // Set the state to LinkLanguageInstalledButNotSynced so we will keep
                         // link additions as pending until we are synced
                         if(!revision) {
-                            //this.setupPendingDiffsPublishing(5000);
+                            this.setupPendingDiffsPublishing(5000);
                         } else {
                             this.updatePerspectiveState(PerspectiveState.Synced);
                         }

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -103,7 +103,6 @@ export default class Perspective {
                         // Set the state to LinkLanguageInstalledButNotSynced so we will keep
                         // link additions as pending until we are synced
                         if(!revision) {
-                            this.updatePerspectiveState(PerspectiveState.LinkLanguageInstalledButNotSynced);
                             this.setupPendingDiffsPublishing(5000);
                         } else {
                             this.updatePerspectiveState(PerspectiveState.Synced);
@@ -162,6 +161,14 @@ export default class Perspective {
     async setupPendingDiffsPublishing(intervalMs: number) {
         if(this.state === PerspectiveState.Synced) {
             return
+        }
+
+        if(this.state == PerspectiveState.LinkLanguageFailedToInstall) {
+            try {
+                await this.getLinksAdapter()
+            } catch(e) {
+                console.error(`Perspective.setupPendingDiffsPublishing(): NH [${this.sharedUrl}] (${this.name}): Got error when trying to install link language: ${e}`);
+            }
         }
         
         if(this.state == PerspectiveState.LinkLanguageInstalledButNotSynced) {

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -463,9 +463,9 @@ export default class Perspective {
             return undefined !== list.find(e =>
                 JSON.stringify(e.author) === JSON.stringify(link.author) &&
                 e.timestamp === link.timestamp &&
-                e.source === link.data.source &&
-                e.target === link.data.target &&
-                e.predicate === link.data.predicate
+                e.data.source === link.data.source &&
+                e.data.target === link.data.target &&
+                e.data.predicate === link.data.predicate
                 )
         }
         let linksToCommit = [];

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -103,7 +103,7 @@ export default class Perspective {
                         // Set the state to LinkLanguageInstalledButNotSynced so we will keep
                         // link additions as pending until we are synced
                         if(!revision) {
-                            this.setupPendingDiffsPublishing(5000);
+                            //this.setupPendingDiffsPublishing(5000);
                         } else {
                             this.updatePerspectiveState(PerspectiveState.Synced);
                         }

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -89,13 +89,19 @@ export default class Perspective {
         });
 
         if (this.neighbourhood) {
+            // setup polling loop for Perspectives with a linkLanguage
+            this.setupSyncSingals(1000);
+            this.setupFullRenderSync(20000);
+
+            // Handle join differently so we wait before publishing diffs until we have seen
+            // a first foreign revision. Otherwise we will never use snaphshots and make the
+            // diff graph complex.
             if(this.createdFromJoin) {
                 try {
                     this.getCurrentRevision().then(revision => {
                         // if revision is null, then we are not connected to the network yet
                         // Set the state to LinkLanguageInstalledButNotSynced so we will keep
-                        // link additions as pending until we are synced in order
-                        // make use of snapshots
+                        // link additions as pending until we are synced
                         if(!revision) {
                             this.updatePerspectiveState(PerspectiveState.LinkLanguageInstalledButNotSynced);
                             this.setupPendingDiffsPublishing(5000);
@@ -109,10 +115,6 @@ export default class Perspective {
             } else {
                 this.updatePerspectiveState(PerspectiveState.Synced);
             }
-
-            // setup polling loop for Perspectives with a linkLanguage
-            this.setupSyncSingals(1000);
-            this.setupFullRenderSync(20000);
         }
 
         this.#prologMutex = new Mutex()

--- a/host/mainnet_seed.json
+++ b/host/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:zQ3sheV6m6sT83woZtVL2PHiz6J1qWRh4FWW2aiJvxy6d2o7S"
   ],
   "knownLinkLanguages": [
-    "QmeYsEe3UnJXmvAPmnDGvfdjnsUH6hWPwV2rmxcdpeokA7"
+    "QmVwmmAqcjxLJH3gX7kXgC17CbnjsFHMGzcz8gkw7Fb9mu"
   ],
   "directMessageLanguage": "QmXR4MZqxqdPmSnCNF24f82EkvahwgXW3FKzGWPZrdC8qb",
   "agentLanguage": "QmR3gt6cjaSBPV3kiLQxeZtiuJT3ZMFLQ755DMpb8yMK2m",


### PR DESCRIPTION
These are the accompanying changes to the refactoring done in https://github.com/perspect3vism/perspective-diff-sync/pull/12. A build of PDiff-Sync from that branch is included in the new bootstrap seed here.

Improves speed, CPU usage and stability of Neighbourhoods by a lot.

Instead of periodically pulling from an "objective" latest-revision (which relied on Holochain link gossips and timestamps (!) for ordering), we now have agents broadcast their local current revision and pull from that if they receive a newer revision from another (online) agent.