### PR TITLE
Timeout fallback added to linkAdded function in useSubjects hook

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 - Avoid high CPU load when idling by deactivating V8's code optimization [PR#531](https://github.com/coasys/ad4m/pull/531)
 - Enable high-throughput of perspective mutations by debouncing commits to link languages and coalesce them into aggregated perspective diffs [PR#533](https://github.com/coasys/ad4m/pull/533)
 - Fix for long Flux messages (and too long subject class properties in general) being broken [PR#538](https://github.com/coasys/ad4m/pull/538)
+- Fix for missing links: timeout added to useSubjects function 'linkAdded' that fetches all data after one second gap between new links propagating [PR#540](https://github.com/coasys/ad4m/pull/540)
 
 ### Added
 - Prolog predicates needed in new Flux mention notification trigger:

--- a/ad4m-hooks/react/src/useSubjects.tsx
+++ b/ad4m-hooks/react/src/useSubjects.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import {
   getCache,
   setCache,
@@ -24,6 +24,7 @@ export function useSubjects<SubjectClass>(props: Props<SubjectClass>) {
   const [error, setError] = useState<string | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(false);
   const { perspective, source, subject } = props;
+  const timeout = useRef<any>(null);
 
   // Create cache key for entry
   const cacheKey = `${perspective.uuid}/${source || ""}/${
@@ -92,7 +93,9 @@ export function useSubjects<SubjectClass>(props: Props<SubjectClass>) {
   }
 
   async function linkAdded(link: LinkExpression) {
-    const allEntries = (getCache(cacheKey) || []) as SubjectClass[];
+    if (timeout.current) clearTimeout(timeout.current);
+    timeout.current = setTimeout(getData, 1000);
+
     const isNewEntry = link.data.source === source;
     // @ts-ignore
     const isUpdated = allEntries?.find((e) => e.id === link.data.source);


### PR DESCRIPTION
Fix for missing links: timeout added to useSubjects function 'linkAdded' that fetches all data after one second gap between new links propagating