### PR TITLE
Fix vue hook private member error.

### DIFF
--- a/ad4m-hooks/vue/src/useSubjects.ts
+++ b/ad4m-hooks/vue/src/useSubjects.ts
@@ -17,7 +17,7 @@ export function useSubjects<SubjectClass>({
       ? (source as any)
       : ref(source || "ad4m://self");
   const perspectiveRef =
-    typeof perspective === "function" ? (perspective as any) : ref(perspective);
+    typeof perspective === "function" ? (perspective as any) : shallowRef(perspective);
 
   let entries = ref<{ [x: string]: any }[]>([]);
   let repo = shallowRef<SubjectRepository<any> | null>(null);


### PR DESCRIPTION
This PR switches the `ref` wrapper on perspective for `shallowRef` to fix the following error:

```
Cannot read private member from an object whose class did not declare it
```

The perspective class contains private members and therefore requires `shallowRef` to be used to prevent vue from trying to make methods that use them reactive.