### PR TITLE
Process expression.get() on client for literals (no signature checking)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). More specifically:
 
 ## unreleased
+- ad4m.expression.get() handles literal values client-side to avoid roundtrips, can be overridden with optional flag [PR#498](https://github.com/coasys/ad4m/pull/498)
 
 ### Fixed
 - Prolog engine gets respawned when a query caused an error to clean the machine state [PR#483](https://github.com/coasys/ad4m/pull/483)

--- a/core/src/expression/ExpressionClient.ts
+++ b/core/src/expression/ExpressionClient.ts
@@ -2,6 +2,7 @@ import { ApolloClient, gql } from "@apollo/client/core";
 import { InteractionCall, InteractionMeta } from "../language/Language";
 import unwrapApolloResult from "../unwrapApolloResult";
 import { ExpressionRendered } from "./Expression";
+import { Literal } from "../Literal";
 
 export class ExpressionClient {
     #apolloClient: ApolloClient<any>
@@ -11,6 +12,15 @@ export class ExpressionClient {
     }
 
     async get(url: string): Promise<ExpressionRendered> {
+        try {
+            let literalValue = Literal.fromUrl(url).get();
+            if (typeof literalValue === 'object' && literalValue !== null) {
+                if ('author' in literalValue && 'timestamp' in literalValue && 'data' in literalValue && 'proof' in literalValue) {
+                    return literalValue;
+                }
+            }
+        } catch(e) {}
+
         const { expression } = unwrapApolloResult(await this.#apolloClient.query({
             query: gql`query expression($url: String!) {
                 expression(url: $url) {

--- a/core/src/expression/ExpressionClient.ts
+++ b/core/src/expression/ExpressionClient.ts
@@ -11,15 +11,18 @@ export class ExpressionClient {
         this.#apolloClient = client
     }
 
-    async get(url: string): Promise<ExpressionRendered> {
-        try {
-            let literalValue = Literal.fromUrl(url).get();
-            if (typeof literalValue === 'object' && literalValue !== null) {
-                if ('author' in literalValue && 'timestamp' in literalValue && 'data' in literalValue && 'proof' in literalValue) {
-                    return literalValue;
+    async get(url: string, alwaysGet: boolean = false): Promise<ExpressionRendered> {
+        if(!alwaysGet){
+            try {
+                let literalValue = Literal.fromUrl(url).get();
+                if (typeof literalValue === 'object' && literalValue !== null) {
+                    if ('author' in literalValue && 'timestamp' in literalValue && 'data' in literalValue && 'proof' in literalValue) {
+                        return literalValue;
+                    }
                 }
-            }
-        } catch(e) {}
+            } catch(e) {}
+        }
+        
 
         const { expression } = unwrapApolloResult(await this.#apolloClient.query({
             query: gql`query expression($url: String!) {


### PR DESCRIPTION
`ad4m.expression.get()` handles literal values client-side to avoid roundtrips, can be overridden with optional flag