### PR TITLE
Fix pending diffs & p-diff-sync, and enable headless executor to do capability request

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           command: pnpm install --no-frozen-lockfile
       - run:
           name: Build dapp
-          command: cd ./dapp && pnpm build
+          command: cd ./dapp && pnpm install && pnpm build
       - run:
           name: Install core dependencies
           command: cd ./core && pnpm install --no-frozen-lockfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,9 @@ jobs:
           name: Install dependencies
           command: pnpm install --no-frozen-lockfile
       - run:
+          name: Build dapp
+          command: cd ./dapp && pnpm build
+      - run:
           name: Install core dependencies
           command: cd ./core && pnpm install --no-frozen-lockfile
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           command: pnpm install --no-frozen-lockfile
       - run:
           name: Build dapp
-          command: cd ./dapp && pnpm install && pnpm build
+          command: pnpm build-dapp
       - run:
           name: Install core dependencies
           command: cd ./core && pnpm install --no-frozen-lockfile

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
  - Hard-wired Hosted ad4m client `AgentInfo` in the executor. [PR#453](https://github.com/coasys/ad4m/pull/453)
  - Added ability to handle multiple agents in launcher. [PR#459](https://github.com/coasys/ad4m/pull/459)
  - Added a way to show & add new `AgentInfo` in launcher. [PR#463](https://github.com/coasys/ad4m/pull/463)
+ - `ad4m-executor` binary prints capability request challange to stdout to enable app hand-shake [PR#471](https://github.com/coasys/ad4m/pull/471)
 
 ### Changed
  - Much improved ADAM Launcher setup flow [PR#440](https://github.com/coasys/ad4m/pull/440) and [PR#444](https://github.com/coasys/ad4m/pull/444):
@@ -43,6 +44,7 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
   - Fixed value returns as undefined if the property was boolean and set to false in `SubjectEntity.
   - Fixed links in docs.
 - Fixed flaky integration tests [PR#462](https://github.com/coasys/ad4m/pull/462)
+- Fixed `p-diff-sync`'s Deno incompatibilities [PR#471](https://github.com/coasys/ad4m/pull/471)
 
 ## [0.8.0] - 12/12/2023
 

--- a/bootstrap-languages/p-diff-sync/linksAdapter.ts
+++ b/bootstrap-languages/p-diff-sync/linksAdapter.ts
@@ -136,16 +136,12 @@ export class LinkAdapter implements LinkSyncAdapter {
       await checkSyncState(this.syncStateChangeCallback);
 
       for (const hash of Array.from(revisions)) {
-        console.log("GOSSIP processing other revision", hash.toString('base64'));
         if(!hash) continue
         if (this.myCurrentRevision && hash.equals(this.myCurrentRevision)) continue
-        console.log("GOSSIP other revision different to ours", this.myCurrentRevision.toString('base64'));
-        console.log("Pulling with is_scribe =", is_scribe)
         let pullResult = await this.hcDna.call(DNA_NICK, ZOME_NAME, "pull", { 
           hash,
           is_scribe 
         });
-        console.log("GOSSIP pullResult", pullResult);
         if (pullResult) {
           if (pullResult.current_revision && Buffer.isBuffer(pullResult.current_revision)) {
             let myRevision = pullResult.current_revision;

--- a/bootstrap-languages/p-diff-sync/linksAdapter.ts
+++ b/bootstrap-languages/p-diff-sync/linksAdapter.ts
@@ -90,10 +90,10 @@ export class LinkAdapter implements LinkSyncAdapter {
       peers.push(this.me);
       
       // Lexically sort the peers
-      peers.sort();
+      peers = peers.sort();
 
       // If we are the first peer, we are the scribe
-      let is_scribe = peers[0] == this.me;
+      let is_scribe = (peers[0] == this.me);
       
       // Get a deduped set of all peer's current revisions
       let revisions = new Set<Buffer>();
@@ -136,12 +136,16 @@ export class LinkAdapter implements LinkSyncAdapter {
       await checkSyncState(this.syncStateChangeCallback);
 
       for (const hash of Array.from(revisions)) {
+        console.log("GOSSIP processing other revision", hash.toString('base64'));
         if(!hash) continue
         if (this.myCurrentRevision && hash.equals(this.myCurrentRevision)) continue
+        console.log("GOSSIP other revision different to ours", this.myCurrentRevision.toString('base64'));
+        console.log("Pulling with is_scribe =", is_scribe)
         let pullResult = await this.hcDna.call(DNA_NICK, ZOME_NAME, "pull", { 
           hash,
           is_scribe 
         });
+        console.log("GOSSIP pullResult", pullResult);
         if (pullResult) {
           if (pullResult.current_revision && Buffer.isBuffer(pullResult.current_revision)) {
             let myRevision = pullResult.current_revision;

--- a/cli/mainnet_seed.json
+++ b/cli/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdiSAPyaXzUN7Zgq6EMPEu8JQG3ck5UgH7REhAicWbVAo2",
+    "QmzSYwdhcfG8Urkt5YsF1KyPEAdd8F6emRG31s7GDLMqbRAQTH3",
     "QmzSYwdnyTVrzufV8HfUfFRwDSiZZjRoBimrm95qjh6KCG9Z6YW",
     "QmzSYwdnHrRH8MmuPWKKrDvFoVyW5CophNpT1ipQUCcenPVTQnd"
   ],

--- a/cli/mainnet_seed.json
+++ b/cli/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdhcfG8Urkt5YsF1KyPEAdd8F6emRG31s7GDLMqbRAQTH3",
+    "QmzSYwdejFmQYpHtztu32516wvjkBohQmZt7dKUn4pnkPJA6kPV",
     "QmzSYwdnyTVrzufV8HfUfFRwDSiZZjRoBimrm95qjh6KCG9Z6YW",
     "QmzSYwdnHrRH8MmuPWKKrDvFoVyW5CophNpT1ipQUCcenPVTQnd"
   ],

--- a/cli/mainnet_seed.json
+++ b/cli/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdejFmQYpHtztu32516wvjkBohQmZt7dKUn4pnkPJA6kPV",
+    "QmzSYwdj7LmLiY7p5vEzBPuQpW3CmAB41vEJe9hkVB9w6ndhcE5",
     "QmzSYwdnyTVrzufV8HfUfFRwDSiZZjRoBimrm95qjh6KCG9Z6YW",
     "QmzSYwdnHrRH8MmuPWKKrDvFoVyW5CophNpT1ipQUCcenPVTQnd"
   ],

--- a/cli/src/ad4m_executor.rs
+++ b/cli/src/ad4m_executor.rs
@@ -181,7 +181,8 @@ async fn main() -> Result<()> {
                 hc_proxy_url,
                 hc_bootstrap_url,
                 connect_holochain,
-                admin_credential
+                admin_credential,
+                auto_permit_cap_requests: Some(true)
             }).await;
         }).await;
         

--- a/cli/src/dev.rs
+++ b/cli/src/dev.rs
@@ -48,6 +48,7 @@ pub async fn run(command: DevFunctions) -> Result<()> {
                     admin_credential: Some(String::from("*")),
                     hc_proxy_url: None,
                     hc_bootstrap_url: None,
+                    auto_permit_cap_requests: Some(true),
                 })
                 .await
                 .join()
@@ -178,6 +179,7 @@ pub async fn run(command: DevFunctions) -> Result<()> {
                     admin_credential: None,
                     hc_proxy_url: None,
                     hc_bootstrap_url: None,
+                    auto_permit_cap_requests: Some(true),
                 })
                 .await
                 .join()

--- a/rust-executor/src/config.rs
+++ b/rust-executor/src/config.rs
@@ -22,6 +22,7 @@ pub struct Ad4mConfig {
     pub hc_bootstrap_url: Option<String>,
     pub connect_holochain: Option<bool>,
     pub admin_credential: Option<String>,
+    pub auto_permit_cap_requests: Option<bool>,
 }
 
 impl Ad4mConfig {
@@ -96,6 +97,7 @@ impl Default for Ad4mConfig {
             hc_bootstrap_url: None,
             connect_holochain: None,
             admin_credential: None,
+            auto_permit_cap_requests: None,
         };
         config.prepare();
         config

--- a/rust-executor/src/dapp_server.rs
+++ b/rust-executor/src/dapp_server.rs
@@ -1,27 +1,27 @@
 use std::net::Ipv4Addr;
 use std::path::Path;
 
-use rocket::fs::{FileServer, relative};
-use rocket::{Config, Route, State};
+use rocket::fs::FileServer;
+use rocket::Config;
 use include_dir::{include_dir, Dir};
 
 const DAPP: Dir = include_dir!("dapp/dist");
 
-pub(crate) async fn serve_dapp(port: u16) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+pub(crate) async fn serve_dapp(port: u16, app_dir: String) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let config = Config {
         port,
         address: Ipv4Addr::new(127, 0, 0, 1).into(),
         ..Config::debug_default()
     };
 
-    let dir = relative!("dapp/dist");
-    if !Path::new(dir).exists() {
-        DAPP.extract("dapp/dist")?;
+    let dir = Path::new(&app_dir).join("dapp");
+    if !dir.exists() {
+        DAPP.extract(dir.clone())?;
     }
 
     rocket::build()
         .configure(&config)
-        .mount("/", FileServer::from(dir))
+        .mount("/", FileServer::from(dir.to_str().expect("Failed to convert path to string")))
         .launch()
         .await?;
 

--- a/rust-executor/src/graphql/graphql_types.rs
+++ b/rust-executor/src/graphql/graphql_types.rs
@@ -13,6 +13,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub struct RequestContext {
     pub capabilities: Result<Vec<Capability>, String>,
     pub js_handle: JsCoreHandle,
+    pub auto_permit_cap_requests: bool,
 }
 
 #[derive(GraphQLObject, Default, Debug, Deserialize, Serialize, Clone)]

--- a/rust-executor/src/graphql/mod.rs
+++ b/rust-executor/src/graphql/mod.rs
@@ -67,6 +67,7 @@ pub async fn start_server(js_core_handle: JsCoreHandle, config: Ad4mConfig) -> R
             RequestContext {
                 capabilities,
                 js_handle: js_core_handle_cloned1.clone(),
+                auto_permit_cap_requests: config.auto_permit_cap_requests.clone().unwrap_or(false),
             }
         });
     let qm_graphql_filter = coasys_juniper_warp::make_graphql_filter(qm_schema, qm_state.boxed());
@@ -80,11 +81,12 @@ pub async fn start_server(js_core_handle: JsCoreHandle, config: Ad4mConfig) -> R
             let root_node = root_node.clone();
             let js_core_handle = js_core_handle.clone();
             let admin_credential_arc = admin_credential_arc.clone();
+            let auto_permit_cap_requests = config.auto_permit_cap_requests.clone().unwrap_or(false);
             ws.on_upgrade(move |websocket| async move {
                 serve_graphql_transport_ws(
                     websocket,
                     root_node,
-                    |val: HashMap<String, InputValue>| async move {
+                    move |val: HashMap<String, InputValue>| async move {
                         let mut auth_header = String::from("");
 
                         if let Some(headers) = val.get("headers") {
@@ -102,6 +104,7 @@ pub async fn start_server(js_core_handle: JsCoreHandle, config: Ad4mConfig) -> R
                         let context = RequestContext {
                             capabilities,
                             js_handle: js_core_handle.clone(),
+                            auto_permit_cap_requests: auto_permit_cap_requests
                         };
                         Ok(ConnectionConfig::new(context))
                             as Result<ConnectionConfig<_>, Infallible>

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -154,7 +154,21 @@ impl Mutation {
         auth_info: AuthInfoInput,
     ) -> FieldResult<String> {
         check_capability(&context.capabilities, &AGENT_AUTH_CAPABILITY)?;
-        Ok(agent::capabilities::request_capability(auth_info.into()).await)
+        let auth_info: AuthInfo = auth_info.into();
+        let request_id = agent::capabilities::request_capability(auth_info.clone()).await;
+        if true == context.auto_permit_cap_requests {
+            println!("======================================");
+            println!("Got capability request: \n{:?}", auth_info);
+            let random_number_challenge = agent::capabilities::permit_capability(AuthInfoExtended {
+                request_id: request_id.clone(), 
+                auth: auth_info
+            })?;
+            println!("--------------------------------------");
+            println!("Random number challenge: {}", random_number_challenge);
+            println!("======================================");
+        } 
+
+        Ok(request_id)
     }
 
     //NOTE: all the functions from here on out have not been tested by calling the cli <-> rust graphql server

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -387,9 +387,9 @@ impl HolochainService {
             .build()
             .await;
 
-        if conductor.is_err() {
-            info!("Could not start holochain conductor: {:#?}", conductor.err());
-            panic!("Could not start holochain conductor");
+        if let Err(e) = conductor {
+            info!("Could not start holochain conductor: {:#?}", e);
+            panic!("Could not start holochain conductor: {:#?}", e);
         }
 
         info!("Started holochain conductor");

--- a/rust-executor/src/languages/language.rs
+++ b/rust-executor/src/languages/language.rs
@@ -12,7 +12,7 @@ fn parse_revision(js_result: String) -> Result<Option<String>, AnyError> {
     if let Ok(maybe_revision) = serde_json::from_str::<Option<ByteArray>>(&js_result) {
         Ok(maybe_revision.map(|revision| {
             let vec: Vec<u8> = revision.into();
-            String::from_utf8(vec).unwrap()
+            base64::encode(&vec)
         }))
     } else {
         Ok(serde_json::from_str::<Option<String>>(&js_result)?)

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -26,7 +26,7 @@ mod test_utils;
 
 use tokio;
 use std::{env, thread::JoinHandle};
-use log::{info, warn};
+use log::{info, warn, error};
 
 use js_core::JsCore;
 
@@ -79,6 +79,11 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
 
     info!("Starting GraphQL...");
 
+    let app_dir = config.app_data_path
+        .as_ref()
+        .expect("App data path not set in Ad4mConfig")
+        .clone();
+
     if let Some(true) = config.run_dapp_server {
         std::thread::spawn(|| {
             let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -86,7 +91,9 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
                 .enable_all()
                 .build()
                 .unwrap();
-            let _ = runtime.block_on(serve_dapp(8080));
+            if let Err(e) = runtime.block_on(serve_dapp(8080, app_dir)) {
+                error!("Failed to start dapp server: {:?}", e);
+            }
         });
     };
 

--- a/rust-executor/src/mainnet_seed.json
+++ b/rust-executor/src/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdiSAPyaXzUN7Zgq6EMPEu8JQG3ck5UgH7REhAicWbVAo2",
+    "QmzSYwdhcfG8Urkt5YsF1KyPEAdd8F6emRG31s7GDLMqbRAQTH3",
     "QmzSYwdnyTVrzufV8HfUfFRwDSiZZjRoBimrm95qjh6KCG9Z6YW",
     "QmzSYwdnHrRH8MmuPWKKrDvFoVyW5CophNpT1ipQUCcenPVTQnd"
   ],

--- a/rust-executor/src/mainnet_seed.json
+++ b/rust-executor/src/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdhcfG8Urkt5YsF1KyPEAdd8F6emRG31s7GDLMqbRAQTH3",
+    "QmzSYwdejFmQYpHtztu32516wvjkBohQmZt7dKUn4pnkPJA6kPV",
     "QmzSYwdnyTVrzufV8HfUfFRwDSiZZjRoBimrm95qjh6KCG9Z6YW",
     "QmzSYwdnHrRH8MmuPWKKrDvFoVyW5CophNpT1ipQUCcenPVTQnd"
   ],

--- a/rust-executor/src/mainnet_seed.json
+++ b/rust-executor/src/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdejFmQYpHtztu32516wvjkBohQmZt7dKUn4pnkPJA6kPV",
+    "QmzSYwdj7LmLiY7p5vEzBPuQpW3CmAB41vEJe9hkVB9w6ndhcE5",
     "QmzSYwdnyTVrzufV8HfUfFRwDSiZZjRoBimrm95qjh6KCG9Z6YW",
     "QmzSYwdnHrRH8MmuPWKKrDvFoVyW5CophNpT1ipQUCcenPVTQnd"
   ],

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
       "outputs": ["dist/**", "lib/**", "build/**"]
     },
     "build-libs": {
-      "dependsOn": ["@coasys/ad4m#build", "@coasys/ad4m-connect#build", "@coasys/ad4m-executor#build", "@coasys/ad4m-cli#build", "@coasys/dapp#build"],
+      "dependsOn": ["@coasys/dapp#build", "@coasys/ad4m#build", "@coasys/ad4m-connect#build", "@coasys/ad4m-executor#build", "@coasys/ad4m-cli#build"],
       "outputs": ["dist/**", "lib/**", "build/**"]
     },
     "build-core-executor": {

--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,16 @@
       "outputs": ["dist/**", "lib/**", "build/**"]
     },
 
+    "rust-ad4m-executor#build": {
+      "dependsOn": ["@coasys/dapp#build"],
+      "outputs": ["dist/**", "lib/**", "build/**"]
+    },
+
+    "ad4m-cli#build": {
+      "dependsOn": ["@coasys/dapp#build"],
+      "outputs": ["dist/**", "lib/**", "build/**"]
+    },
+
     "ad4m-launcher#package-ad4m": {
       "dependsOn": ["build-libs"],
       "outputs": ["dist/**"]


### PR DESCRIPTION
 - Make JS part of P-Diff-Sync Deno compatible by replacing `Buffer` with  `Uint8Array`
 - Fix pending diffs loop to not keep committing empty diffs
 - `ad4m-executor run` will now print out the capability random number challenge so apps can actually get authorized against a headless ad4m agent (without launcher)
 - dapp files are now extracted to and read from ~/.ad4m config directory to avoid relative path mixups