### PR TITLE
Agent list handling imrovements and other cleanup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 - Fix for missing links: race-condition fixed in useSubjects [PR#540](https://github.com/coasys/ad4m/pull/540) and [PR#554](https://github.com/coasys/ad4m/pull/554)
 - Fix for missing links: detect and rerun failed commits in p-diff-sync [PR#551](https://github.com/coasys/ad4m/pull/551)
 - Fix for syncing broken after some time: Prevent p-diff-sync diff entries from exceeding HC entry size limit of 4MB (which would happen at some point through snapshot creation) [PR#553](https://github.com/coasys/ad4m/pull/553)
+- Fix for crash when removing .ad4m directory after using multiple agent feature [PR#556](https://github.com/coasys/ad4m/pull/556)
 
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20873,8 +20873,3 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
-
-[[patch.unused]]
-name = "notify-rust"
-version = "4.6.0"
-source = "git+https://github.com/coasys/notify-rust.git#b08ab0233810d365d1e914998ff81002090753a6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,3 @@ members = [
     "rust-executor",
     "ui/src-tauri"
 ]
-
-
-[patch.crates-io]
-notify-rust = { version = "4.6.0", git = "https://github.com/coasys/notify-rust.git" }

--- a/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/link_adapter/pull.rs
+++ b/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/link_adapter/pull.rs
@@ -98,6 +98,7 @@ pub fn pull<Retriever: PerspectiveDiffRetreiver>(
     // First check if we are actually ahead of them -> we don't have to do anything
     // they will have to merge with / or fast-forward to our current
     if workspace.all_ancestors(&current.hash)?.contains(&theirs) {
+        debug!("===PerspectiveDiffSync.pull(): We are ahead of them. They will have to pull/fast-forward. Exiting without change...");
         return Ok(PullResult {
             diff: PerspectiveDiff::default(),
             current_revision: Some(current.hash),

--- a/cli/mainnet_seed.json
+++ b/cli/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdZYYgYGWSiRZqMGs5YrJu8gQzCQCxJFkK9Ar28vaki9UN"
+    "QmzSYwdbWZ8Y7w8ZtAb47xN8AEaTUveoUnxgnT6pxvrWdtBDMVy"
   ],
   "directMessageLanguage": "QmzSYwdmrcq32PAsQFD95D6oTGUK7odPDCmXvoYgDcV6SPRcA3u",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/rust-executor/src/mainnet_seed.json
+++ b/rust-executor/src/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdZYYgYGWSiRZqMGs5YrJu8gQzCQCxJFkK9Ar28vaki9UN"
+    "QmzSYwdbWZ8Y7w8ZtAb47xN8AEaTUveoUnxgnT6pxvrWdtBDMVy"
   ],
   "directMessageLanguage": "QmzSYwdmrcq32PAsQFD95D6oTGUK7odPDCmXvoYgDcV6SPRcA3u",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/ui/src-tauri/src/app_state.rs
+++ b/ui/src-tauri/src/app_state.rs
@@ -1,6 +1,6 @@
 use dirs::home_dir;
 use serde::{Deserialize, Serialize};
-use std::fs::{File, OpenOptions, create_dir_all};
+use std::fs::{create_dir_all, File, OpenOptions};
 use std::io::prelude::*;
 use std::path::PathBuf;
 
@@ -20,13 +20,9 @@ pub struct LauncherState {
 }
 
 fn file_path() -> PathBuf {
-    let path = home_dir()
-        .expect("Could not get home dir")
-        .join(".ad4m");
-    
+    let path = home_dir().expect("Could not get home dir").join(".ad4m");
     // Create directories if they don't exist
     create_dir_all(&path).expect("Failed to create directory");
-    
     path.join(FILE_NAME)
 }
 

--- a/ui/src-tauri/src/app_state.rs
+++ b/ui/src-tauri/src/app_state.rs
@@ -5,7 +5,7 @@ use std::io::prelude::*;
 use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct AgentList {
+pub struct AgentConfigDir {
     pub name: String,
     pub path: PathBuf,
     pub bootstrap: Option<PathBuf>,
@@ -13,8 +13,8 @@ pub struct AgentList {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct LauncherState {
-    pub agent_list: Vec<AgentList>,
-    pub selected_agent: Option<AgentList>,
+    pub agent_list: Vec<AgentConfigDir>,
+    pub selected_agent: Option<AgentConfigDir>,
 }
 
 impl LauncherState {
@@ -44,7 +44,7 @@ impl LauncherState {
         let state = match serde_json::from_str(&data) {
             Ok(state) => state,
             Err(_) => {
-                let agent = AgentList {
+                let agent = AgentConfigDir {
                     name: "Main Net".to_string(),
                     path: home_dir().expect("Could not get home dir").join(".ad4m"),
                     bootstrap: None,
@@ -60,13 +60,13 @@ impl LauncherState {
         Ok(state)
     }
 
-    pub fn add_agent(&mut self, agent: AgentList) {
+    pub fn add_agent(&mut self, agent: AgentConfigDir) {
         if !self.is_agent_taken(&agent.name, &agent.path) {
             self.agent_list.push(agent);
         }
     }
 
-    pub fn remove_agent(&mut self, agent: AgentList) {
+    pub fn remove_agent(&mut self, agent: AgentConfigDir) {
         self.agent_list
             .retain(|a| a.name != agent.name && a.path != agent.path);
     }

--- a/ui/src-tauri/src/commands/app.rs
+++ b/ui/src-tauri/src/commands/app.rs
@@ -1,5 +1,5 @@
 extern crate remove_dir_all;
-use crate::app_state::{AgentList, LauncherState};
+use crate::app_state::{AgentConfigDir, LauncherState};
 use crate::util::create_tray_message_windows;
 use crate::{config::data_path, get_main_window};
 
@@ -49,7 +49,7 @@ pub fn open_tray(app_handle: tauri::AppHandle) {
 }
 
 #[tauri::command]
-pub fn add_app_agent_state(agent: AgentList) {
+pub fn add_app_agent_state(agent: AgentConfigDir) {
     let mut state = LauncherState::load().unwrap();
 
     let mut new_agent = agent.clone();
@@ -62,7 +62,7 @@ pub fn add_app_agent_state(agent: AgentList) {
 }
 
 #[tauri::command]
-pub fn remove_app_agent_state(agent: AgentList) {
+pub fn remove_app_agent_state(agent: AgentConfigDir) {
     let mut state = LauncherState::load().unwrap();
 
     state.remove_agent(agent.clone());
@@ -71,7 +71,7 @@ pub fn remove_app_agent_state(agent: AgentList) {
 }
 
 #[tauri::command]
-pub fn set_selected_agent(agent: AgentList) {
+pub fn set_selected_agent(agent: AgentConfigDir) {
     let mut state = LauncherState::load().unwrap();
 
     state.selected_agent = Some(agent);


### PR DESCRIPTION
- Moves ~/ad4m-state.json to ~/.ad4m/launcher-state.json and fixes problem that we run into when using multiple agent feature and then manually deleting .ad4m directory
- debug output in p-diff-sync added
- unused notify-rust patch removed