### PR TITLE
Fix race-condition in useSubjects

### DIFF
--- a/ad4m-hooks/helpers/src/cache.ts
+++ b/ad4m-hooks/helpers/src/cache.ts
@@ -41,14 +41,14 @@ export function subscribeToPerspective(
   if (!subscribers.has(addedKey)) {
     console.log("subscribing!");
     perspective.addListener("link-added", (link) => {
-      subscribers.get(addedKey).forEach((cb) => cb(link));
+      subscribers.get(addedKey)!.forEach((cb) => cb(link));
       return null;
     });
   }
 
   if (!subscribers.has(removedKey)) {
     perspective.addListener("link-removed", (link) => {
-      subscribers.get(removedKey).forEach((cb) => cb(link));
+      subscribers.get(removedKey)!.forEach((cb) => cb(link));
       return null;
     });
   }

--- a/ad4m-hooks/helpers/src/factory/SubjectRepository.ts
+++ b/ad4m-hooks/helpers/src/factory/SubjectRepository.ts
@@ -173,6 +173,7 @@ export class SubjectRepository<SubjectClass extends { [x: string]: any }> {
           const mainQuery = `findall([Timestamp, Base], (subject_class("${this.className}", C), instance(C, Base), link("${tempSource}", Predicate, Base, Timestamp, Author)), AllData), sort(AllData, SortedData), reverse(SortedData, ReverseSortedData), paginate(ReverseSortedData, ${query.page}, ${newPageSize}, PageData).`;
           res = await this.perspective.infer(mainQuery);
 
+          //@ts-ignore
           res = res[0].PageData.map((r) => ({
             Base: r[1],
             Timestamp: r[0],
@@ -195,6 +196,7 @@ export class SubjectRepository<SubjectClass extends { [x: string]: any }> {
       res &&
       res.filter(
         (obj, index, self) =>
+          //@ts-ignore
           index === self.findIndex((t) => t.Base === obj.Base)
       );
 
@@ -204,6 +206,7 @@ export class SubjectRepository<SubjectClass extends { [x: string]: any }> {
       results.map(async (result) => {
         let subject = new Subject(
           this.perspective!,
+          //@ts-ignore
           result.Base,
           this.className
         );

--- a/ad4m-hooks/react/src/useSubjects.tsx
+++ b/ad4m-hooks/react/src/useSubjects.tsx
@@ -114,7 +114,11 @@ export function useSubjects<SubjectClass>(props: Props<SubjectClass>) {
       );
 
       if (isInstance) {
-        fetchEntry(id);
+        // debounced getData
+        if (timeout.current) clearTimeout(timeout.current);
+        timeout.current = setTimeout(() => {
+          getData();
+        }, 100);
       }
     }
 

--- a/ad4m-hooks/react/src/useSubjects.tsx
+++ b/ad4m-hooks/react/src/useSubjects.tsx
@@ -71,6 +71,13 @@ export function useSubjects<SubjectClass>(props: Props<SubjectClass>) {
     }
   }, [cacheKey, query?.page, query?.infinite, query?.size]);
 
+  function debouncedGetData() {
+    if (timeout.current) clearTimeout(timeout.current);
+    timeout.current = setTimeout(() => {
+      getData();
+    }, 100);
+  }
+
   // Trigger initial fetch
   useEffect(getData, [cacheKey, query?.page, query?.infinite, query?.size]);
 
@@ -114,11 +121,7 @@ export function useSubjects<SubjectClass>(props: Props<SubjectClass>) {
       );
 
       if (isInstance) {
-        // debounced getData
-        if (timeout.current) clearTimeout(timeout.current);
-        timeout.current = setTimeout(() => {
-          getData();
-        }, 100);
+        debouncedGetData()
       }
     }
 
@@ -135,7 +138,7 @@ export function useSubjects<SubjectClass>(props: Props<SubjectClass>) {
     );
 
     if (removedAssociation) {
-      getData();
+      debouncedGetData()
     }
 
     // Remove entries if they are removed from source


### PR DESCRIPTION
Instead of calling `fetchEntry()` immediately when linkChangs indicate a relevant change, which will result in potentially several fetchEntry calls running simultaneously, but ultimately haven all of them set the entries array, we might end up with old state.

It seems much more resilient to always fetch all the data (`getData`) when there are relevant linke changes, but in order to avoid many fetches, we do this after all the checks (like `fetchEntry`) and we debounce it with a timeout. 