### PR TITLE
Detect and rerun failed commits in p-diff-sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ test-runner/.ad4m-test
 temp
 
 !removePnpm.js
+
+.aider*

--- a/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/lib.rs
+++ b/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/lib.rs
@@ -74,7 +74,7 @@ pub fn pull(args: PullArguments) -> ExternResult<PullResult> {
     debug!("pull");
     let pull_result = link_adapter::pull::pull::<retriever::HolochainRetreiver>(true, args.hash, args.is_scribe)
         .map_err(|error| utils::err(&format!("{}", error)));
-    debug!("pull_result: {:?}", pull_result);
+    //debug!("pull_result: {:?}", pull_result);
     pull_result
 }
 

--- a/bootstrap-languages/p-diff-sync/linksAdapter.ts
+++ b/bootstrap-languages/p-diff-sync/linksAdapter.ts
@@ -203,13 +203,30 @@ export class LinkAdapter implements LinkSyncAdapter {
         additions: diff.additions.map((diff) => prepareLinkExpression(diff)),
         removals: diff.removals.map((diff) => prepareLinkExpression(diff))
       }
-      let res = await this.hcDna.call(DNA_NICK, ZOME_NAME, "commit", prep_diff);
-      if (res && Buffer.isBuffer(res)) {
-        this.myCurrentRevision = res;
+
+      let attempts = 0;
+      const maxAttempts = 5;
+      let lastError;
+
+      while (attempts < maxAttempts) {
+        try {
+          let res = await this.hcDna.call(DNA_NICK, ZOME_NAME, "commit", prep_diff);
+          if (res && Buffer.isBuffer(res)) {
+            this.myCurrentRevision = res;
+          }
+          return res as string;
+        } catch (e) {
+          lastError = e;
+          attempts++;
+          if (attempts < maxAttempts) {
+            console.warn(`PerspectiveDiffSync.commit(); attempt ${attempts} failed, retrying...`, e);
+            // Wait a small amount before retrying
+            await new Promise(resolve => setTimeout(resolve, 100 * attempts));
+          }
+        }
       }
-      return res as string;
-    } catch (e) {
-      console.error("PerspectiveDiffSync.commit(); got error", e);
+      
+      console.error(`PerspectiveDiffSync.commit(); failed after ${maxAttempts} attempts`, lastError);
     } finally {
       release();
     }

--- a/bootstrap-languages/p-diff-sync/linksAdapter.ts
+++ b/bootstrap-languages/p-diff-sync/linksAdapter.ts
@@ -211,8 +211,14 @@ export class LinkAdapter implements LinkSyncAdapter {
       while (attempts < maxAttempts) {
         try {
           let res = await this.hcDna.call(DNA_NICK, ZOME_NAME, "commit", prep_diff);
-          if (!res || !Buffer.isBuffer(res) || res.length === 0) {
-            throw new Error("Got no revision from Holochain commit zome function")
+          if(!res){
+            throw new Error("Got undefined from Holochain commit zome function")
+          }          
+          if (!(Buffer.isBuffer(res) || res instanceof Uint8Array)) {
+            throw new Error("Did not get a buffer from Holochain commit zome function")
+          }
+          if (!(res.length || res.byteLength)) {
+            throw new Error("Got an empty buffer from Holochain commit zome function")
           }
           this.myCurrentRevision = res;
           //@ts-ignore

--- a/bootstrap-languages/p-diff-sync/linksAdapter.ts
+++ b/bootstrap-languages/p-diff-sync/linksAdapter.ts
@@ -211,10 +211,12 @@ export class LinkAdapter implements LinkSyncAdapter {
       while (attempts < maxAttempts) {
         try {
           let res = await this.hcDna.call(DNA_NICK, ZOME_NAME, "commit", prep_diff);
-          if (res && Buffer.isBuffer(res)) {
-            this.myCurrentRevision = res;
+          if (!res || !Buffer.isBuffer(res) || res.length === 0) {
+            throw new Error("Got no revision from Holochain commit zome function")
           }
-          return res as string;
+          this.myCurrentRevision = res;
+          //@ts-ignore
+          return res
         } catch (e) {
           lastError = e;
           attempts++;

--- a/cli/mainnet_seed.json
+++ b/cli/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdZHkASjEnxtos29LURJ3voiXDwGUKhArFN9W1b2E4BhJ1"
+    "QmzSYwdmXHS2auGygpkTrbZT5jpgmuyEQR1xcJWjm942TUQSYjd"
   ],
   "directMessageLanguage": "QmzSYwdmrcq32PAsQFD95D6oTGUK7odPDCmXvoYgDcV6SPRcA3u",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/cli/mainnet_seed.json
+++ b/cli/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdqSdRU7fjjbNqJrYbbAWx6DUuxtgbQTynXp1zihKMM8N5"
+    "QmzSYwdZHkASjEnxtos29LURJ3voiXDwGUKhArFN9W1b2E4BhJ1"
   ],
   "directMessageLanguage": "QmzSYwdmrcq32PAsQFD95D6oTGUK7odPDCmXvoYgDcV6SPRcA3u",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/cli/mainnet_seed.json
+++ b/cli/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdmF6e4KsTZ7nsjaZxXt4P3Lnt8YypXzxhRt4wrU3Gz3iz"
+    "QmzSYwdqSdRU7fjjbNqJrYbbAWx6DUuxtgbQTynXp1zihKMM8N5"
   ],
   "directMessageLanguage": "QmzSYwdmrcq32PAsQFD95D6oTGUK7odPDCmXvoYgDcV6SPRcA3u",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/cli/mainnet_seed.json
+++ b/cli/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdkkdidEMcrUrYtJpKHi9kXGNBDLpG9R8zESvz8fYaMD1G"
+    "QmzSYwdmF6e4KsTZ7nsjaZxXt4P3Lnt8YypXzxhRt4wrU3Gz3iz"
   ],
   "directMessageLanguage": "QmzSYwdmrcq32PAsQFD95D6oTGUK7odPDCmXvoYgDcV6SPRcA3u",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/cli/src/perspectives.rs
+++ b/cli/src/perspectives.rs
@@ -166,8 +166,8 @@ pub async fn run(ad4m_client: Ad4mClient, command: Option<PerspectiveFunctions>)
                 .perspectives
                 .query_links(
                     args.id,
-                    args.source,
-                    args.target,
+                    args.source.filter(|s| s != "_"),
+                    args.target.filter(|s| s != "_"),
                     args.predicate,
                     from_date,
                     until_date,

--- a/rust-executor/src/mainnet_seed.json
+++ b/rust-executor/src/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdZHkASjEnxtos29LURJ3voiXDwGUKhArFN9W1b2E4BhJ1"
+    "QmzSYwdmXHS2auGygpkTrbZT5jpgmuyEQR1xcJWjm942TUQSYjd"
   ],
   "directMessageLanguage": "QmzSYwdmrcq32PAsQFD95D6oTGUK7odPDCmXvoYgDcV6SPRcA3u",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/rust-executor/src/mainnet_seed.json
+++ b/rust-executor/src/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdqSdRU7fjjbNqJrYbbAWx6DUuxtgbQTynXp1zihKMM8N5"
+    "QmzSYwdZHkASjEnxtos29LURJ3voiXDwGUKhArFN9W1b2E4BhJ1"
   ],
   "directMessageLanguage": "QmzSYwdmrcq32PAsQFD95D6oTGUK7odPDCmXvoYgDcV6SPRcA3u",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/rust-executor/src/mainnet_seed.json
+++ b/rust-executor/src/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdmF6e4KsTZ7nsjaZxXt4P3Lnt8YypXzxhRt4wrU3Gz3iz"
+    "QmzSYwdqSdRU7fjjbNqJrYbbAWx6DUuxtgbQTynXp1zihKMM8N5"
   ],
   "directMessageLanguage": "QmzSYwdmrcq32PAsQFD95D6oTGUK7odPDCmXvoYgDcV6SPRcA3u",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/rust-executor/src/mainnet_seed.json
+++ b/rust-executor/src/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdkkdidEMcrUrYtJpKHi9kXGNBDLpG9R8zESvz8fYaMD1G"
+    "QmzSYwdmF6e4KsTZ7nsjaZxXt4P3Lnt8YypXzxhRt4wrU3Gz3iz"
   ],
   "directMessageLanguage": "QmzSYwdmrcq32PAsQFD95D6oTGUK7odPDCmXvoYgDcV6SPRcA3u",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -326,12 +326,11 @@ impl PerspectiveInstance {
         let mut count = MAX_PENDING_DIFFS_COUNT;
         let pending_diffs;
         let pending_ids;
-        
+
         // Keep reducing count until serialized size is under 3MB
         loop {
-            let (diffs, ids) = Ad4mDb::with_global_instance(|db| {
-                db.get_pending_diffs(&uuid, Some(count))
-            })?;
+            let (diffs, ids) =
+                Ad4mDb::with_global_instance(|db| db.get_pending_diffs(&uuid, Some(count)))?;
 
             // Check serialized size
             let serialized = serde_json::to_vec(&diffs)?;
@@ -340,7 +339,7 @@ impl PerspectiveInstance {
                 pending_ids = ids;
                 break;
             }
-            
+
             count = count / 2;
         }
 
@@ -518,7 +517,7 @@ impl PerspectiveInstance {
                     false
                 } else {
                     log::info!("Committed to revision: {}", rev);
-                    true    
+                    true
                 }
             }
             Ok(None) => {

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -513,8 +513,13 @@ impl PerspectiveInstance {
 
         let ok = match commit_result {
             Ok(Some(rev)) => {
-                log::info!("Committed to revision: {}", rev);
-                true
+                if rev.trim().len() == 0 {
+                    log::warn!("Committed but got no revision from LinkLanguage!\nStoring in pending diffs for later");
+                    false
+                } else {
+                    log::info!("Committed to revision: {}", rev);
+                    true    
+                }
             }
             Ok(None) => {
                 log::warn!("Committed but got no revision from LinkLanguage!\nStoring in pending diffs for later");

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -489,7 +489,7 @@ impl PerspectiveInstance {
                 }
             } else {
                 Err(anyhow!("LinkLanguage not available"))
-            }
+            };
         //} else {
         //    Err(anyhow!("Other pending diffs already in queue"))
         //};

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -464,11 +464,11 @@ impl PerspectiveInstance {
         }
 
         // Seeing if we already have pending diffs, to not overtake older commits but instead add this one to the queue
-        let (_, pending_ids) =
-            Ad4mDb::with_global_instance(|db| db.get_pending_diffs(&handle.uuid, Some(1)))
-                .unwrap_or((PerspectiveDiff::empty(), Vec::new()));
+        //let (_, pending_ids) =
+        //    Ad4mDb::with_global_instance(|db| db.get_pending_diffs(&handle.uuid, Some(1)))
+        //        .unwrap_or((PerspectiveDiff::empty(), Vec::new()));
 
-        let commit_result = if pending_ids.is_empty() {
+        //let commit_result = if pending_ids.is_empty() {
             // No pending diffs, let's try
             if let Some(link_language) = self.link_language.lock().await.as_mut() {
                 // Got lock on Link Language, no other commit running
@@ -476,23 +476,23 @@ impl PerspectiveInstance {
                     // Revision set, we are synced
                     // we are in a healthy Neighbourhood state and should be able to commit
                     // but let's make sure we're not DoS'ing the link language in bursts
-                    let mut immediate_commits_remaining =
-                        self.immediate_commits_remaining.lock().await;
-                    if *immediate_commits_remaining > 0 {
-                        *immediate_commits_remaining -= 1;
+                    //let mut immediate_commits_remaining =
+                    //    self.immediate_commits_remaining.lock().await;
+                    //if *immediate_commits_remaining > 0 {
+                    //    *immediate_commits_remaining -= 1;
                         link_language.commit(diff.clone()).await
-                    } else {
-                        Err(anyhow!("Debouncing commit burst"))
-                    }
+                    //} else {
+                    //    Err(anyhow!("Debouncing commit burst"))
+                    //}
                 } else {
                     Err(anyhow!("Link Language not synced"))
                 }
             } else {
                 Err(anyhow!("LinkLanguage not available"))
             }
-        } else {
-            Err(anyhow!("Other pending diffs already in queue"))
-        };
+        //} else {
+        //    Err(anyhow!("Other pending diffs already in queue"))
+        //};
 
         match commit_result {
             Ok(Some(rev)) => log::info!("Committed to revision: {}", rev),

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -470,7 +470,7 @@ impl PerspectiveInstance {
 
         //let commit_result = if pending_ids.is_empty() {
             // No pending diffs, let's try
-            if let Some(link_language) = self.link_language.lock().await.as_mut() {
+            let commit_result = if let Some(link_language) = self.link_language.lock().await.as_mut() {
                 // Got lock on Link Language, no other commit running
                 if link_language.current_revision().await?.is_some() {
                     // Revision set, we are synced


### PR DESCRIPTION
 - [x] Detect and handle source chain changes during commit in p-diff-sync
 - [x] Quick retry loop inside p-diff-sync for failed commits
 - [x] Use pending diffs in ADAM for link language commits that don't return a new revision
 - [x] Add wildcard to `ad4m perspectives query-links` command

This fixes missing links, i.e. perspective changes that exist in the author's perspective but never got shared with the neighbourhood - which happened sporadically.

In p-diff-sync, commits would sometimes fail (especially with high loads, i.e. many link changes locally + changes coming in from peers) when the source chain got changed in-between the commit call. This wasn't handled correctly and so the commit was never retried and links got missing.

These changes add a loop inside p-diff sync to retry quickly if a commit fails, and also handle the case in ADAM of link languages not returning a new revision by storing the failed PerspectiveDiff in the pending diffs to retry later.

This also adds wildcards (underscore: "_") to the ad4m cli command `query-links` which was needed to debug this. For instance:
```
ad4m perspectives query-links <ID> _ _ flux://body
```
would print all links with predicate `flux://body` and any source or target.