### PR TITLE
Fix link-removal problems with proper implementation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,7 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 - Fix for syncing broken after some time: Prevent p-diff-sync diff entries from exceeding HC entry size limit of 4MB (which would happen at some point through snapshot creation) [PR#553](https://github.com/coasys/ad4m/pull/553)
 - Fix for crash when removing .ad4m directory after using multiple agent feature [PR#556](https://github.com/coasys/ad4m/pull/556)
 - Fix error after spawning AI task [PR#559](https://github.com/coasys/ad4m/pull/559)
+- Fix some problems with perspective.removeLinks() with a proper implementation [PR#563](https://github.com/coasys/ad4m/pull/563)
 
 ### Added
 - Prolog predicates needed in new Flux mention notification trigger:

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -834,12 +834,8 @@ impl Mutation {
             &perspective_update_capability(vec![uuid.clone()]),
         )?;
         let mut perspective = get_perspective_with_uuid_field_error(&uuid)?;
-        let mut removed_links = Vec::new();
-        for link in links.into_iter() {
-            let link = crate::types::LinkExpression::try_from(link)?;
-            removed_links.push(perspective.remove_link(link).await?);
-        }
-
+        let links = links.into_iter().map(|l| LinkExpression::try_from(l)).collect::<Result<Vec<_>, _>>()?;
+        let removed_links = perspective.remove_links(links).await?;
         Ok(removed_links)
     }
 

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -834,7 +834,10 @@ impl Mutation {
             &perspective_update_capability(vec![uuid.clone()]),
         )?;
         let mut perspective = get_perspective_with_uuid_field_error(&uuid)?;
-        let links = links.into_iter().map(|l| LinkExpression::try_from(l)).collect::<Result<Vec<_>, _>>()?;
+        let links = links
+            .into_iter()
+            .map(|l| LinkExpression::try_from(l))
+            .collect::<Result<Vec<_>, _>>()?;
         let removed_links = perspective.remove_links(links).await?;
         Ok(removed_links)
     }

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -846,6 +846,67 @@ impl PerspectiveInstance {
         }
     }
 
+    pub async fn remove_links(
+        &mut self,
+        link_expressions: Vec<LinkExpression>,
+    ) -> Result<Vec<DecoratedLinkExpression>, AnyError> {
+        let handle = self.persisted.lock().await.clone();
+        
+        // Filter to only existing links and collect their statuses
+        let mut existing_links = Vec::new();
+        for link in link_expressions {
+            if let Some((link_from_db, status)) = 
+                Ad4mDb::with_global_instance(|db| db.get_link(&handle.uuid, &link))? {
+                existing_links.push((link_from_db, status));
+            }
+        }
+
+        // Skip if no links found
+        if existing_links.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Split into links and statuses
+        let (links, statuses): (Vec<_>, Vec<_>) = existing_links.into_iter().unzip();
+
+        // Create diff from links that exist
+        let diff = PerspectiveDiff::from_removals(links.clone());
+        
+        // Create decorated versions
+        let decorated_links: Vec<DecoratedLinkExpression> = links
+            .into_iter()
+            .zip(statuses.iter())
+            .map(|(link, status)| DecoratedLinkExpression::from((link, status.clone())))
+            .collect();
+        
+        let decorated_diff = DecoratedPerspectiveDiff::from_removals(decorated_links.clone());
+
+        // Remove from DB
+        for link in diff.removals.iter() {
+            Ad4mDb::with_global_instance(|db| db.remove_link(&handle.uuid, link))?;
+        }
+
+        self.spawn_prolog_facts_update(decorated_diff.clone());
+        self.pubsub_publish_diff(decorated_diff).await;
+
+        // Only commit shared links by filtering decorated_links
+        let shared_links: Vec<LinkExpression> = decorated_links.iter()
+            .filter(|link| link.status == Some(LinkStatus::Shared))
+            .map(|link| link.clone().into())
+            .collect();
+
+        if !shared_links.is_empty() {
+            let shared_diff = PerspectiveDiff {
+                additions: vec![],
+                removals: shared_links,
+            };
+            self.spawn_commit_and_handle_error(&shared_diff);
+        }
+
+        *(self.links_have_changed.lock().await) = true;
+        Ok(decorated_links)
+    }
+    
     async fn get_links_local(
         &self,
         query: &LinkQuery,

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -851,12 +851,13 @@ impl PerspectiveInstance {
         link_expressions: Vec<LinkExpression>,
     ) -> Result<Vec<DecoratedLinkExpression>, AnyError> {
         let handle = self.persisted.lock().await.clone();
-        
+
         // Filter to only existing links and collect their statuses
         let mut existing_links = Vec::new();
         for link in link_expressions {
-            if let Some((link_from_db, status)) = 
-                Ad4mDb::with_global_instance(|db| db.get_link(&handle.uuid, &link))? {
+            if let Some((link_from_db, status)) =
+                Ad4mDb::with_global_instance(|db| db.get_link(&handle.uuid, &link))?
+            {
                 existing_links.push((link_from_db, status));
             }
         }
@@ -871,14 +872,14 @@ impl PerspectiveInstance {
 
         // Create diff from links that exist
         let diff = PerspectiveDiff::from_removals(links.clone());
-        
+
         // Create decorated versions
         let decorated_links: Vec<DecoratedLinkExpression> = links
             .into_iter()
             .zip(statuses.iter())
             .map(|(link, status)| DecoratedLinkExpression::from((link, status.clone())))
             .collect();
-        
+
         let decorated_diff = DecoratedPerspectiveDiff::from_removals(decorated_links.clone());
 
         // Remove from DB
@@ -890,7 +891,8 @@ impl PerspectiveInstance {
         self.pubsub_publish_diff(decorated_diff).await;
 
         // Only commit shared links by filtering decorated_links
-        let shared_links: Vec<LinkExpression> = decorated_links.iter()
+        let shared_links: Vec<LinkExpression> = decorated_links
+            .iter()
             .filter(|link| link.status == Some(LinkStatus::Shared))
             .map(|link| link.clone().into())
             .collect();
@@ -906,7 +908,7 @@ impl PerspectiveInstance {
         *(self.links_have_changed.lock().await) = true;
         Ok(decorated_links)
     }
-    
+
     async fn get_links_local(
         &self,
         query: &LinkQuery,

--- a/tests/js/tests/perspective.ts
+++ b/tests/js/tests/perspective.ts
@@ -130,6 +130,28 @@ export default function perspectiveTests(testContext: TestContext) {
                 expect(linksPostMutation.length).to.equal(2);
             })
 
+            it(`doesn't error when duplicate entries passed to removeLinks`, async () => {
+                const ad4mClient = testContext.ad4mClient!;
+                const perspective = await ad4mClient.perspective.add('test-duplicate-link-removal');
+                expect(perspective.name).to.equal('test-duplicate-link-removal');
+
+                // create link
+                const link = { source: 'root', predicate: 'p', target: 'abc' };
+                const addLink = await perspective.add(link);
+                expect(addLink.data.target).to.equal("abc");
+
+                // get link expression
+                const linkExpression = (await perspective.get(new LinkQuery(link)))[0];
+                expect(linkExpression.data.target).to.equal("abc");
+
+                // attempt to remove link twice (currently errors and prevents further execution of code)
+                await perspective.removeLinks([linkExpression, linkExpression])
+
+                // check link is removed
+                const links = await perspective.get(new LinkQuery(link));
+                expect(links.length).to.equal(0);
+            })
+
             it('test local perspective links - time query', async () => {
                 const ad4mClient = testContext.ad4mClient!
 


### PR DESCRIPTION
The old and naive implementation for removing multiple links would 
1. kick-off prolog rebuilding and link language commits for each link and
2. would fail all remaining links if on link in the list fails (doesn't exist)

Here is a proper implementation for removing many links in one go.