### PR TITLE
Performance: don't run notification check on every link mutation

### DIFF
--- a/rust-executor/src/init.rs
+++ b/rust-executor/src/init.rs
@@ -14,7 +14,7 @@ pub fn init(
 ) -> Result<(), Box<dyn Error>> {
     std::env::set_var(
         "RUST_LOG",
-        "holochain=warn,wasmer_compiler_cranelift=warn,rust_executor=info,warp=warn,warp::server=warn",
+        "holochain=warn,wasmer_compiler_cranelift=warn,rust_executor=info,warp::server",
     );
     let _ = env_logger::try_init();
 

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -107,14 +107,11 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
     LanguageController::init_global_instance(js_core_handle.clone());
     perspectives::initialize_from_db();
 
-    
-
     let app_dir = config
         .app_data_path
         .as_ref()
         .expect("App data path not set in Ad4mConfig")
         .clone();
-
 
     info!("Starting dapp server...");
 

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -42,7 +42,7 @@ use crate::{
 pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
     env::set_var(
         "RUST_LOG",
-        "holochain=warn,wasmer_compiler_cranelift=warn,rust_executor=debug,warp=warn,warp::server=warn",
+        "holochain=warn,wasmer_compiler_cranelift=warn,rust_executor=debug,warp::server",
     );
     let _ = env_logger::try_init();
     config.prepare();
@@ -107,13 +107,16 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
     LanguageController::init_global_instance(js_core_handle.clone());
     perspectives::initialize_from_db();
 
-    info!("Starting GraphQL...");
+    
 
     let app_dir = config
         .app_data_path
         .as_ref()
         .expect("App data path not set in Ad4mConfig")
         .clone();
+
+
+    info!("Starting dapp server...");
 
     if let Some(true) = config.run_dapp_server {
         std::thread::spawn(|| {
@@ -127,6 +130,8 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
             }
         });
     };
+
+    info!("Starting GraphQL...");
 
     std::thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -976,10 +976,7 @@ impl PerspectiveInstance {
         }
     }
 
-    fn spawn_prolog_facts_update(
-        &self,
-        diff: DecoratedPerspectiveDiff,
-    ) {
+    fn spawn_prolog_facts_update(&self, diff: DecoratedPerspectiveDiff) {
         let self_clone = self.clone();
 
         tokio::spawn(async move {
@@ -1066,15 +1063,16 @@ impl PerspectiveInstance {
         after
             .iter()
             .map(|(notification, matches)| {
-                let new_matches: Vec<QueryMatch> = if let Some(old_matches) = before.get(&notification) {
-                    matches
-                        .iter()
-                        .filter(|m| !old_matches.contains(m))
-                        .cloned()
-                        .collect()
-                } else {
-                    Vec::new()
-                };
+                let new_matches: Vec<QueryMatch> =
+                    if let Some(old_matches) = before.get(&notification) {
+                        matches
+                            .iter()
+                            .filter(|m| !old_matches.contains(m))
+                            .cloned()
+                            .collect()
+                    } else {
+                        Vec::new()
+                    };
 
                 (notification.clone(), new_matches)
             })

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -1064,7 +1064,7 @@ impl PerspectiveInstance {
             .iter()
             .map(|(notification, matches)| {
                 let new_matches: Vec<QueryMatch> =
-                    if let Some(old_matches) = before.get(&notification) {
+                    if let Some(old_matches) = before.get(notification) {
                         matches
                             .iter()
                             .filter(|m| !old_matches.contains(m))

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -304,7 +304,7 @@ impl PerspectiveInstance {
 
     async fn notification_check_loop(&self) {
         let uuid = self.persisted.lock().await.uuid.clone();
-        let mut interval = time::interval(Duration::from_secs(1));
+        let mut interval = time::interval(Duration::from_secs(5));
         let mut before = self.notification_trigger_snapshot().await;
         while !*self.is_teardown.lock().await {
             interval.tick().await;

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -1071,7 +1071,7 @@ impl PerspectiveInstance {
                             .cloned()
                             .collect()
                     } else {
-                        Vec::new()
+                        matches.clone()
                     };
 
                 (notification.clone(), new_matches)

--- a/tests/js/tests/runtime.ts
+++ b/tests/js/tests/runtime.ts
@@ -276,7 +276,7 @@ export default function runtimeTests(testContext: TestContext) {
 
             // Happy path
             await notificationPerspective.add(new Link({source: "test://source", predicate: triggerPredicate, target: "test://target1"}))
-            await sleep(1000)
+            await sleep(7000)
             expect(mockFunction.called).to.be.true
             let triggeredNotification = mockFunction.getCall(0).args[0] as TriggeredNotification
             expect(triggeredNotification.notification.description).to.equal(notification.description)
@@ -290,7 +290,7 @@ export default function runtimeTests(testContext: TestContext) {
 
             // Ensuring we don't get old data on a new trigger
             await notificationPerspective.add(new Link({source: "test://source", predicate: triggerPredicate, target: "test://target2"}))
-            await sleep(1000)
+            await sleep(7000)
             expect(mockFunction.callCount).to.equal(2)
             triggeredNotification = mockFunction.getCall(1).args[0] as TriggeredNotification
             triggerMatch = JSON.parse(triggeredNotification.triggerMatch)


### PR DESCRIPTION
But instead check periodically every 5s

Also fix execution of integration tests by turning on warp logs again (needed by test suite)

From:
![flamegraph_1st](https://github.com/user-attachments/assets/6bfe712a-9bcb-4ca1-a95b-f0fa1d7df98d)
To:
![flamegraph_pr](https://github.com/user-attachments/assets/7538dae2-d922-4468-a704-b739ebc82646)
