### PR TITLE
Fix problems with Subject Classes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 - Show an error when the code is wrong. [PR#502](https://github.com/coasys/ad4m/pull/502)
 - Error handling in connect when hosting is not working [PR#502](https://github.com/coasys/ad4m/pull/502)
 - Make new Rust create_subject() implementation wait for Prolog engine to be updated, reflecting the new instance to avoid race conditions [PR#520](https://github.com/coasys/ad4m/pull/520)
+- Fix problems with Subject Classes created by other non-progenitor agents, and make isSubjectInstance() more stable agains race conditions [PR#521](https://github.com/coasys/ad4m/pull/521)
 
 ### Added
 - Prolog predicates needed in new Flux mention notification trigger:

--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -365,7 +365,16 @@ export class PerspectiveProxy {
     */
     async isSubjectInstance<T>(expression: string, subjectClass: T): Promise<boolean> {
         let className = await this.stringOrTemplateObjectToSubjectClass(subjectClass)
-        return await this.infer(`subject_class("${className}", C), instance(C, "${expression}")`)
+        let isInstance = false;
+        const maxAttempts = 5;
+        let attempts = 0;
+
+        while (attempts < maxAttempts && !isInstance) {
+            isInstance = await this.infer(`subject_class("${className}", C), instance(C, "${expression}")`);
+            attempts++;
+          }
+
+        return isInstance
     }
 
 

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -3,7 +3,7 @@ use super::update_perspective;
 use super::utils::{
     prolog_get_all_string_bindings, prolog_get_first_string_binding, prolog_resolution_to_string,
 };
-use crate::agent::{self, create_signed_expression, did};
+use crate::agent::{self, create_signed_expression};
 use crate::graphql::graphql_types::{
     DecoratedPerspectiveDiff, ExpressionRendered, JsResultType, LinkMutations, LinkQuery,
     LinkStatus, NeighbourhoodSignalFilter, OnlineAgent, PerspectiveExpression, PerspectiveHandle,

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -3,7 +3,7 @@ use super::update_perspective;
 use super::utils::{
     prolog_get_all_string_bindings, prolog_get_first_string_binding, prolog_resolution_to_string,
 };
-use crate::agent::create_signed_expression;
+use crate::agent::{self, create_signed_expression, did};
 use crate::graphql::graphql_types::{
     DecoratedPerspectiveDiff, ExpressionRendered, JsResultType, LinkMutations, LinkQuery,
     LinkStatus, NeighbourhoodSignalFilter, OnlineAgent, PerspectiveExpression, PerspectiveHandle,
@@ -888,7 +888,14 @@ impl PerspectiveInstance {
             })
             .await?;
 
+        let author = agent::did();
+
         let mut sdna_links: Vec<Link> = Vec::new();
+
+        let links = links
+            .into_iter()
+            .filter(|l| l.author == author)
+            .collect::<Vec<DecoratedLinkExpression>>();
 
         if (Literal::from_url(sdna_code.clone())).is_err() {
             sdna_code = Literal::from_string(sdna_code)
@@ -904,7 +911,7 @@ impl PerspectiveInstance {
             });
 
             sdna_links.push(Link {
-                source: literal_name,
+                source: literal_name.clone(),
                 predicate: Some("ad4m://sdna".to_string()),
                 target: sdna_code,
             });


### PR DESCRIPTION
- Improve isSubjectInstance method with retry logic for better reliability
- Fix addSdna() to not omit adding a new SDNA definition if the same name was added by someone else (which breaks use-case of some other non progenitor agent adding a subject class for them, which we won't run because not signed by a trustet agent, but we don't get out of that situation because we can't add it with our signature since the old implementation doesn't regard the author of the SDNA, but just finds it existing already)