### PR TITLE
Notification-request-dialog improvements

### DIFF
--- a/ui/src/components/Notification.tsx
+++ b/ui/src/components/Notification.tsx
@@ -10,8 +10,7 @@ const Notification = ({ notification }: { notification: NotificationType }) => {
   } = useContext(Ad4minContext);
 
   const [requestModalOpened, setRequestModalOpened] = useState(true);
-  const [showTriggerCode, setShowTriggerCode] = useState(false);
-  const [showPerspectives, setShowPerspectives] = useState(false);
+  const [showInfo, setShowInfo] = useState(false);
   const [perspectives, setPerspectives] = useState<PerspectiveProxy[]>([]);
 
   useEffect(() => {
@@ -56,8 +55,6 @@ const Notification = ({ notification }: { notification: NotificationType }) => {
                 <j-text nomargin size="600" color="black" weight="600">
                   App wants to register a Notification trigger
                 </j-text>
-                <br></br>
-                <j-text nomargin>ADAM will create system notifications when trigger condition is met</j-text>
               </j-box>
 
               <j-flex gap="500">
@@ -71,65 +68,34 @@ const Notification = ({ notification }: { notification: NotificationType }) => {
                   </j-text>
                 </div>
               </j-flex>
-              <j-flex gap="200" direction="column">
-                <j-box pb="100" style={{ cursor: 'pointer' }} onClick={() => setShowPerspectives(!showPerspectives)}>
-                  <j-flex a="center" gap="200">
-                    <j-text>
-                      Perspectives
-                    </j-text>
-                    <j-icon name={showPerspectives ? "chevron-down" : "chevron-right"} size="sm" />
-                  </j-flex>
-                  {showPerspectives && (
-                    <j-box pl="400" pt="200">
-                      <ul>
-                        {perspectives?.map((perspective) => (
-                          <li key={perspective.uuid}>
-                            <j-text nomargin size="500">
-                              {perspective.name}
-                            </j-text>
-                          </li>
-                        ))}
-                      </ul>
-                    </j-box>
-                  )}
-                </j-box>
-                <j-box pb="200" style={{ cursor: 'pointer' }} onClick={() => setShowTriggerCode(!showTriggerCode)}>
-                <j-flex a="center" gap="200">
-                  <j-text>
-                    Notification trigger Prolog code
-                  </j-text>
-                  <j-icon name={showTriggerCode ? "chevron-down" : "chevron-right"} size="sm" />
-                </j-flex>
-                {showTriggerCode && (
-                  <j-box pl="400" pt="200">
-                    <j-text>
-                      {notification?.trigger}
-                    </j-text>
-                  </j-box>
-                )}
+
+              <j-box>
+              <br></br>
+              <j-text nomargin>ADAM will monitor trigger condition and issue:</j-text>
+              <ul>
+                <li>Desktop notifications</li>
+                {notification?.webhookUrl && 
+                  <li>
+                    Push notifications
+                    {notification?.webhookUrl.startsWith("http://push-notifications.ad4m.dev") ? (
+                      <p style="height: 60px; color: green; font-size: 14px; margin: 0; ">
+                        Through trusted AD4M Push Notification relay
+                      </p>
+                    ) : (
+                      <>
+                        <p style="height: 50px; color: red; font-size: 14px; margin: 0; ">
+                          Caution: Push notifications will be sent through the following URL:
+                        </p>
+                        <j-box px="200">
+                          <j-text color="blue">{notification?.webhookUrl}</j-text>
+                        </j-box>
+                        <j-text>Only confirm if you trust this app!</j-text>
+                      </>
+                    )
+                    }
+                  </li>}
+              </ul>
               </j-box>
-                {
-                  notification?.webhookUrl && (
-                    <div>
-                      <j-flex>
-                        <j-text>
-                          Webhook URL: {notification?.webhookUrl}
-                        </j-text>
-                      </j-flex>
-                      {notification?.webhookUrl.startsWith("http://push-notifications.ad4m.dev") ? (
-                        <p style="height: 60px; color: green; font-size: 14px; margin: 0; ">
-                          Trusted AD4M Push Notification relay
-                        </p>
-                      ) : (
-                        <p style="height: 60px; color: red; font-size: 14px; margin: 0; ">
-                          Caution: This notification will be sent to the above URL and the data can be leaked outside of the app. Please make sure you trust the app.
-                        </p>
-                      )
-                      }
-                    </div>
-                  )
-                }
-              </j-flex>
 
               <j-flex gap="300">
                 <j-button variant="link" onClick={closeRequestModal}>
@@ -140,6 +106,42 @@ const Notification = ({ notification }: { notification: NotificationType }) => {
                 </j-button>
               </j-flex>            
             </j-flex>
+            <br></br>
+            <j-flex gap="200" direction="column">
+                <j-box pb="100" style={{ cursor: 'pointer' }} onClick={() => setShowInfo(!showInfo)}>
+                  <j-flex a="center" gap="200">
+                    <j-text>
+                    {showInfo ? "Hide" : "Show"} Notification Details
+                    </j-text>
+                    <j-icon name={showInfo ? "chevron-down" : "chevron-right"} size="sm" />
+                  </j-flex>
+                  {showInfo && (
+                    <>
+                      <j-box pl="400" pt="200">
+                        <j-text>Perspectives / Neighbourhoods:</j-text>
+                        <ul>
+                          {!perspectives?.length && <li>None</li>}
+                          {perspectives?.map((perspective) => (
+                            <li key={perspective.uuid}>
+                              <j-text nomargin size="500">
+                                {perspective.name}
+                              </j-text>
+                            </li>
+                          ))}
+                        </ul>
+                      </j-box>
+                      <j-box pl="400" pt="200">
+                        <j-text>
+                          Notification trigger Prolog code:
+                        </j-text>
+                        <j-text color="black">
+                          {notification?.trigger}
+                        </j-text>
+                      </j-box>
+                    </>
+                  )}
+                </j-box>
+              </j-flex>
           </j-box>
         </j-modal>
       )}

--- a/ui/src/components/Notification.tsx
+++ b/ui/src/components/Notification.tsx
@@ -10,6 +10,8 @@ const Notification = ({ notification }: { notification: NotificationType }) => {
   } = useContext(Ad4minContext);
 
   const [requestModalOpened, setRequestModalOpened] = useState(true);
+  const [showTriggerCode, setShowTriggerCode] = useState(false);
+  const [showPerspectives, setShowPerspectives] = useState(false);
   const [perspectives, setPerspectives] = useState<PerspectiveProxy[]>([]);
 
   useEffect(() => {
@@ -49,11 +51,13 @@ const Notification = ({ notification }: { notification: NotificationType }) => {
           onToggle={(e: any) => setRequestModalOpened(e.target.open)}
         >
           <j-box px="500" py="600">
-            <j-flex gap="200" direction="column">
-              <j-box pb="900">
+            <j-flex direction="column">
+              <j-box pb="400">
                 <j-text nomargin size="600" color="black" weight="600">
-                  Authorize Notification
+                  App wants to register a Notification trigger
                 </j-text>
+                <br></br>
+                <j-text nomargin>ADAM will create system notifications when trigger condition is met</j-text>
               </j-box>
 
               <j-flex gap="500">
@@ -68,27 +72,42 @@ const Notification = ({ notification }: { notification: NotificationType }) => {
                 </div>
               </j-flex>
               <j-flex gap="200" direction="column">
-                <div>
-                  <j-text nomargin size="500">
-                    Perspectives:
-                  </j-text>
-                  <ul>
-                    {perspectives?.map((perspective) => (
-                      <li key={perspective.uuid}>
-                        <j-text nomargin size="500">
-                          {perspective.name}
-                        </j-text>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-                <div>
-                  <j-flex>
+                <j-box pb="100" style={{ cursor: 'pointer' }} onClick={() => setShowPerspectives(!showPerspectives)}>
+                  <j-flex a="center" gap="200">
                     <j-text>
-                      Notification Trigger: {notification?.trigger}
+                      Perspectives
                     </j-text>
+                    <j-icon name={showPerspectives ? "chevron-down" : "chevron-right"} size="sm" />
                   </j-flex>
-                </div>
+                  {showPerspectives && (
+                    <j-box pl="400" pt="200">
+                      <ul>
+                        {perspectives?.map((perspective) => (
+                          <li key={perspective.uuid}>
+                            <j-text nomargin size="500">
+                              {perspective.name}
+                            </j-text>
+                          </li>
+                        ))}
+                      </ul>
+                    </j-box>
+                  )}
+                </j-box>
+                <j-box pb="200" style={{ cursor: 'pointer' }} onClick={() => setShowTriggerCode(!showTriggerCode)}>
+                <j-flex a="center" gap="200">
+                  <j-text>
+                    Notification trigger Prolog code
+                  </j-text>
+                  <j-icon name={showTriggerCode ? "chevron-down" : "chevron-right"} size="sm" />
+                </j-flex>
+                {showTriggerCode && (
+                  <j-box pl="400" pt="200">
+                    <j-text>
+                      {notification?.trigger}
+                    </j-text>
+                  </j-box>
+                )}
+              </j-box>
                 {
                   notification?.webhookUrl && (
                     <div>
@@ -97,12 +116,16 @@ const Notification = ({ notification }: { notification: NotificationType }) => {
                           Webhook URL: {notification?.webhookUrl}
                         </j-text>
                       </j-flex>
-                      <j-text color="danger" variant="caption">
-
-                      </j-text>
-                      <p style="height: 60px; color: red; font-size: 14px; margin: 0; ">
-                        Caution: This notification will be sent to the above URL and the data can be leaked outside of the app. Please make sure you trust the app.
-                      </p>
+                      {notification?.webhookUrl.startsWith("http://push-notifications.ad4m.dev") ? (
+                        <p style="height: 60px; color: green; font-size: 14px; margin: 0; ">
+                          Trusted AD4M Push Notification relay
+                        </p>
+                      ) : (
+                        <p style="height: 60px; color: red; font-size: 14px; margin: 0; ">
+                          Caution: This notification will be sent to the above URL and the data can be leaked outside of the app. Please make sure you trust the app.
+                        </p>
+                      )
+                      }
                     </div>
                   )
                 }
@@ -115,7 +138,7 @@ const Notification = ({ notification }: { notification: NotificationType }) => {
                 <j-button variant="primary" onClick={permitNotification}>
                   Confirm
                 </j-button>
-              </j-flex>
+              </j-flex>            
             </j-flex>
           </j-box>
         </j-modal>


### PR DESCRIPTION
Showing the notification trigger prolog code and a red warning if a webhook is set (which is always the case for Flux now, to enable the push notifications for the mobile app) looked very broken. This hides the code behind a "Show details" button, and summarises if we have only desktop or also push notifications and shows a green text if the webhook URL is our notification relay.