### PR TITLE
Fix ad4m-connect bug introduced in PR#532

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,7 +44,7 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 - ad4m.expression.get() handles literal values client-side to avoid roundtrips, can be overridden with optional flag [PR#498](https://github.com/coasys/ad4m/pull/498)
 - Update to Holochain 0.3.2-rc1 [PR#506](https://github.com/coasys/ad4m/pull/506)
 - Make Prolog engine update O(1) in case of only having link additions [PR#510](https://github.com/coasys/ad4m/pull/510)
-- Have Ad4mConnect set `authState` to `authenticated` on successful connection [PR#532](https://github.com/coasys/ad4m/pull/532)
+- Have Ad4mConnect set `authState` to `authenticated` on successful connection [PR#532](https://github.com/coasys/ad4m/pull/532) & [PR#543](https://github.com/coasys/ad4m/pull/543)
 
 ## [0.9.0] - 23/03/2024
 

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -326,7 +326,7 @@ export default class Ad4mConnect {
         },
         connected: () => {
           this.notifyConnectionChange("connected");
-          this.notifyAuthChange("authenticated");
+          this.checkAuth();
         },
         closed: async () => {
           if (!this.requestedRestart) {


### PR DESCRIPTION
Change in https://github.com/coasys/ad4m/pull/532 will make connect behave as if authenticated, when actually we didn't even request a new token yet.

Instead we have to check if we are authenticated, so that authenticated state gets correctly updated if we are (which was the initial bug fixed by the first PR) but also it will stay "unauthenticated" if we yet have to request a token.