### PR TITLE
Runtime improvements, BorrowMutError Fix + JS Core Fixes, Scryer fixes

### DIFF
--- a/bootstrap-languages/p-diff-sync/linksAdapter.ts
+++ b/bootstrap-languages/p-diff-sync/linksAdapter.ts
@@ -112,13 +112,15 @@ export class LinkAdapter implements LinkSyncAdapter {
         });
       }
 
-      function checkSyncState(callback: SyncStateChangeObserver) {
+      async function checkSyncState(callback: SyncStateChangeObserver) {
         if (sameRevisions.length > 0 || differentRevisions.length > 0) {
           if (sameRevisions.length <= differentRevisions.length) {
-            callback(PerspectiveState.LinkLanguageInstalledButNotSynced);
+            await callback(PerspectiveState.LinkLanguageInstalledButNotSynced);
           } else {
-            callback(PerspectiveState.Synced);
+            await callback(PerspectiveState.Synced);
           };
+        } else if (differentRevisions == 0) {
+          await callback(PerspectiveState.Synced);
         }
       }
 
@@ -126,7 +128,7 @@ export class LinkAdapter implements LinkSyncAdapter {
       generateRevisionStates(this.myCurrentRevision);
 
       //@ts-ignore
-      checkSyncState(this.syncStateChangeCallback);
+      await checkSyncState(this.syncStateChangeCallback);
 
       for (const hash of Array.from(revisions)) {
         if(!hash) continue
@@ -143,7 +145,7 @@ export class LinkAdapter implements LinkSyncAdapter {
             //@ts-ignore
             generateRevisionStates(this.myCurrentRevision);
             //@ts-ignore
-            checkSyncState(this.syncStateChangeCallback);
+            await checkSyncState(this.syncStateChangeCallback);
           }
         }
       }

--- a/executor/src/core/Ad4mCore.ts
+++ b/executor/src/core/Ad4mCore.ts
@@ -300,7 +300,7 @@ export default class Ad4mCore {
         }
 
         console.log("Core.installNeighbourhood(): Creating perspective", url, neighbourhood, state);
-        return this.#perspectivesController!.add("", url, neighbourhood, true, state);
+        return await this.#perspectivesController!.add("", url, neighbourhood, true, state);
     }
 
     async languageApplyTemplateAndPublish(sourceLanguageHash: string, templateData: object): Promise<LanguageRef> {

--- a/executor/src/core/Ad4mCore.ts
+++ b/executor/src/core/Ad4mCore.ts
@@ -90,7 +90,7 @@ export default class Ad4mCore {
     }
 
     async callResolver (type: string, fnName: string, args: any, context: any) {
-        console.log("Calling resolvers with data", type, fnName, args, context);
+        //console.log("Calling resolvers with data", type, fnName, args, context);
       if(!this.resolvers[type]) throw new Error(`Could not find resolver for type ${type}`)
       if(!this.resolvers[type][fnName]) throw new Error(`Could not find resolver function ${fnName} for type ${type}`)
       try {

--- a/executor/src/core/LanguageController.ts
+++ b/executor/src/core/LanguageController.ts
@@ -256,6 +256,7 @@ export default class LanguageController {
 
             if (language.linksAdapter.addSyncStateChangeCallback) {
                 language.linksAdapter.addSyncStateChangeCallback((state: PerspectiveState) => {
+                    console.log("LanguageController.loadLanguage: sync state change", state);
                     this.callSyncStateChangeObservers(state, {address: hash, name: language.name} as LanguageRef);
                 })
             }

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -589,6 +589,7 @@ export default class Perspective {
                 await this.#db.removeLink(this.uuid!, link);
             }))
         }
+        this.#prologNeedsRebuild = true;
     }
 
     private async getLinksLocal(query: LinkQuery): Promise<LinkExpression[]> {

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -29,6 +29,7 @@ export default class Perspective {
     #db: Ad4mDb;
     #agent: AgentService;
     #languageController?: LanguageController
+    #updateControllersHandleSyncStatus?: (uuid: string, status: PerspectiveState) => void
     #config?: MainConfig;
     #pubSub: PubSub;
 
@@ -56,6 +57,7 @@ export default class Perspective {
         this.#agent = context.agentService!
         this.#languageController = context.languageController!
         this.#config = context.config;
+        this.#updateControllersHandleSyncStatus = context.updateControllersHandleSyncStatus;
         this.#pubSub = getPubSub();
 
         this.#prologEngine = null
@@ -93,9 +95,13 @@ export default class Perspective {
     }
 
     async updatePerspectiveState(state: PerspectiveState) {
-        if (this.state != state) {
+        if (this.state !== state) {
+            if (this.#updateControllersHandleSyncStatus) {
+                this.#updateControllersHandleSyncStatus(this.uuid!, state);
+            };
+            this.state = state;
             await this.#pubSub.publish(PubSubDefinitions.PERSPECTIVE_SYNC_STATE_CHANGE, {state, uuid: this.uuid})
-            this.state = state
+            await this.#pubSub.publish(PubSubDefinitions.PERSPECTIVE_UPDATED_TOPIC, this.plain());
         }
     }
 
@@ -143,7 +149,7 @@ export default class Perspective {
                 // If LinkLanguage is connected/synced (otherwise currentRevision would be null)...
                 if (await this.getCurrentRevision()) {
                     //TODO; once we have more data information coming from the link language, correctly determine when to mark perspective as synced
-                    this.updatePerspectiveState(PerspectiveState.Synced);
+                    await this.updatePerspectiveState(PerspectiveState.Synced);
                     //Let's check if we have unpublished diffs:
                     const mutations = await this.#db.getPendingDiffs(this.uuid!);
                     if (mutations.additions.length > 0 || mutations.removals.length > 0) {                        
@@ -220,7 +226,7 @@ export default class Perspective {
                 return undefined;
             }
         } catch (e) {
-            this.updatePerspectiveState(PerspectiveState.LinkLanguageFailedToInstall);
+            await this.updatePerspectiveState(PerspectiveState.LinkLanguageFailedToInstall);
             this.retries++;
             throw e;
         }
@@ -255,7 +261,7 @@ export default class Perspective {
     //@ts-ignore
     private callLinksAdapter(functionName: string, ...args): Promise<PerspectiveDiff> {
         if(!this.neighbourhood || !this.neighbourhood.linkLanguage) {
-            //console.warn("Perspective.callLinksAdapter: Did not find neighbourhood or linkLanguage for neighbourhood on perspective, returning empty array")
+            console.warn("Perspective.callLinksAdapter: Did not find neighbourhood or linkLanguage for neighbourhood on perspective, returning empty array")
             return Promise.resolve({
                 additions: [],
                 removals: []

--- a/executor/src/core/Perspective.ts
+++ b/executor/src/core/Perspective.ts
@@ -845,6 +845,8 @@ export default class Perspective {
         lines.push(":- discontiguous(p3_class_color/2).")
         lines.push(":- discontiguous(p3_instance_color/3).")
 
+        lines.push(":- use_module(library(lists)).");
+
         let seenSubjectClasses = new Set()
         for(let linkExpression of allLinks) {
             let link = linkExpression.data

--- a/executor/src/core/PerspectiveContext.ts
+++ b/executor/src/core/PerspectiveContext.ts
@@ -1,3 +1,4 @@
+import { PerspectiveState } from "@perspect3vism/ad4m"
 import type AgentService from "./agent/AgentService"
 import { MainConfig } from "./Config"
 import type LanguageController from "./LanguageController"
@@ -7,4 +8,5 @@ export default class PerspectiveContext {
     agentService?: AgentService
     languageController?: LanguageController
     config?: MainConfig
+    updateControllersHandleSyncStatus?: (uuid: string, status: PerspectiveState) => void
 }

--- a/executor/src/core/storage-services/Holochain/HolochainService.ts
+++ b/executor/src/core/storage-services/Holochain/HolochainService.ts
@@ -70,7 +70,8 @@ export default class HolochainService {
     }
 
     async handleCallback(signal: EncodedAppSignal) {
-        //console.debug(new Date().toISOString(), "GOT CALLBACK FROM HC, checking against language callbacks");
+        //console.log(new Date().toISOString(), "GOT CALLBACK FROM HC, checking against language callbacks");
+        //console.dir(signal);
         //@ts-ignore
         let payload = decode(signal.signal);
         var TypedArray = Object.getPrototypeOf(Uint8Array);

--- a/rust-executor/src/graphql/mod.rs
+++ b/rust-executor/src/graphql/mod.rs
@@ -5,7 +5,6 @@ mod subscription_resolvers;
 mod utils;
 
 use graphql_types::RequestContext;
-use hyper::body::Bytes;
 use mutation_resolvers::*;
 use query_resolvers::*;
 use subscription_resolvers::*;

--- a/rust-executor/src/holochain_service/interface.rs
+++ b/rust-executor/src/holochain_service/interface.rs
@@ -231,6 +231,11 @@ pub fn maybe_get_holochain_service() -> Option<HolochainServiceInterface> {
     }
 }
 
+pub async fn maybe_get_holochain_service_async() -> Option<HolochainServiceInterface> {
+    let lock = HOLOCHAIN_SERVICE.read().await;
+    lock.clone()
+}
+
 pub async fn set_holochain_service(service: HolochainServiceInterface) {
     let mut lock = HOLOCHAIN_SERVICE.write().await;
     *lock = Some(service);

--- a/rust-executor/src/holochain_service/interface.rs
+++ b/rust-executor/src/holochain_service/interface.rs
@@ -223,15 +223,7 @@ pub async fn get_holochain_service() -> HolochainServiceInterface {
     lock.clone().expect("Holochain Conductor not started")
 }
 
-pub fn maybe_get_holochain_service() -> Option<HolochainServiceInterface> {
-    let lock = HOLOCHAIN_SERVICE.try_read();
-    match lock {
-        Ok(guard) => guard.clone(),
-        Err(_) => None,
-    }
-}
-
-pub async fn maybe_get_holochain_service_async() -> Option<HolochainServiceInterface> {
+pub async fn maybe_get_holochain_service() -> Option<HolochainServiceInterface> {
     let lock = HOLOCHAIN_SERVICE.read().await;
     lock.clone()
 }

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -28,8 +28,8 @@ pub(crate) mod holochain_service_extension;
 pub(crate) mod interface;
 
 pub(crate) use interface::{
-    get_holochain_service, maybe_get_holochain_service, HolochainServiceInterface,
-    HolochainServiceRequest, HolochainServiceResponse, maybe_get_holochain_service_async
+    get_holochain_service, HolochainServiceInterface,
+    HolochainServiceRequest, HolochainServiceResponse, maybe_get_holochain_service
 };
 
 use self::interface::set_holochain_service;

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -29,7 +29,7 @@ pub(crate) mod interface;
 
 pub(crate) use interface::{
     get_holochain_service, maybe_get_holochain_service, HolochainServiceInterface,
-    HolochainServiceRequest, HolochainServiceResponse,
+    HolochainServiceRequest, HolochainServiceResponse, maybe_get_holochain_service_async
 };
 
 use self::interface::set_holochain_service;

--- a/rust-executor/src/js_core/futures.rs
+++ b/rust-executor/src/js_core/futures.rs
@@ -40,7 +40,9 @@ impl Future for GlobalVariableFuture {
     type Output = Result<String, AnyError>; // You can customize the output type.
 
     fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        println!("Trying to get the worker lock: {}", self.name);
         let mut worker = self.worker.lock().unwrap();
+        println!("Got the lock: {}", self.name);
         if let Ok(global_value) = worker.execute_script("global_var_future", self.name.clone().into()) {
             let scope = &mut v8::HandleScope::new(worker.js_runtime.v8_isolate());
             let context = v8::Context::new(scope);

--- a/rust-executor/src/js_core/mod.rs
+++ b/rust-executor/src/js_core/mod.rs
@@ -240,6 +240,9 @@ impl JsCore {
     ) -> impl Future {
         async move {
             loop {
+                let maybe_request = rx.lock().as_mut().ok().map(|c| c.try_recv());
+
+
                 if let Ok(mut rx) = rx.lock() {
                     if let Ok(request) = rx.try_recv() {
                         let script = request.script;

--- a/rust-executor/src/js_core/mod.rs
+++ b/rust-executor/src/js_core/mod.rs
@@ -285,7 +285,7 @@ impl JsCore {
         let tx_inside_clone = tx_inside.clone();
         let tx_inside_loader_clone = tx_inside_loader.clone();
         std::thread::spawn(move || {
-            let rt = Builder::new_multi_thread()
+            let rt = Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .expect("Failed to create Tokio runtime");

--- a/rust-executor/src/js_core/mod.rs
+++ b/rust-executor/src/js_core/mod.rs
@@ -91,7 +91,7 @@ impl JsCoreHandle {
 
         let response = response_rx.await.unwrap();
 
-        info!("Got response: {:?}", response);
+        //info!("Got response: {:?}", response);
 
         response
             .result
@@ -231,9 +231,7 @@ impl JsCore {
             r#"
         globalThis.{} = undefined;
         (async () => {{
-            console.log("starting execution of script");
             globalThis.{} = ({});
-            console.log("finished execution of script");
         }})();
         "#,
             name, name, script
@@ -252,7 +250,7 @@ impl JsCore {
                 let mut maybe_request = rx.lock().await;
                 //let maybe_request = rx.lock().as_mut().ok().map(|c| c.try_recv());
                 if let Ok(request) = maybe_request.try_recv()  {
-                    info!("Got request: {:?}", request);
+                    //info!("Got request: {:?}", request);
                     let script = request.script.clone();
                     let id = request.id.clone();
                     let js_core_cloned = js_core.clone();
@@ -262,15 +260,15 @@ impl JsCore {
                     //global_req_id = Some(id.clone());
 
                     tokio::task::spawn_local(async move {
-                        info!("Spawn local driving: {}", id);
+                        //info!("Spawn local driving: {}", id);
                         let local_variable_name = uuid_to_valid_variable_name(&id);
                         let script_fut =
                             js_core_cloned.execute_async(local_variable_name, script);
-                        info!("Script fut created: {}", id);
+                        //info!("Script fut created: {}", id);
                         match script_fut {
                             Ok(script_fut) => match script_fut.await {
                                 Ok(res) => {
-                                    info!("Script execution completed Succesfully: {}", id);
+                                    //info!("Script execution completed Succesfully: {}", id);
                                     response_tx
                                         .send(JsCoreResponse {
                                             result: Ok(res),

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -49,7 +49,7 @@ pub async fn run(mut config: Ad4mConfig) {
         });
     }
 
-    std::thread::spawn(move || {
+    let handle = std::thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -60,6 +60,7 @@ pub async fn run(mut config: Ad4mConfig) {
             config.app_data_path.expect("Did not get app data path")
         )).unwrap();
     });
+    handle.join().unwrap();
 }
 
 /// Runs the GraphQL server and the deno core runtime
@@ -99,4 +100,6 @@ pub async fn run_with_tokio(mut config: Ad4mConfig) {
             config.app_data_path.expect("Did not get app data path")
         )).unwrap();
     });
+
+    //TODO; we need someway to know that the graphql server is running before we allow this function to return
 }

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -42,7 +42,7 @@ pub async fn run(mut config: Ad4mConfig) {
 
     if config.run_dapp_server.unwrap() {
         std::thread::spawn(|| {
-            let runtime = tokio::runtime::Builder::new_current_thread()
+            let runtime = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
                 .build()
                 .unwrap();
@@ -51,7 +51,7 @@ pub async fn run(mut config: Ad4mConfig) {
     }
 
     let handle = std::thread::spawn(move || {
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .unwrap();
@@ -82,7 +82,7 @@ pub async fn run_with_tokio(mut config: Ad4mConfig) {
 
     if config.run_dapp_server.unwrap() {
         std::thread::spawn(|| {
-            let runtime = tokio::runtime::Builder::new_current_thread()
+            let runtime = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
                 .build()
                 .unwrap();
@@ -91,7 +91,7 @@ pub async fn run_with_tokio(mut config: Ad4mConfig) {
     };
 
     std::thread::spawn(move || {
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .unwrap();

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -34,6 +34,7 @@ pub async fn run(mut config: Ad4mConfig) {
 
     info!("Starting js_core...");
     let mut js_core_handle = JsCore::start(config.clone()).await;
+    info!("Finished start");
     js_core_handle.initialized().await;
     info!("js_core initialized.");
 

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -14,7 +14,7 @@ mod pubsub;
 mod dapp_server;
 
 use std::env;
-use tracing::{info, error};
+use tracing::info;
 
 use js_core::JsCore;
 

--- a/ui/src-tauri/src/commands/app.rs
+++ b/ui/src-tauri/src/commands/app.rs
@@ -2,7 +2,7 @@ extern crate remove_dir_all;
 use std::time::{Duration, SystemTime};
 
 use crate::Payload;
-use crate::{config::data_path, get_main_window, util::find_and_kill_processes};
+use crate::{config::data_path, get_main_window};
 
 use remove_dir_all::*;
 

--- a/ui/src-tauri/src/main.rs
+++ b/ui/src-tauri/src/main.rs
@@ -17,17 +17,14 @@ use std::sync::Mutex;
 use libc::{rlimit, RLIMIT_NOFILE, setrlimit};
 use std::io;
 use std::io::Write;
-use tracing_subscriber::{fmt::format::FmtSpan, FmtSubscriber};
 
 extern crate remove_dir_all;
-use remove_dir_all::*;
 
 use config::app_url;
 use menu::build_menu;
 use system_tray::{ build_system_tray, handle_system_tray_event };
 use tauri::{
     AppHandle,
-    api::process::{Command, CommandEvent},
     RunEvent, SystemTrayEvent,
     Window
 };
@@ -41,7 +38,6 @@ mod system_tray;
 mod menu;
 mod commands;
 
-use tauri::api::dialog;
 use tauri::Manager;
 use crate::commands::proxy::{get_proxy, login_proxy, setup_proxy, stop_proxy};
 use crate::commands::state::{get_port, request_credential};
@@ -52,7 +48,7 @@ use crate::util::create_tray_message_windows;
 use crate::util::find_port;
 use crate::menu::{handle_menu_event, open_logs_folder};
 use crate::util::has_processes_running;
-use crate::util::{find_and_kill_processes, create_main_window, save_executor_port};
+use crate::util::{create_main_window, save_executor_port};
 
 
 // the payload type must implement `Serialize` and `Clone`.
@@ -282,12 +278,4 @@ fn get_main_window(handle: &AppHandle) -> Window {
         let main = handle.get_window("AD4M");
         main.expect("Couldn't get main window right after creating it")
     }
-}
-
-fn log_error(window: &Window, message: &str) {
-    dialog::message(
-        Some(window),
-        "Error",
-        message
-    );
 }

--- a/ui/src-tauri/src/system_tray.rs
+++ b/ui/src-tauri/src/system_tray.rs
@@ -1,6 +1,5 @@
 use crate::config::executor_port_path;
 use crate::create_main_window;
-use crate::util::find_and_kill_processes;
 use crate::Payload;
 use std::env;
 use std::fs::remove_file;

--- a/ui/src-tauri/src/util.rs
+++ b/ui/src-tauri/src/util.rs
@@ -6,7 +6,7 @@ use std::fs::remove_file;
 use std::fs::File;
 use std::io::prelude::*;
 use sysinfo::Process;
-use sysinfo::{ProcessExt, Signal, System, SystemExt};
+use sysinfo::{System, SystemExt};
 use tauri::{AppHandle, Manager, WindowBuilder, WindowEvent, WindowUrl, Wry};
 use tauri_plugin_positioner::Position;
 use tauri_plugin_positioner::WindowExt;
@@ -22,18 +22,6 @@ pub fn find_port(start_port: u16, end_port: u16) -> u16 {
         "No open port found between: [{:?}, {:?}]",
         start_port, end_port
     );
-}
-
-pub fn find_and_kill_processes(name: &str) {
-    let processes = System::new_all();
-
-    for process in processes.processes_by_exact_name(name) {
-        log::info!("Prosses running: {} {}", process.pid(), process.name());
-
-        if process.kill_with(Signal::Term) == None {
-            log::error!("This signal isn't supported on this platform");
-        }
-    }
 }
 
 pub fn has_processes_running(name: &str) -> usize {


### PR DESCRIPTION
This PR:

- Refactors the runtime of `js_core/mod.rs` to allow for async receiving of requests to: execute JS, load modules and handle holochain callbacks. Each received request will be spawned as a future on the current thread and executed in fairness with other futures being driven in js_core.
- Change Tokio runtime for spawned JS thread to `new_current_thread` which fixes the `BorrowMutError` seen randomly in certain ad4m ops
- Update Mutex around JsCore to a tokio mutex; improves intelligence of driving futures and knowing when we can sleep or repoll
- Updates GlobalVariableFuture to correctly wake the Future after receiving `Poll::Pending`; also uses deno method `worker.js_runtime.poll_value` to poll the worker whilst trying to resolve a value, increasing speed by having it more likely for a future to drive the even loop
- Spawns graphql & dapp servers in their own threads with their own multithreaded tokio runtime to avoid clogging main tauri thread or cli
- Runs the scryer list module on scryer engines for perspectives to allow use of the `length/2` predicate
- Fixes PerspectiveState not being correctly updated in PerspectiveController when being update from within a Perspective class
- Fixes neighbourhood object being lost on a Perspective handle after persistence to JSON database 
- Fixes an issue where PerspectiveDiffSync would not call the perspective state handler if no other agents are present in the gossip loop