### PR TITLE
SubjectEntity improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,7 +41,9 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 - Full CRUD systems for choosing AI models, remote models through API calls and UI in ADAM Launcher for setup and managing of models [PR#504](https://github.com/coasys/ad4m/pull/504)
 - Add remote AI API model picking, to enable Ollama use-case [PR#547](https://github.com/coasys/ad4m/pull/547)
 - ad4m CLI: wildcards (underscore: "_") in query-links command [PR#551](https://github.com/coasys/ad4m/pull/551)
-
+- Add `author` and `timestamp` to SubjectEntity objects [PR#557](https://github.com/coasys/ad4m/pull/557)
+- Make `SubjectEntity.#perspective` protected to enable subclasses to implement complex fields and methods [PR#557](https://github.com/coasys/ad4m/pull/557)
+- 
 ### Changed
 - Partially migrated the Runtime service to Rust. (DM language installation for agents is pending.) [PR#466](https://github.com/coasys/ad4m/pull/466)
 - Improved performance of SDNA / SubjectClass functions by moving code from client into executor and saving a lot of client <-> executor roundtrips [PR#480](https://github.com/coasys/ad4m/pull/480)

--- a/core/src/subject/SubjectEntity.ts
+++ b/core/src/subject/SubjectEntity.ts
@@ -41,6 +41,14 @@ export class SubjectEntity {
     return this.#baseExpression
   }
 
+  /**
+   * Protected getter for the perspective.
+   * Allows subclasses to access the perspective while keeping it private from external code.
+   */
+  protected get perspective(): PerspectiveProxy {
+    return this.#perspective;
+  }
+
   private async getData(id?: string) {
     const tempId = id ?? this.#baseExpression;
     let data = await this.#perspective.getSubjectData(this.#subjectClass, tempId)

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -1559,8 +1559,14 @@ impl PerspectiveInstance {
         let first_link = base_links
             .first()
             .ok_or_else(|| anyhow!("No links found for base expression: {}", base_expression))?;
-        object.insert(String::from("author"), first_link.author.clone());
-        object.insert(String::from("timestamp"), first_link.timestamp.clone());
+        object.insert(
+            String::from("author"),
+            format!("\"{}\"", first_link.author.clone()),
+        );
+        object.insert(
+            String::from("timestamp"),
+            format!("\"{}\"", first_link.timestamp.clone()),
+        );
 
         let class_name = self
             .subject_class_option_to_class_name(subject_class)

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -1552,6 +1552,16 @@ impl PerspectiveInstance {
     ) -> Result<String, AnyError> {
         let mut object: HashMap<String, String> = HashMap::new();
 
+        // Get author and timestamp from the first link mentioning base as source
+        let mut base_query = LinkQuery::default();
+        base_query.source = Some(base_expression.clone());
+        let base_links = self.get_links(&base_query).await?;
+        let first_link = base_links
+            .first()
+            .ok_or_else(|| anyhow!("No links found for base expression: {}", base_expression))?;
+        object.insert(String::from("author"), first_link.author.clone());
+        object.insert(String::from("timestamp"), first_link.timestamp.clone());
+
         let class_name = self
             .subject_class_option_to_class_name(subject_class)
             .await?;

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -627,6 +627,23 @@ describe("Prolog + Literals", () => {
                     expect(recipe2.booleanTest).to.equal(false)
                 })
 
+                it("should have author and timestamp properties", async () => {
+                    let root = Literal.from("Author and timestamp test").toUrl()
+                    const recipe = new Recipe(perspective!, root)
+
+                    recipe.name = "recipe://test";
+                    await recipe.save();
+
+                    const recipe2 = new Recipe(perspective!, root);
+                    await recipe2.get();
+
+                    const me = await ad4m!.agent.me();
+                    // @ts-ignore - author and timestamp are added by the system
+                    expect(recipe2.author).to.equal(me!.did)
+                    // @ts-ignore
+                    expect(recipe2.timestamp).to.not.be.undefined;
+                })
+
                 it("update()", async () => {
                     let root = Literal.from("Active record implementation test").toUrl()
                     const recipe = new Recipe(perspective!, root)

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -627,23 +627,6 @@ describe("Prolog + Literals", () => {
                     expect(recipe2.booleanTest).to.equal(false)
                 })
 
-                it("should have author and timestamp properties", async () => {
-                    let root = Literal.from("Author and timestamp test").toUrl()
-                    const recipe = new Recipe(perspective!, root)
-
-                    recipe.name = "recipe://test";
-                    await recipe.save();
-
-                    const recipe2 = new Recipe(perspective!, root);
-                    await recipe2.get();
-
-                    const me = await ad4m!.agent.me();
-                    // @ts-ignore - author and timestamp are added by the system
-                    expect(recipe2.author).to.equal(me!.did)
-                    // @ts-ignore
-                    expect(recipe2.timestamp).to.not.be.undefined;
-                })
-
                 it("update()", async () => {
                     let root = Literal.from("Active record implementation test").toUrl()
                     const recipe = new Recipe(perspective!, root)
@@ -798,6 +781,23 @@ describe("Prolog + Literals", () => {
 
                     expect(recipe2.resolve.length).to.equal(longName.length)
                     expect(recipe2.resolve).to.equal(longName)
+                })
+
+                it("should have author and timestamp properties", async () => {
+                    let root = Literal.from("Author and timestamp test").toUrl()
+                    const recipe = new Recipe(perspective!, root)
+
+                    recipe.name = "recipe://test";
+                    await recipe.save();
+
+                    const recipe2 = new Recipe(perspective!, root);
+                    await recipe2.get();
+
+                    const me = await ad4m!.agent.me();
+                    // @ts-ignore - author and timestamp are added by the system
+                    expect(recipe2.author).to.equal(me!.did)
+                    // @ts-ignore
+                    expect(recipe2.timestamp).to.not.be.undefined;
                 })
             })
         })


### PR DESCRIPTION
- Make private field `#perspective` protected in SubjectEntity class so subclasses can use it to implement complex fields and methods
- Include `author` and `timestamp` in SubjectEntity objects 