### PR TITLE
Add `where` to SubjectEntity's query()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,7 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 - Add `author` and `timestamp` to SubjectEntity objects [PR#557](https://github.com/coasys/ad4m/pull/557)
 - Make `SubjectEntity.#perspective` protected to enable subclasses to implement complex fields and methods [PR#557](https://github.com/coasys/ad4m/pull/557)
 - Add AI client to PerspectiveProxy to enable SubjectEntity sub-classes (subject classes) to use AI processes without having to rely on ad4m-connect or similar to access the AI client. [PR#558](https://github.com/coasys/ad4m/pull/558)
+- SubjectEntity.query() with `where: { propertyName: "value" }` and `where: { condition: 'triple(Base, _, "...")'} [PR#560](https://github.com/coasys/ad4m/pull/560)
 
 ### Changed
 - Partially migrated the Runtime service to Rust. (DM language installation for agents is pending.) [PR#466](https://github.com/coasys/ad4m/pull/466)

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -694,24 +694,43 @@ describe("Prolog + Literals", () => {
 
                 it("query()", async () => {
                     let recipes = await Recipe.query(perspective!, { page: 1, size: 2 });
-
                     expect(recipes.length).to.equal(2)
 
                     recipes = await Recipe.query(perspective!, { page: 2, size: 1 });
-
                     expect(recipes.length).to.equal(1)
+
+                    const testName = "recipe://where_test"
+
+                    recipes = await Recipe.query(perspective!, { where: { name: testName }})
+                    expect(recipes.length).to.equal(0)
+
+                    let root = Literal.from("Where test").toUrl()
+                    const whereTestRecipe = new Recipe(perspective!, root)
+                    whereTestRecipe.name = testName
+                    await whereTestRecipe.save()
+
+                    recipes = await Recipe.query(perspective!, { where: { name: testName }})
+                    expect(recipes.length).to.equal(1)
+
+                    recipes = await Recipe.query(perspective!, { where: { condition: `triple(Base, _, "ad4m://test_self")` }})
+                    expect(recipes.length).to.equal(0)
+
+                    await perspective?.add({source: root, target: "ad4m://test_self"})
+                    recipes = await Recipe.query(perspective!, { where: { condition: `triple(Base, _, "ad4m://test_self")` }})
+                    expect(recipes.length).to.equal(1)
+
                 })
 
                 it("delete()", async () => {
                     const recipe2 = await Recipe.all(perspective!);
 
-                    expect(recipe2.length).to.equal(3)
+                    expect(recipe2.length).to.equal(4)
 
                     await recipe2[0].delete();
 
                     const recipe3 = await Recipe.all(perspective!);
 
-                    expect(recipe3.length).to.equal(2)
+                    expect(recipe3.length).to.equal(3)
                 })
 
                 it("can constrain collection entries through 'where' clause with prolog condition", async () => {


### PR DESCRIPTION
Conditions on SubjectEntity queries:

Constraining properties:
```JS
await Message.query(perspective, {
  where: { author: "..." }
}
```

Custom Prolog conditions:
```JS
await Message.query(perspective, {
  where: { condition: 'triple(Base, _, "my://expression"' }
}
```
