### PR TITLE
Change CLI default port to 12000

### DIFF
--- a/cli/src/startup.rs
+++ b/cli/src/startup.rs
@@ -35,8 +35,8 @@ pub fn get_executor_port() -> Result<u16> {
         Ok(port) => Ok(port.parse::<u16>().unwrap()),
         Err(err) => {
             println!("{}", err);
-            println!("Attempting to connect on default port 4000...\n");
-            Ok(4000)
+            println!("Attempting to connect on default port 12000...\n");
+            Ok(12000)
         }
     }
 }

--- a/rust-executor/src/config.rs
+++ b/rust-executor/src/config.rs
@@ -61,7 +61,7 @@ impl Ad4mConfig {
             self.run_dapp_server = Some(true);
         }
         if self.gql_port.is_none() {
-            self.gql_port = Some(4000);
+            self.gql_port = Some(12000);
         }
         if self.connect_holochain.is_none() {
             self.connect_holochain = Some(false);


### PR DESCRIPTION
So it can be used as replacement for launcher just with `ad4m-executor run`