### PR TITLE
Fix error after spawning AI task

### DIFF
--- a/rust-executor/src/ai_service/mod.rs
+++ b/rust-executor/src/ai_service/mod.rs
@@ -425,6 +425,7 @@ impl AIService {
                                         spawn_request.task.task_id.clone(),
                                         spawn_request.task,
                                     );
+                                    let _ = spawn_request.result_sender.send(Ok(()));
                                 }
                                 LlmModel::Local(ref mut llama) => {
                                     rt.block_on(publish_model_status(


### PR DESCRIPTION
Not return an `Ok(())` through the channel was preventing multiple tasks from being spawned on launcher startup