### PR TITLE
Ensure create_subject was successful before returning

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 - Removed capacitor barcode scanner [PR#502](https://github.com/coasys/ad4m/pull/502)
 - Show an error when the code is wrong. [PR#502](https://github.com/coasys/ad4m/pull/502)
 - Error handling in connect when hosting is not working [PR#502](https://github.com/coasys/ad4m/pull/502)
+- Make new Rust create_subject() implementation wait for Prolog engine to be updated, reflecting the new instance to avoid race conditions [PR#520](https://github.com/coasys/ad4m/pull/520)
 
 ### Added
 - Prolog predicates needed in new Flux mention notification trigger:

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -27,6 +27,7 @@ use json5;
 use scryer_prolog::machine::parsed_results::{QueryMatch, QueryResolution};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tokio::time::sleep;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
@@ -1396,8 +1397,34 @@ impl PerspectiveInstance {
             .ok_or(anyhow!("No constructor found for class: {}", class_name))?;
 
         let commands: Vec<Command> = json5::from_str(&actions).unwrap();
-        self.execute_commands(commands, expression_address, vec![])
+        self.execute_commands(commands, expression_address.clone(), vec![])
             .await?;
+
+        let mut tries = 0;
+        let mut instance_check_passed = false;
+        while !instance_check_passed && tries < 50 {
+            match self
+                .prolog_query(format!(
+                    "subject_class(\"{}\", C), instance(C, \"{}\").",
+                    class_name, expression_address
+                ))
+                .await
+            {
+                Ok(QueryResolution::True) => instance_check_passed = true,
+                Ok(QueryResolution::Matches(_)) => instance_check_passed = true,
+                Err(e) => log::warn!("Error trying to check instance after create_subject: {}", e),
+                Ok(r) => log::info!("create_subject instance query returned: {:?}", r),
+            }
+            sleep(Duration::from_millis(10)).await;
+            tries += 1;
+        }
+
+        if instance_check_passed {
+            log::info!("Subject class \"{}\" successfully instantiated around \"{}\".", class_name, expression_address);
+        } else {
+            log::warn!("create_subject: instance check still false after running constructor and waiting 5s. Something seems off with subject class: {}", class_name);
+        }
+
         Ok(())
     }
 

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -27,11 +27,11 @@ use json5;
 use scryer_prolog::machine::parsed_results::{QueryMatch, QueryResolution};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tokio::time::sleep;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
+use tokio::time::sleep;
 use tokio::{join, time};
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -1420,7 +1420,11 @@ impl PerspectiveInstance {
         }
 
         if instance_check_passed {
-            log::info!("Subject class \"{}\" successfully instantiated around \"{}\".", class_name, expression_address);
+            log::info!(
+                "Subject class \"{}\" successfully instantiated around \"{}\".",
+                class_name,
+                expression_address
+            );
         } else {
             log::warn!("create_subject: instance check still false after running constructor and waiting 5s. Something seems off with subject class: {}", class_name);
         }


### PR DESCRIPTION
Make new Rust create_subject() implementation wait for Prolog engine to be updated, reflecting the new instance to avoid race condition