### PR TITLE
Notifications Fix

### DIFF
--- a/rust-executor/src/perspectives/utils.rs
+++ b/rust-executor/src/perspectives/utils.rs
@@ -7,37 +7,25 @@ pub fn prolog_value_to_json_string(value: Value) -> String {
         Value::Rational(r) => format!("{}", r),
         Value::Atom(a) => format!("{}", a.as_str()),
         Value::String(s) => {
-            log::debug!("processing string: {}",s);
             //try unescaping an escape json string
             let wrapped_s = format!("\"{}\"",s);
             if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(wrapped_s.as_str()) {
-                let r = json_value.to_string();
-                log::debug!("return escaped: {}", r);
-                r
+                json_value.to_string()
             } else {
-                log::debug!("not valid json: {}", wrapped_s);
-                
-                    // try fixing wrong \' escape sequences:
-                    let fixed_s = wrapped_s.replace("\\'", "'");
-                    if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(fixed_s.as_str()) {
-                        let r = json_value.to_string();
-                        log::debug!("is valid with fixed \\': {}", r);
-                        r
-                    } else {
-                        log::debug!("nothing helps. manual unescapingl...");
-                            //treat as string literal
-                            //escape double quotes
-                            format!("\"{}\"", s
-                                .replace("\"", "\\\"")
-                                .replace("\n", "\\n")
-                                .replace("\t", "\\t")
-                                .replace("\r", "\\r"))
-                        }
-
-                //} else {
-                    //return valid json string
-                //    s
-                //}
+                // try fixing wrong \' escape sequences:
+                let fixed_s = wrapped_s.replace("\\'", "'");
+                if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(fixed_s.as_str()) {
+                    json_value.to_string()
+                } else {
+                    log::debug!("nothing helps. manual unescapingl...");
+                        //treat as string literal
+                        //escape double quotes
+                        format!("\"{}\"", s
+                            .replace("\"", "\\\"")
+                            .replace("\n", "\\n")
+                            .replace("\t", "\\t")
+                            .replace("\r", "\\r"))
+                }
             }
         },
         Value::List(l) => {

--- a/rust-executor/src/perspectives/utils.rs
+++ b/rust-executor/src/perspectives/utils.rs
@@ -7,24 +7,29 @@ pub fn prolog_value_to_json_string(value: Value) -> String {
         Value::Rational(r) => format!("{}", r),
         Value::Atom(a) => format!("{}", a.as_str()),
         Value::String(s) => {
-            //try unescaping an escape json string
-            let wrapped_s = format!("\"{}\"",s);
-            if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(wrapped_s.as_str()) {
-                json_value.to_string()
-            } else {
-                // try fixing wrong \' escape sequences:
-                let fixed_s = wrapped_s.replace("\\'", "'");
-                if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(fixed_s.as_str()) {
-                    json_value.to_string()
-                } else {
-                    log::debug!("nothing helps. manual unescapingl...");
-                        //treat as string literal
-                        //escape double quotes
-                        format!("\"{}\"", s
-                            .replace("\"", "\\\"")
-                            .replace("\n", "\\n")
-                            .replace("\t", "\\t")
-                            .replace("\r", "\\r"))
+            match s.as_str() {
+                "true" => String::from("true"),
+                "false" => String::from("false"),
+                _ =>  {
+                    //try unescaping an escaped json string
+                    let wrapped_s = format!("\"{}\"",s);
+                    if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(wrapped_s.as_str()) {
+                        json_value.to_string()
+                    } else {
+                        // try fixing wrong \' escape sequences:
+                        let fixed_s = wrapped_s.replace("\\'", "'");
+                        if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(fixed_s.as_str()) {
+                            json_value.to_string()
+                        } else {
+                                //treat as string literal
+                                //escape double quotes
+                                format!("\"{}\"", s
+                                    .replace("\"", "\\\"")
+                                    .replace("\n", "\\n")
+                                    .replace("\t", "\\t")
+                                    .replace("\r", "\\r"))
+                        }
+                    }
                 }
             }
         },

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -387,6 +387,7 @@ describe("Prolog + Literals", () => {
                 expect(todo2).to.have.property("comments")
                 // @ts-ignore
                 await todo.setState("todo://review")
+                await sleep(1000)
                 expect(await todo.state).to.equal("todo://review")
                 expect(await todo.comments).to.be.empty
 


### PR DESCRIPTION
Flux escapes apostrophes "'" with a backslash "\'" which is not a valid JSON escape sequence. We have handcrafted code that turns Prolog results into JSON. With these "\'" it failed to produce valid JSON. This fixes that.