### PR TITLE
Prevent p-diff-sync diff entries from exceeding HC entry size limit of 4MB

### DIFF
--- a/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/lib.rs
+++ b/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/lib.rs
@@ -189,5 +189,5 @@ lazy_static! {
     pub static ref ACTIVE_AGENT_DURATION: chrono::Duration = chrono::Duration::seconds(3600);
     pub static ref ENABLE_SIGNALS: bool = true;
     pub static ref SNAPSHOT_INTERVAL: usize = 100;
-    pub static ref CHUNK_SIZE: u16 = 10000;
+    pub static ref CHUNK_SIZE: u16 = 1000;
 }

--- a/cli/mainnet_seed.json
+++ b/cli/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdmXHS2auGygpkTrbZT5jpgmuyEQR1xcJWjm942TUQSYjd"
+    "QmzSYwdZYYgYGWSiRZqMGs5YrJu8gQzCQCxJFkK9Ar28vaki9UN"
   ],
   "directMessageLanguage": "QmzSYwdmrcq32PAsQFD95D6oTGUK7odPDCmXvoYgDcV6SPRcA3u",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -1033,6 +1033,22 @@ impl Ad4mDb {
         ))
     }
 
+    pub fn get_pending_diffs_by_size(&self, perspective_uuid: &str, max_bytes: usize, initial_count: Option<usize>) -> Ad4mDbResult<(PerspectiveDiff, Vec<u64>)> {
+        let mut count = initial_count.unwrap_or(100); // Start with provided count or default to 100
+        loop {
+            let (diffs, ids) = self.get_pending_diffs(perspective_uuid, Some(count))?;
+            
+            // Check serialized size
+            let serialized = serde_json::to_string(&diffs)?;
+            if serialized.len() <= max_bytes || count == 1 {
+                return Ok((diffs, ids));
+            }
+            
+            // Reduce count and try again
+            count = count / 2;
+        }
+    }
+
     pub fn clear_pending_diffs(&self, perspective_uuid: &str, ids: Vec<u64>) -> Ad4mDbResult<()> {
         let id_list = ids
             .iter()
@@ -1936,5 +1952,56 @@ mod tests {
         // Clean up
         db.remove_model(&model.name).unwrap();
         db.remove_model(&model2.name).unwrap();
+    }
+
+    #[test]
+    fn can_get_pending_diffs_by_size() {
+        let db = Ad4mDb::new(":memory:").unwrap();
+        let p_uuid = Uuid::new_v4().to_string();
+
+        // Create 10 diffs with large content
+        for _ in 0..10 {
+            let diff = PerspectiveDiff {
+                additions: vec![
+                    construct_dummy_link_expression(LinkStatus::Shared),
+                    construct_dummy_link_expression(LinkStatus::Shared),
+                    construct_dummy_link_expression(LinkStatus::Shared),
+                    construct_dummy_link_expression(LinkStatus::Shared),
+                    construct_dummy_link_expression(LinkStatus::Shared),
+                ],
+                removals: vec![
+                    construct_dummy_link_expression(LinkStatus::Shared),
+                    construct_dummy_link_expression(LinkStatus::Shared),
+                    construct_dummy_link_expression(LinkStatus::Shared),
+                    construct_dummy_link_expression(LinkStatus::Shared),
+                    construct_dummy_link_expression(LinkStatus::Shared),
+                ],
+            };
+            db.add_pending_diff(&p_uuid, &diff).unwrap();
+        }
+
+        // Get all diffs first to calculate total size
+        let (all_diffs, all_ids) = db.get_pending_diffs(&p_uuid, None).unwrap();
+        assert_eq!(all_ids.len(), 10);
+        
+        let total_serialized = serde_json::to_string(&all_diffs).unwrap();
+        let total_size = total_serialized.len();
+        
+        // Use half of total size as limit - should get roughly half the diffs
+        let half_size = total_size / 2;
+        let (half_diffs, half_ids) = db.get_pending_diffs_by_size(&p_uuid, half_size, Some(10)).unwrap();
+        
+        // Verify we got fewer diffs than total
+        assert!(half_ids.len() < all_ids.len());
+        
+        // Verify the serialized size is under our limit
+        let half_serialized = serde_json::to_string(&half_diffs).unwrap();
+        assert!(half_serialized.len() <= half_size || half_ids.len() == 1);
+
+        // Test with size bigger than total - should get all diffs
+        let (full_diffs, full_ids) = db.get_pending_diffs_by_size(&p_uuid, total_size * 2, Some(10)).unwrap();
+        assert_eq!(full_ids.len(), 10);
+        assert_eq!(full_diffs.additions.len(), 50); // 10 diffs * 5 additions
+        assert_eq!(full_diffs.removals.len(), 50); // 10 diffs * 5 removals
     }
 }

--- a/rust-executor/src/mainnet_seed.json
+++ b/rust-executor/src/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdmXHS2auGygpkTrbZT5jpgmuyEQR1xcJWjm942TUQSYjd"
+    "QmzSYwdZYYgYGWSiRZqMGs5YrJu8gQzCQCxJFkK9Ar28vaki9UN"
   ],
   "directMessageLanguage": "QmzSYwdmrcq32PAsQFD95D6oTGUK7odPDCmXvoYgDcV6SPRcA3u",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -34,8 +34,9 @@ use tokio::sync::{Mutex, RwLock};
 use tokio::time::sleep;
 use tokio::{join, time};
 
-static MAX_COMMIT_BYTES: usize = 3_000_000;
+static MAX_COMMIT_BYTES: usize = 3_000_000; //3MiB
 static MAX_PENDING_DIFFS_COUNT: usize = 150;
+static MAX_PENDING_SECONDS: u64 = 3;
 static IMMEDIATE_COMMITS_COUNT: usize = 20;
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -286,8 +287,8 @@ impl PerspectiveInstance {
                 }
 
                 // Commit if either:
-                // 1. It's been 10s since first diff in burst (don't collect longer than 10s)
-                if last_diff_time.unwrap().elapsed() >= Duration::from_secs(10) {
+                // 1. It's been MAX_PENDING_SECONDS since first diff in burst (don't collect longer than MAX_PENDING_SECONDS)
+                if last_diff_time.unwrap().elapsed() >= Duration::from_secs(MAX_PENDING_SECONDS) {
                     if self.commit_pending_diffs().await.is_ok() {
                         last_diff_time = None;
                         log::info!("Committed diffs after reaching 10s maximum wait time");

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -323,13 +323,9 @@ impl PerspectiveInstance {
 
     async fn commit_pending_diffs(&self) -> Result<(), AnyError> {
         let uuid = self.persisted.lock().await.uuid.clone();
-
-        let mut count = MAX_PENDING_DIFFS_COUNT;
-        let pending_diffs;
-        let pending_ids;
-
+        
         let (pending_diffs, pending_ids) = Ad4mDb::with_global_instance(|db| {
-            db.get_pending_diffs_by_size(&uuid, MAX_COMMIT_BYTES, Some(count))
+            db.get_pending_diffs_by_size(&uuid, MAX_COMMIT_BYTES, Some(MAX_PENDING_DIFFS_COUNT))
         })?;
 
         if !pending_ids.is_empty() {

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -324,7 +324,7 @@ impl PerspectiveInstance {
 
     async fn commit_pending_diffs(&self) -> Result<(), AnyError> {
         let uuid = self.persisted.lock().await.uuid.clone();
-        
+
         let (pending_diffs, pending_ids) = Ad4mDb::with_global_instance(|db| {
             db.get_pending_diffs_by_size(&uuid, MAX_COMMIT_BYTES, Some(MAX_PENDING_DIFFS_COUNT))
         })?;


### PR DESCRIPTION
The main fix here is decreasing the `CHUNK_SIZE` in p-diff-sync. The other changes, which are keeping diffs committed to link languages below 3MB will not affect the size of snapshot entries that p-diff-sync creates for quick syncing of new agents. The old value of 10.000 was a good estimate before introducing embedding vectors in a literal format, i.e. stored in the URL of links. 

Also reduced the max diff pending time from 10s to 3s, in order to keep NH syncing more responsive also in cases of ongoing bursts.