### PR TITLE
New useSubjects hook filter to reduce unnecissary re-renders

### DIFF
--- a/ad4m-hooks/react/package.json
+++ b/ad4m-hooks/react/package.json
@@ -15,8 +15,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@coasys/ad4m": "0.10",
-    "@coasys/ad4m-connect": "0.10",
+    "@coasys/ad4m": "*",
+    "@coasys/ad4m-connect": "*",
     "@coasys/hooks-helpers": "*",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19"

--- a/ad4m-hooks/react/package.json
+++ b/ad4m-hooks/react/package.json
@@ -15,8 +15,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@coasys/ad4m": "*",
-    "@coasys/ad4m-connect": "*",
+    "@coasys/ad4m": "0.10.0-rc13",
+    "@coasys/ad4m-connect": "0.10.0-rc13",
     "@coasys/hooks-helpers": "*",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19"

--- a/ad4m-hooks/react/package.json
+++ b/ad4m-hooks/react/package.json
@@ -15,8 +15,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@coasys/ad4m": "0.10.0-rc13",
-    "@coasys/ad4m-connect": "0.10.0-rc13",
+    "@coasys/ad4m": "0.10",
+    "@coasys/ad4m-connect": "0.10",
     "@coasys/hooks-helpers": "*",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19"

--- a/ad4m-hooks/react/src/useSubjects.tsx
+++ b/ad4m-hooks/react/src/useSubjects.tsx
@@ -93,16 +93,17 @@ export function useSubjects<SubjectClass>(props: Props<SubjectClass>) {
   }
 
   async function linkAdded(link: LinkExpression) {
-    if (timeout.current) clearTimeout(timeout.current);
-    timeout.current = setTimeout(getData, 1000);
-
     const isNewEntry = link.data.source === source;
     const allEntries = (getCache(cacheKey) || []) as SubjectClass[];
     const isUpdated = allEntries?.find((e: any) => e.id === link.data.source);
 
+    // @ts-ignore
+    const propertyValues = Object.values(subject.prototype.__properties);
+    const includedInSubjectClassDefinition = !!propertyValues.find((p: any) => p.through === link.data.predicate);
+
     const id = isNewEntry
       ? link.data.target
-      : isUpdated
+      : isUpdated && includedInSubjectClassDefinition
         ? link.data.source
         : false;
 

--- a/ad4m-hooks/react/src/useSubjects.tsx
+++ b/ad4m-hooks/react/src/useSubjects.tsx
@@ -98,8 +98,8 @@ export function useSubjects<SubjectClass>(props: Props<SubjectClass>) {
     const isUpdated = allEntries?.find((e: any) => e.id === link.data.source);
 
     // @ts-ignore
-    const propertyValues = Object.values(subject.prototype.__properties);
-    const includedInSubjectClassDefinition = !!propertyValues.find((p: any) => p.through === link.data.predicate);
+    const propertyValues = typeof subject === "string" ? false : Object.values(subject.prototype.__properties);
+    const includedInSubjectClassDefinition = !propertyValues || propertyValues.find((p: any) => p.through === link.data.predicate);
 
     const id = isNewEntry
       ? link.data.target

--- a/ad4m-hooks/vue/src/useSubjects.ts
+++ b/ad4m-hooks/vue/src/useSubjects.ts
@@ -67,9 +67,13 @@ export function useSubjects<SubjectClass>({
       const isNewEntry = link.data.source === s;
       const isUpdated = entries.value.find((e) => e.id === link.data.source);
 
+      // @ts-ignore
+      const propertyValues = Object.values(subject.prototype.__properties);
+      const includedInSubjectClassDefinition = !!propertyValues.find((p: any) => p.through === link.data.predicate);
+
       const id = isNewEntry
         ? link.data.target
-        : isUpdated
+        : isUpdated && includedInSubjectClassDefinition
           ? link.data.source
           : false;
 

--- a/ad4m-hooks/vue/src/useSubjects.ts
+++ b/ad4m-hooks/vue/src/useSubjects.ts
@@ -68,8 +68,8 @@ export function useSubjects<SubjectClass>({
       const isUpdated = entries.value.find((e) => e.id === link.data.source);
 
       // @ts-ignore
-      const propertyValues = Object.values(subject.prototype.__properties);
-      const includedInSubjectClassDefinition = !!propertyValues.find((p: any) => p.through === link.data.predicate);
+      const propertyValues = typeof subject === "string" ? false : Object.values(subject.prototype.__properties);
+      const includedInSubjectClassDefinition = !propertyValues || propertyValues.find((p: any) => p.through === link.data.predicate);
 
       const id = isNewEntry
         ? link.data.target


### PR DESCRIPTION
New check added to React & Vue useSubjects hooks to ensure that only links included in the subject class definition trigger re-fetching of subject class entries, preventing unnecessary re-renders in components using the hook.

Old getData timeout removed as recent testing has revealed it was not the cause of missing links.