### PR TITLE
Notification Prolog helper predicates and OS notification push

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,20 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 
 ## unreleased
 
+### Fixed
+- Prolog engine gets respawned when a query caused an error to clean the machine state [PR#483](https://github.com/coasys/ad4m/pull/483)
+- Catch panics in Scryer and handle as error instead of killing the engine thread which caused `channel closed` error in future queries [PR#483](https://github.com/coasys/ad4m/pull/483)
+
 ### Added
+- Prolog predicates needed in new Flux mention notification trigger:
+ - agent_did/1
+ - remove_html_tags/2
+ - string_includes/2
+ - literal_from_url/3
+ - json_property/3
+[PR#483](https://github.com/coasys/ad4m/pull/483) 
+- Triggered notifications are handled through operating system notifications [PR#483](https://github.com/coasys/ad4m/pull/483)
+
 - App notifications implemented. ADAM apps can register Prolog queries with the executor which will be checked on every perspective change. If the change adds a new match, it will trigger the publishing of a notifications via subscriptions in client interface [PR#475](https://github.com/coasys/ad4m/pull/475), as well as calling a web hook if given [PR#482](https://github.com/coasys/ad4m/pull/482)
 - Support ADAM executor hosting service alpha [PR#474](https://github.com/coasys/ad4m/pull/474)
 - Complete instructions in README [PR#473](https://github.com/coasys/ad4m/pull/473)

--- a/rust-executor/src/perspectives/sdna.rs
+++ b/rust-executor/src/perspectives/sdna.rs
@@ -285,17 +285,33 @@ url_decode_char(Char) --> [Char], { \+ member(Char, "%") }.
     json_value_list([Value|Values]) --> json_value(Value), ws, ("," -> json_value_list(Values) ; {Values=[]}).
     
     json_string(String) -->
-        "\"", string_chars(String), "\"".
+    "\"", json_string_chars(String), "\"".
+
+    json_string_chars([]) --> [].
+    json_string_chars([C|Cs]) --> json_string_char(C), json_string_chars(Cs).
+
+    json_string_char(C) --> [C], { dif(C, '"'), dif(C, '\\') }.
+    json_string_char('"') --> ['\\', '"'].
+    json_string_char('\\') --> ['\\', '\\'].
+    json_string_char('/') --> ['\\', '/'].
+    json_string_char('\b') --> ['\\', 'b'].
+    json_string_char('\f') --> ['\\', 'f'].
+    json_string_char('\n') --> ['\\', 'n'].
+    json_string_char('\r') --> ['\\', 'r'].
+    json_string_char('\t') --> ['\\', 't'].
     
     json_number(Number) -->
-        number_chars(Chars),
-        { number_chars(Number, Chars) }.
+        number_sequence(Chars),
+        { atom_chars(Atom, Chars),
+          atom_number(Atom, Number) }.
     
     string_chars([]) --> [].
     string_chars([C|Cs]) --> [C], { dif(C, '"') }, string_chars(Cs).
     
-    number_chars([D|Ds]) --> digit(D), number_chars(Ds).
-    number_chars([]) --> [].
+    % Simplified number_sequence to handle both integer and fractional parts
+    number_sequence([D|Ds]) --> digit(D), number_sequence_rest(Ds).
+    number_sequence_rest([D|Ds]) --> digit(D), number_sequence_rest(Ds).
+    number_sequence_rest([]) --> [].
     
     digit(D) --> [D], { member(D, "0123456789.") }.
     

--- a/rust-executor/src/perspectives/sdna.rs
+++ b/rust-executor/src/perspectives/sdna.rs
@@ -141,7 +141,11 @@ pub async fn init_engine_facts(all_links: Vec<DecoratedLinkExpression>, neighbou
     lines.push(":- discontiguous(p3_class_color/2).".to_string());
     lines.push(":- discontiguous(p3_instance_color/3).".to_string());
 
+    // library modules
     lines.push(":- use_module(library(lists)).".to_string());
+    lines.push(":- use_module(library(dcgs)).".to_string());
+    lines.push(":- use_module(library(charsio)).".to_string());
+    lines.push(":- use_module(library(format)).".to_string());
 
     let lib = r#"
 :- discontiguous(paginate/4).
@@ -168,8 +172,80 @@ N > 0,
 NextN is N - 1,
 takeN(Rest, NextN, PageRest).
     "#;
-
+    
     lines.extend(lib.split('\n').map(|s| s.to_string()));
+
+    let literal_html_string_predicates = r#"
+% Main predicate to remove HTML tags
+remove_html_tags(Input, Output) :-
+    phrase(strip_html(Output), Input).
+
+% DCG rule to strip HTML tags
+strip_html([]) --> [].
+strip_html(Result) -->
+    "<", !, skip_tag, strip_html(Result).
+strip_html([Char|Result]) -->
+    [Char],
+    strip_html(Result).
+
+% DCG rule to skip HTML tags
+skip_tag --> ">", !.
+skip_tag --> [_], skip_tag.
+
+% Main predicate to check if Substring is included in String
+string_includes(String, Substring) :-
+    phrase((..., string(Substring), ...), String).
+
+% DCG rule for any sequence of characters
+... --> [].
+... --> [_], ... .
+
+% DCG rule for matching a specific string
+string([]) --> [].
+string([C|Cs]) --> [C], string(Cs).
+
+
+literal_from_url(Url, Decoded, Scheme) :-
+    phrase(parse_url(Scheme, Encoded), Url),
+    phrase(url_decode(Decoded), Encoded).
+
+% DCG rule to parse the URL
+parse_url(Scheme, Encoded) -->
+    "literal://", scheme(Scheme), ":", string(Encoded).
+
+scheme(string) --> "string".
+scheme(number) --> "number".
+scheme(json) --> "json".
+
+url_decode([]) --> [].
+url_decode([H|T]) --> url_decode_char(H), url_decode(T).
+
+url_decode_char(' ') --> "%20".
+url_decode_char('!') --> "%21".
+url_decode_char('#') --> "%23".
+url_decode_char('$') --> "%24".
+url_decode_char('%') --> "%25".
+url_decode_char('&') --> "%26".
+url_decode_char('\'') --> "%27".
+url_decode_char('(') --> "%28".
+url_decode_char(')') --> "%29".
+url_decode_char('*') --> "%2A".
+url_decode_char('+') --> "%2B".
+url_decode_char(',') --> "%2C".
+url_decode_char('/') --> "%2F".
+url_decode_char(':') --> "%3A".
+url_decode_char(';') --> "%3B".
+url_decode_char('=') --> "%3D".
+url_decode_char('?') --> "%3F".
+url_decode_char('@') --> "%40".
+url_decode_char('[') --> "%5B".
+url_decode_char(']') --> "%5D".
+url_decode_char('{') --> "%7B".
+url_decode_char('}') --> "%7D".
+url_decode_char(Char) --> [Char], { \+ member(Char, "%") }.
+    "#;
+
+    lines.extend(literal_html_string_predicates.split('\n').map(|s| s.to_string()));
 
     let mut author_agents = vec![agent::did()];
     if let Some(neughbourhood_author) = neighbourhood_author {

--- a/rust-executor/src/perspectives/sdna.rs
+++ b/rust-executor/src/perspectives/sdna.rs
@@ -223,6 +223,7 @@ url_decode([H|T]) --> url_decode_char(H), url_decode(T).
 
 url_decode_char(' ') --> "%20".
 url_decode_char('!') --> "%21".
+url_decode_char('"') --> "%22".
 url_decode_char('#') --> "%23".
 url_decode_char('$') --> "%24".
 url_decode_char('%') --> "%25".
@@ -243,6 +244,17 @@ url_decode_char('[') --> "%5B".
 url_decode_char(']') --> "%5D".
 url_decode_char('{') --> "%7B".
 url_decode_char('}') --> "%7D".
+url_decode_char('<') --> "%3C".
+url_decode_char('>') --> "%3E".
+url_decode_char('\\') --> "%5C".
+url_decode_char('^') --> "%5E".
+url_decode_char('_') --> "%5F".
+url_decode_char('|') --> "%7C".
+url_decode_char('~') --> "%7E".
+url_encode_char('`') --> "%60".
+url_encode_char('-') --> "%2D".
+url_encode_char('.') --> "%2E".
+
 url_decode_char(Char) --> [Char], { \+ member(Char, "%") }.
     "#;
 

--- a/rust-executor/src/perspectives/sdna.rs
+++ b/rust-executor/src/perspectives/sdna.rs
@@ -247,6 +247,8 @@ url_decode_char(Char) --> [Char], { \+ member(Char, "%") }.
 
     lines.extend(literal_html_string_predicates.split('\n').map(|s| s.to_string()));
 
+    lines.push(format!("agent_did(\"{}\").", agent::did()));    
+
     let mut author_agents = vec![agent::did()];
     if let Some(neughbourhood_author) = neighbourhood_author {
         author_agents.push(neughbourhood_author);

--- a/rust-executor/src/perspectives/sdna.rs
+++ b/rust-executor/src/perspectives/sdna.rs
@@ -147,6 +147,7 @@ pub async fn init_engine_facts(all_links: Vec<DecoratedLinkExpression>, neighbou
     lines.push(":- use_module(library(charsio)).".to_string());
     lines.push(":- use_module(library(format)).".to_string());
     lines.push(":- use_module(library(assoc)).".to_string());
+    lines.push(":- use_module(library(dif)).".to_string());
 
     let lib = r#"
 :- discontiguous(paginate/4).

--- a/rust-executor/src/perspectives/sdna.rs
+++ b/rust-executor/src/perspectives/sdna.rs
@@ -251,9 +251,9 @@ url_decode_char('^') --> "%5E".
 url_decode_char('_') --> "%5F".
 url_decode_char('|') --> "%7C".
 url_decode_char('~') --> "%7E".
-url_encode_char('`') --> "%60".
-url_encode_char('-') --> "%2D".
-url_encode_char('.') --> "%2E".
+url_decode_char('`') --> "%60".
+url_decode_char('-') --> "%2D".
+url_decode_char('.') --> "%2E".
 
 url_decode_char(Char) --> [Char], { \+ member(Char, "%") }.
     "#;

--- a/rust-executor/src/perspectives/utils.rs
+++ b/rust-executor/src/perspectives/utils.rs
@@ -8,13 +8,20 @@ pub fn prolog_value_to_json_string(value: Value) -> String {
         Value::Atom(a) => format!("{}", a.as_str()),
         Value::String(s) => 
             if let Err(_e) = serde_json::from_str::<serde_json::Value>(s.as_str()) {
-                //treat as string literal
-                //escape double quotes
-                format!("\"{}\"", s
-                    .replace("\"", "\\\"")
-                    .replace("\n", "\\n")
-                    .replace("\t", "\\t")
-                    .replace("\r", "\\r"))
+                //try unescaping an escape json string
+                let wrapped_s = format!("\"{}\"",s);
+                if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(wrapped_s.as_str()) {
+                    json_value.to_string()
+                } else {
+                    //treat as string literal
+                    //escape double quotes
+                    format!("\"{}\"", s
+                        .replace("\"", "\\\"")
+                        .replace("\n", "\\n")
+                        .replace("\t", "\\t")
+                        .replace("\r", "\\r"))
+                }
+                
             } else {
                 //return valid json string
                 s

--- a/rust-executor/src/prolog_service/engine.rs
+++ b/rust-executor/src/prolog_service/engine.rs
@@ -6,6 +6,7 @@ use tokio::sync::{mpsc, oneshot};
 pub enum PrologServiceRequest {
     RunQuery(String, oneshot::Sender<PrologServiceResponse>),
     LoadModuleString(String, Vec<String>, oneshot::Sender<PrologServiceResponse>),
+    Drop,
 }
 
 #[derive(Debug)]
@@ -73,6 +74,7 @@ impl PrologEngine {
                                     machine.consult_module_string(module_name.as_str(), program);
                                 let _ = response.send(PrologServiceResponse::LoadModuleResult(Ok(())));
                             }
+                            PrologServiceRequest::Drop => return
                         }
                     }
                 })
@@ -117,6 +119,12 @@ impl PrologEngine {
             PrologServiceResponse::LoadModuleResult(result) => result,
             _ => unreachable!(),
         }
+    }
+
+    pub fn drop(&self) -> Result<(), Error> {
+        self.request_sender
+            .send(PrologServiceRequest::Drop)?;
+        Ok(())
     }
 }
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -20,7 +20,7 @@ import TrayMessage from "./components/TrayMessage";
 const App = () => {
   const [opened, setOpened] = useState(false);
   const {
-    state: { candidate, did, auth, notification },
+    state: { candidate, did, auth, notifications },
     methods: { handleTrustAgent },
   } = useContext(Ad4minContext);
 
@@ -86,7 +86,7 @@ const App = () => {
         <TrustAgent candidate={candidate} handleTrustAgent={handleTrustAgent} />
       )}
       {auth && <Auth />}
-      {notification && <Notification />}
+      {notifications.map((notification) => (<Notification key={notification.id} notification={notification} />))}
     </div>
   );
 };

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,6 +4,7 @@ import { useContext, useEffect, useState } from "react";
 import TrustAgent from "./components/TrustAgent";
 import Navigation from "./components/Navigation";
 import Auth from "./components/Auth";
+import Notification from "./components/Notification";
 import { Ad4minContext } from "./context/Ad4minContext";
 import { AgentProvider } from "./context/AgentContext";
 import { Route, Routes } from "react-router-dom";
@@ -19,7 +20,7 @@ import TrayMessage from "./components/TrayMessage";
 const App = () => {
   const [opened, setOpened] = useState(false);
   const {
-    state: { candidate, did, auth },
+    state: { candidate, did, auth, notification },
     methods: { handleTrustAgent },
   } = useContext(Ad4minContext);
 
@@ -85,6 +86,7 @@ const App = () => {
         <TrustAgent candidate={candidate} handleTrustAgent={handleTrustAgent} />
       )}
       {auth && <Auth />}
+      {notification && <Notification />}
     </div>
   );
 };

--- a/ui/src/components/Notification.tsx
+++ b/ui/src/components/Notification.tsx
@@ -1,0 +1,77 @@
+import { useContext, useEffect, useState } from "react";
+import { Ad4minContext } from "../context/Ad4minContext";
+
+const Notification = () => {
+  const {
+    state: { client, notification },
+    methods: { handleNotification },
+  } = useContext(Ad4minContext);
+
+  const [requestModalOpened, setRequestModalOpened] = useState(true);
+
+  useEffect(() => {
+    setRequestModalOpened(true);
+  }, [notification]);
+
+
+  const permitNotification = async () => {
+    // @ts-ignore
+    let result = await client!.runtime.grantNotification(notification?.id);
+
+    console.log(`permit result: ${result}`);
+
+    // @ts-ignore
+    handleNotification(null);
+
+    closeRequestModal();
+  };
+
+  const closeRequestModal = () => {
+    setRequestModalOpened(false);
+  };
+
+  return (
+    <div>
+      {requestModalOpened && (
+        <j-modal
+          size="fullscreen"
+          open={requestModalOpened}
+          onToggle={(e: any) => setRequestModalOpened(e.target.open)}
+        >
+          <j-box px="500" py="600">
+            <j-flex gap="200" direction="column">
+              <j-box pb="900">
+                <j-text nomargin size="600" color="black" weight="600">
+                  Authorize Notification
+                </j-text>
+              </j-box>
+
+              <j-flex gap="500">
+                <div>
+                  <j-avatar size="xl" src={notification?.appIconPath}></j-avatar>
+                </div>
+                <div>
+                  <j-text variant="heading-sm">{notification?.appName}</j-text>
+                  <j-text nomargin size="500">
+                    {notification?.description}
+                  </j-text>
+                </div>
+              </j-flex>
+
+              <j-flex gap="300">
+                <j-button variant="link" onClick={closeRequestModal}>
+                  Close
+                </j-button>
+                <j-button variant="primary" onClick={permitNotification}>
+                  Confirm
+                </j-button>
+              </j-flex>
+            </j-flex>
+          </j-box>
+        </j-modal>
+      )}
+    </div>
+  );
+};
+
+export default Notification;

--- a/ui/src/components/Notification.tsx
+++ b/ui/src/components/Notification.tsx
@@ -89,19 +89,23 @@ const Notification = ({ notification }: { notification: NotificationType }) => {
                     </j-text>
                   </j-flex>
                 </div>
-                <div>
-                  <j-flex>
-                    <j-text>
-                      Webhook URL: {notification?.webhookUrl}
-                    </j-text>
-                  </j-flex>
-                  <j-text color="danger" variant="caption">
+                {
+                  notification?.webhookUrl && (
+                    <div>
+                      <j-flex>
+                        <j-text>
+                          Webhook URL: {notification?.webhookUrl}
+                        </j-text>
+                      </j-flex>
+                      <j-text color="danger" variant="caption">
 
-                  </j-text>
-                  <p style="height: 60px; color: red; font-size: 14px; margin: 0; ">
-                    Caution: This notification will be sent to the above URL and the data can be leaked outside of the app. Please make sure you trust the app.
-                  </p>
-                </div>
+                      </j-text>
+                      <p style="height: 60px; color: red; font-size: 14px; margin: 0; ">
+                        Caution: This notification will be sent to the above URL and the data can be leaked outside of the app. Please make sure you trust the app.
+                      </p>
+                    </div>
+                  )
+                }
               </j-flex>
 
               <j-flex gap="300">

--- a/ui/src/components/Notification.tsx
+++ b/ui/src/components/Notification.tsx
@@ -1,19 +1,28 @@
 import { useContext, useEffect, useState } from "react";
 import { Ad4minContext } from "../context/Ad4minContext"
-import { Notification as NotificationType } from "@coasys/ad4m/lib/src/runtime/RuntimeResolver";;
+import { Notification as NotificationType } from "@coasys/ad4m/lib/src/runtime/RuntimeResolver"; import { PerspectiveProxy } from "@coasys/ad4m";
+;
 
-const Notification = ({notification}: {notification: NotificationType}) => {
+const Notification = ({ notification }: { notification: NotificationType }) => {
   const {
-    state: { client  },
+    state: { client },
     methods: { handleNotification },
   } = useContext(Ad4minContext);
 
   const [requestModalOpened, setRequestModalOpened] = useState(true);
+  const [perspectives, setPerspectives] = useState<PerspectiveProxy[]>([]);
 
   useEffect(() => {
     setRequestModalOpened(true);
+    getPerspectives();
   }, [notification]);
 
+
+  const getPerspectives = async () => {
+    const perspectives = await client?.perspective.all();
+    const filteredPerspectives = perspectives?.filter((perspective) => notification.perspectiveIds.includes(perspective.uuid));
+    setPerspectives(filteredPerspectives);
+  }
 
   const permitNotification = async () => {
     // @ts-ignore
@@ -56,6 +65,42 @@ const Notification = ({notification}: {notification: NotificationType}) => {
                   <j-text nomargin size="500">
                     {notification?.description}
                   </j-text>
+                </div>
+              </j-flex>
+              <j-flex gap="200" direction="column">
+                <div>
+                  <j-text nomargin size="500">
+                    Perspectives:
+                  </j-text>
+                  <ul>
+                    {perspectives?.map((perspective) => (
+                      <li key={perspective.uuid}>
+                        <j-text nomargin size="500">
+                          {perspective.name}
+                        </j-text>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <j-flex>
+                    <j-text>
+                      Notification Trigger: {notification?.trigger}
+                    </j-text>
+                  </j-flex>
+                </div>
+                <div>
+                  <j-flex>
+                    <j-text>
+                      Webhook URL: {notification?.webhookUrl}
+                    </j-text>
+                  </j-flex>
+                  <j-text color="danger" variant="caption">
+
+                  </j-text>
+                  <p style="height: 60px; color: red; font-size: 14px; margin: 0; ">
+                    Caution: This notification will be sent to the above URL and the data can be leaked outside of the app. Please make sure you trust the app.
+                  </p>
                 </div>
               </j-flex>
 

--- a/ui/src/components/Notification.tsx
+++ b/ui/src/components/Notification.tsx
@@ -1,9 +1,10 @@
 import { useContext, useEffect, useState } from "react";
-import { Ad4minContext } from "../context/Ad4minContext";
+import { Ad4minContext } from "../context/Ad4minContext"
+import { Notification as NotificationType } from "@coasys/ad4m/lib/src/runtime/RuntimeResolver";;
 
-const Notification = () => {
+const Notification = ({notification}: {notification: NotificationType}) => {
   const {
-    state: { client, notification },
+    state: { client  },
     methods: { handleNotification },
   } = useContext(Ad4minContext);
 
@@ -21,7 +22,7 @@ const Notification = () => {
     console.log(`permit result: ${result}`);
 
     // @ts-ignore
-    handleNotification(null);
+    handleNotification(notification);
 
     closeRequestModal();
   };

--- a/ui/src/context/Ad4minContext.tsx
+++ b/ui/src/context/Ad4minContext.tsx
@@ -158,10 +158,13 @@ export function Ad4minProvider({ children }: any) {
           console.log("Notification triggered: ", notification);
           const match = notification.triggerMatch;
           const parsed = JSON.parse(match);
+          const firstMatch = parsed[0];
+          const title = firstMatch?.Title
           sendNotification({
             icon: notification.notification.appIconPath,
-            title: parsed?.Title || notification.notification.appName,
-            body: parsed?.Description || "Received a new notification",
+            title: notification.notification.appName + (title ? ": " + title : ""),
+            body: firstMatch?.Description || "Received a new notification",
+            //body: match
           });
         })
       }

--- a/ui/src/context/Ad4minContext.tsx
+++ b/ui/src/context/Ad4minContext.tsx
@@ -136,7 +136,7 @@ export function Ad4minProvider({ children }: any) {
           if (exception.type === ExceptionType.InstallNotificationRequest) {
             setState((prev) => ({
               ...prev,
-              notifications: [prev.notifications, JSON.parse(exception.addon!)],
+              notifications: [...prev.notifications, JSON.parse(exception.addon!)],
             }));
           }
 
@@ -241,7 +241,7 @@ export function Ad4minProvider({ children }: any) {
       const filteredNotifications = prev.notifications.filter(
         (n) => n.id !== notification.id
       );
-      
+
       return {
         ...prev,
         notifications: filteredNotifications,

--- a/ui/src/context/Ad4minContext.tsx
+++ b/ui/src/context/Ad4minContext.tsx
@@ -1,4 +1,5 @@
 import { Ad4mClient, ExceptionType } from "@coasys/ad4m";
+import { sendNotification } from "@tauri-apps/api/notification";
 import { ExceptionInfo, Notification as NotificationType } from "@coasys/ad4m/lib/src/runtime/RuntimeResolver";
 import { createContext, useCallback, useEffect, useState } from "react";
 import {
@@ -151,6 +152,17 @@ export function Ad4minProvider({ children }: any) {
 
           return null;
         });
+
+        // @ts-ignore
+        client.runtime.addNotificationTriggeredCallback((notification) => {
+          console.log("Notification triggered: ", notification);
+          const match = notification.triggerMatch;
+          const parsed = JSON.parse(match);
+          sendNotification({
+            title: parsed?.Title || notification.notification.appName,
+            body: parsed?.Description || "Received a new notification",
+          });
+        })
       }
     },
     []

--- a/ui/src/context/Ad4minContext.tsx
+++ b/ui/src/context/Ad4minContext.tsx
@@ -22,7 +22,7 @@ type State = {
   connected: boolean;
   connectedLaoding: boolean;
   expertMode: boolean;
-  notification: NotificationType | null;
+  notifications: NotificationType[];
 };
 
 type ContextProps = {
@@ -33,7 +33,7 @@ type ContextProps = {
     handleTrustAgent: (str: string) => void;
     handleLogin: (client: Ad4mClient, login: Boolean, did: string) => void;
     toggleExpertMode: () => void;
-    handleNotification: (notification: Notification) => void;
+    handleNotification: (notification: NotificationType) => void;
   };
 };
 
@@ -50,7 +50,7 @@ const initialState: ContextProps = {
     connected: false,
     connectedLaoding: true,
     expertMode: getForVersion("expertMode") === "true",
-    notification: null,
+    notifications: [],
   },
   methods: {
     configureEndpoint: () => null,
@@ -136,7 +136,7 @@ export function Ad4minProvider({ children }: any) {
           if (exception.type === ExceptionType.InstallNotificationRequest) {
             setState((prev) => ({
               ...prev,
-              notification: JSON.parse(exception.addon!),
+              notifications: [prev.notifications, JSON.parse(exception.addon!)],
             }));
           }
 
@@ -236,11 +236,17 @@ export function Ad4minProvider({ children }: any) {
     }));
   };
 
-  const handleNotification = (notification: Notification) => {
-    setState((prev) => ({
-      ...prev,
-      notification,
-    }));
+  const handleNotification = (notification: NotificationType) => {
+    setState((prev) => {
+      const filteredNotifications = prev.notifications.filter(
+        (n) => n.id !== notification.id
+      );
+      
+      return {
+        ...prev,
+        notifications: filteredNotifications,
+      }
+    });
   }
 
   const configureEndpoint = async (url: string) => {

--- a/ui/src/context/Ad4minContext.tsx
+++ b/ui/src/context/Ad4minContext.tsx
@@ -1,5 +1,5 @@
 import { Ad4mClient, ExceptionType } from "@coasys/ad4m";
-import { ExceptionInfo } from "@coasys/ad4m/lib/src/runtime/RuntimeResolver";
+import { ExceptionInfo, Notification as NotificationType } from "@coasys/ad4m/lib/src/runtime/RuntimeResolver";
 import { createContext, useCallback, useEffect, useState } from "react";
 import {
   buildAd4mClient,
@@ -22,6 +22,7 @@ type State = {
   connected: boolean;
   connectedLaoding: boolean;
   expertMode: boolean;
+  notification: NotificationType | null;
 };
 
 type ContextProps = {
@@ -32,6 +33,7 @@ type ContextProps = {
     handleTrustAgent: (str: string) => void;
     handleLogin: (client: Ad4mClient, login: Boolean, did: string) => void;
     toggleExpertMode: () => void;
+    handleNotification: (notification: Notification) => void;
   };
 };
 
@@ -48,6 +50,7 @@ const initialState: ContextProps = {
     connected: false,
     connectedLaoding: true,
     expertMode: getForVersion("expertMode") === "true",
+    notification: null,
   },
   methods: {
     configureEndpoint: () => null,
@@ -55,6 +58,7 @@ const initialState: ContextProps = {
     handleTrustAgent: () => null,
     handleLogin: () => null,
     toggleExpertMode: () => null,
+    handleNotification: () => null,
   },
 };
 
@@ -128,6 +132,14 @@ export function Ad4minProvider({ children }: any) {
               auth: exception.addon!,
             }));
           }
+
+          if (exception.type === ExceptionType.InstallNotificationRequest) {
+            setState((prev) => ({
+              ...prev,
+              notification: JSON.parse(exception.addon!),
+            }));
+          }
+
           Notification.requestPermission().then((response) => {
             if (response === "granted") {
               new Notification(exception.title, { body: exception.message });
@@ -224,6 +236,13 @@ export function Ad4minProvider({ children }: any) {
     }));
   };
 
+  const handleNotification = (notification: Notification) => {
+    setState((prev) => ({
+      ...prev,
+      notification,
+    }));
+  }
+
   const configureEndpoint = async (url: string) => {
     if (url) {
       setState((prev) => ({
@@ -270,6 +289,7 @@ export function Ad4minProvider({ children }: any) {
           resetEndpoint,
           handleLogin,
           toggleExpertMode,
+          handleNotification
         },
       }}
     >

--- a/ui/src/context/Ad4minContext.tsx
+++ b/ui/src/context/Ad4minContext.tsx
@@ -159,6 +159,7 @@ export function Ad4minProvider({ children }: any) {
           const match = notification.triggerMatch;
           const parsed = JSON.parse(match);
           sendNotification({
+            icon: notification.notification.appIconPath,
             title: parsed?.Title || notification.notification.appName,
             body: parsed?.Description || "Received a new notification",
           });


### PR DESCRIPTION
# Added 
### Prolog predicates needed in new Flux mention notification trigger:
 - agent_did/1
 - remove_html_tags/2
 - string_includes/2
 - literal_from_url/3
 - json_property/3
 
### Triggered notifications are handled through operating system notifications

# Fixed
- Prolog engine gets respawned when a query caused an error to clean the machine state
- Catch panics in Scryer and handle as error instead of killing the engine thread which caused `channel closed` error in future queries