### PR TITLE
Hard-wired Holochain AgentInfo on init & admin_credential arg for CLI

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -70,6 +70,10 @@ struct ClapApp {
     /// Override default executor URL look-up and provide custom URL
     #[arg(short, long)]
     executor_url: Option<String>,
+
+    /// Provide admin credential to gain all capabilities
+    #[arg(short, long)]
+    admin_credential: Option<String>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -160,7 +164,9 @@ async fn get_ad4m_client(args: &ClapApp) -> Result<Ad4mClient> {
         crate::startup::get_executor_url()?
     };
 
-    let cap_token = if args.no_capability {
+    let cap_token = if let Some(admin_credential) = &args.admin_credential {
+        admin_credential.clone()
+    } else if args.no_capability {
         "".to_string()
     } else {
         match &args.domain {

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -4,7 +4,7 @@ use kitsune_p2p_types::agent_info::AgentInfoSigned;
 use log::debug;
 
 use super::graphql_types::*;
-use crate::{agent::{self, capabilities::*}, holochain_service::get_holochain_service};
+use crate::{agent::{self, capabilities::*}, holochain_service::{agent_infos_from_str, get_holochain_service}};
 use ad4m_client::literal::Literal;
 pub struct Mutation;
 
@@ -1025,20 +1025,8 @@ impl Mutation {
             &RUNTIME_HC_AGENT_INFO_CREATE_CAPABILITY,
         )?;
 
-        log::debug!("Adding agent infos... Got RAW String: {}", agent_infos);
-        let agent_infos: Vec<String> = serde_json::from_str(&agent_infos)?;
-        let agent_infos: Vec<AgentInfoSigned> = agent_infos
-            .into_iter()
-            .map(|encoded_info| {
-                let info_bytes = base64::decode(encoded_info)
-                    .expect("Failed to decode base64 AgentInfoSigned");
-                AgentInfoSigned::decode(&info_bytes)
-                    .expect("Failed to decode AgentInfoSigned")
-            })
-            .collect();
-
+        let agent_infos = agent_infos_from_str(agent_infos.as_str())?;
         log::info!("Adding HC agent infos: {:?}", agent_infos);
-        
 
         get_holochain_service()
             .await


### PR DESCRIPTION
This AgentInfo string is from our new persistence server for the setup of which I had to add the admin_credential arg, so we can actually run that node securely with capability checks and at the same time drive it (agent generation, getting AgentInfos) from the CLI.

Since the only running HC DNA we get from a vanilla ad4m node currently is just the DM Language, this won't help yet.

We need at least one HC DNA that every node runs. Either we switch back to the Holochain agent Language, or we create a new default Neighbourhood with p-diff-sync and then re-create the hard-wired AgentInfo string.