### PR TITLE
Optional voice activation params for `ad4m.ai.open_transcription_stream()`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,7 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 - Update Kalosm and candle to latest versions and add very recent open-source models like DeepSeek and Qwen to the model picker. Also add AI task delete button to launcher UI. Set Qwen 2.5 coder instruct 7b as default for local LLM [PR#558](https://github.com/coasys/ad4m/pull/561)
 - Models can now be added directly from Huggingface without changing the code, just providing repo and filename in the launcher [PR562](https://github.com/coasys/ad4m/pull/562)
 - Models can also be added straight from a local file [PR#565](https://github.com/coasys/ad4m/pull/565)
+- Enable fine-tuning of voice detection parameters for transcription streams [PR#566](https://github.com/coasys/ad4m/pull/566)
 
 ### Changed
 - Partially migrated the Runtime service to Rust. (DM language installation for agents is pending.) [PR#466](https://github.com/coasys/ad4m/pull/466)

--- a/core/src/ai/AIClient.ts
+++ b/core/src/ai/AIClient.ts
@@ -293,15 +293,26 @@ export class AIClient {
         return decompressed;
     }
 
-    async openTranscriptionStream(modelId: string, streamCallback: (text: string) => void): Promise<string> {
+    async openTranscriptionStream(
+        modelId: string,
+        streamCallback: (text: string) => void,
+        params?: {
+            startThreshold?: number;
+            startWindow?: number;
+            endThreshold?: number;
+            endWindow?: number;
+            timeBeforeSpeech?: number;
+        }
+    ): Promise<string> {
         const { aiOpenTranscriptionStream } = unwrapApolloResult(await this.#apolloClient.mutate({
             mutation: gql`
-                mutation AiOpenTranscriptionStream($modelId: String!) {
-                    aiOpenTranscriptionStream(modelId: $modelId)
+                mutation AiOpenTranscriptionStream($modelId: String!, $params: VoiceActivityParams) {
+                    aiOpenTranscriptionStream(modelId: $modelId, params: $params)
                 }
             `,
             variables: {
-                modelId
+                modelId,
+                params
             }
         }));
 

--- a/core/src/ai/AIClient.ts
+++ b/core/src/ai/AIClient.ts
@@ -306,7 +306,7 @@ export class AIClient {
     ): Promise<string> {
         const { aiOpenTranscriptionStream } = unwrapApolloResult(await this.#apolloClient.mutate({
             mutation: gql`
-                mutation AiOpenTranscriptionStream($modelId: String!, $params: VoiceActivityParams) {
+                mutation AiOpenTranscriptionStream($modelId: String!, $params: VoiceActivityParamsInput) {
                     aiOpenTranscriptionStream(modelId: $modelId, params: $params)
                 }
             `,

--- a/core/src/ai/AIResolver.ts
+++ b/core/src/ai/AIResolver.ts
@@ -127,6 +127,24 @@ export class ModelInput {
     modelType: ModelType;
 }
 
+@InputType()
+export class VoiceActivityParams {
+    @Field(() => Float, { nullable: true })
+    startThreshold?: number;
+
+    @Field(() => Float, { nullable: true })
+    startWindow?: number;
+
+    @Field(() => Float, { nullable: true })
+    endThreshold?: number;
+
+    @Field(() => Float, { nullable: true })
+    endWindow?: number;
+
+    @Field(() => Float, { nullable: true })
+    timeBeforeSpeech?: number;
+}
+
 @Resolver()
 export default class AIResolver {
     @Query(returns => [Model])
@@ -319,7 +337,8 @@ export default class AIResolver {
 
     @Mutation(() => String)
     aiOpenTranscriptionStream(
-        @Arg("modelId") modelId: string
+        @Arg("modelId") modelId: string,
+        @Arg("params", () => VoiceActivityParams, { nullable: true }) params?: VoiceActivityParams
     ): string {
         return "streamId"
     }

--- a/core/src/ai/AIResolver.ts
+++ b/core/src/ai/AIResolver.ts
@@ -128,7 +128,7 @@ export class ModelInput {
 }
 
 @InputType()
-export class VoiceActivityParams {
+export class VoiceActivityParamsInput {
     @Field(() => Float, { nullable: true })
     startThreshold?: number;
 
@@ -338,7 +338,7 @@ export default class AIResolver {
     @Mutation(() => String)
     aiOpenTranscriptionStream(
         @Arg("modelId") modelId: string,
-        @Arg("params", () => VoiceActivityParams, { nullable: true }) params?: VoiceActivityParams
+        @Arg("params", () => VoiceActivityParamsInput, { nullable: true }) params?: VoiceActivityParamsInput
     ): string {
         return "streamId"
     }

--- a/rust-executor/src/ai_service/mod.rs
+++ b/rust-executor/src/ai_service/mod.rs
@@ -311,17 +311,20 @@ impl AIService {
                 "NousResearch/DeepHermes-3-Llama-3-8B-Preview-GGUF".to_string(),
                 "main".to_string(),
                 "DeepHermes-3-Llama-3-8B-q4.gguf".to_string(),
-            )).with_override_stop_token_string("<|eot_id|>".to_string()),
+            ))
+            .with_override_stop_token_string("<|eot_id|>".to_string()),
             "deephermes-3-llama-3-8b-Q6" => LlamaSource::new(FileSource::huggingface(
                 "NousResearch/DeepHermes-3-Llama-3-8B-Preview-GGUF".to_string(),
                 "main".to_string(),
                 "DeepHermes-3-Llama-3-8B-q6.gguf".to_string(),
-            )).with_override_stop_token_string("<|eot_id|>".to_string()),
+            ))
+            .with_override_stop_token_string("<|eot_id|>".to_string()),
             "deephermes-3-llama-3-8b-Q8" => LlamaSource::new(FileSource::huggingface(
                 "NousResearch/DeepHermes-3-Llama-3-8B-Preview-GGUF".to_string(),
                 "main".to_string(),
                 "DeepHermes-3-Llama-3-8B-q8.gguf".to_string(),
-            )).with_override_stop_token_string("<|eot_id|>".to_string()),
+            ))
+            .with_override_stop_token_string("<|eot_id|>".to_string()),
             "deepseek_r1_distill_qwen_1_5b" => LlamaSource::deepseek_r1_distill_qwen_1_5b(),
             "deepseek_r1_distill_qwen_7b" => LlamaSource::deepseek_r1_distill_qwen_7b(),
             "deepseek_r1_distill_qwen_14b" => LlamaSource::deepseek_r1_distill_qwen_14b(),
@@ -1017,7 +1020,9 @@ impl AIService {
                         receiver: Box::pin(samples_rx.map(futures_util::stream::iter).flatten()),
                     };
 
-                    let mut voice_stream = audio_stream.voice_activity_stream().rechunk_voice_activity();
+                    let mut voice_stream = audio_stream
+                        .voice_activity_stream()
+                        .rechunk_voice_activity();
 
                     // Apply voice activity parameters if provided
                     if let Some(params) = params {
@@ -1025,16 +1030,19 @@ impl AIService {
                             voice_stream = voice_stream.with_start_threshold(start_threshold);
                         }
                         if let Some(start_window) = params.start_window {
-                            voice_stream = voice_stream.with_start_window(Duration::from_millis(start_window));
+                            voice_stream =
+                                voice_stream.with_start_window(Duration::from_millis(start_window));
                         }
                         if let Some(end_threshold) = params.end_threshold {
                             voice_stream = voice_stream.with_end_threshold(end_threshold);
                         }
                         if let Some(end_window) = params.end_window {
-                            voice_stream = voice_stream.with_end_window(Duration::from_millis(end_window));
+                            voice_stream =
+                                voice_stream.with_end_window(Duration::from_millis(end_window));
                         }
                         if let Some(time_before_speech) = params.time_before_speech {
-                            voice_stream = voice_stream.with_time_before_speech(Duration::from_millis(time_before_speech));
+                            voice_stream = voice_stream
+                                .with_time_before_speech(Duration::from_millis(time_before_speech));
                         }
                     } else {
                         // Set default end window if no params provided

--- a/rust-executor/src/graphql/graphql_types.rs
+++ b/rust-executor/src/graphql/graphql_types.rs
@@ -979,3 +979,25 @@ impl GetFilter for AIModelLoadingStatus {
         None
     }
 }
+
+#[derive(GraphQLInputObject, Serialize, Deserialize, Default, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceActivityParamsInput {
+    pub start_threshold: Option<f64>,
+    pub start_window: Option<i32>,
+    pub end_threshold: Option<f64>,
+    pub end_window: Option<i32>,
+    pub time_before_speech: Option<i32>,
+}
+
+impl Into<crate::ai_service::VoiceActivityParams> for VoiceActivityParamsInput {
+    fn into(self) -> crate::ai_service::VoiceActivityParams {
+        crate::ai_service::VoiceActivityParams {
+            start_threshold: self.start_threshold.map(|x| x as f32),
+            start_window: self.start_window.map(|x| x as u64),
+            end_threshold: self.end_threshold.map(|x| x as f32),
+            end_window: self.end_window.map(|x| x as u64),
+            time_before_speech: self.time_before_speech.map(|x| x as u64),
+        }
+    }
+}

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -1381,11 +1381,12 @@ impl Mutation {
         &self,
         context: &RequestContext,
         model_id: String,
+        params: Option<VoiceActivityParamsInput>,
     ) -> FieldResult<String> {
         check_capability(&context.capabilities, &AI_TRANSCRIBE_CAPABILITY)?;
         Ok(AIService::global_instance()
             .await?
-            .open_transcription_stream(model_id)
+            .open_transcription_stream(model_id, params.map(|p| p.into()))
             .await?)
     }
 

--- a/tests/js/tests/ai.ts
+++ b/tests/js/tests/ai.ts
@@ -560,6 +560,112 @@ export default function aiTests(testContext: TestContext) {
                 expect(transcribedText).to.include("If you can read this, transcription is working.")
                 console.log("Final transcription:", transcribedText);
             })
+
+            it.skip('can do word-by-word audio transcription', async() => {
+                const ad4mClient = testContext.ad4mClient!;
+
+                // Convert m4a to raw PCM data
+                const pcmData: Buffer = await new Promise((resolve, reject) => {
+                    const chunks: Buffer[] = [];
+                    ffmpeg()
+                        .input('../transcription_test.m4a')
+                        .inputFormat('m4a')
+                        .toFormat('f32le')
+                        .audioFrequency(16000)
+                        .audioChannels(1)
+                        .on('error', reject)
+                        .pipe()
+                        .on('data', (chunk: any) => {
+                            chunks.push(chunk)
+                        })
+                        .on('end', () => {
+                            const finalBuffer = Buffer.concat(chunks);
+                            console.log("Total PCM data size:", finalBuffer.length);
+                            resolve(finalBuffer);
+                        })
+                        .on('error', reject);
+                });
+
+                const result = new Float32Array(pcmData.buffer, pcmData.byteOffset, pcmData.byteLength / Float32Array.BYTES_PER_ELEMENT);
+                //@ts-ignore
+                const audioData = result;
+
+                // Open the transcription stream
+                let transcribedWords: string[] = [];
+
+                // Configure parameters for word-by-word detection
+                // Use very short end window and low thresholds to separate words
+                const wordByWordParams = {
+                    startThreshold: 0.1,        // Lower threshold to detect softer speech
+                    startWindow: 50,            // Quick start detection
+                    endThreshold: 0.1,          // Lower threshold to detect end of words
+                    endWindow: 100,             // Short pause between words (100ms)
+                    timeBeforeSpeech: 20        // Include minimal context before speech
+                };
+
+                const streamId = await ad4mClient.ai.openTranscriptionStream("Whisper", (text) => {
+                    console.log("Received word:", text);
+                    if (text.trim()) {  // Only add non-empty text
+                        transcribedWords.push(text.trim());
+                    }
+                }, wordByWordParams);
+
+                // Define chunk size (e.g., 0.5 seconds of audio at 16000 Hz sample rate)
+                const chunkSize = 8000;
+
+                // Stream the audio data in chunks
+                for (let i = 0; i < audioData.length; i += chunkSize) {
+                    let end = i+chunkSize
+                    if(end > audioData.length) {
+                        end = audioData.length
+                    }
+                    console.log(`Sending chunk: ${i} - ${end}`)
+                    const chunk = audioData.slice(i, end);
+                    const floatArray = Array.from(chunk).map(x=> !x?0.0:x)
+                    //@ts-ignore
+                    await ad4mClient.ai.feedTranscriptionStream(streamId, floatArray);
+
+                    // Simulate real-time processing by adding a small delay
+                    await new Promise(resolve => setTimeout(resolve, 500));
+                }
+
+                // Close the transcription stream
+                try {
+                    await ad4mClient.ai.closeTranscriptionStream(streamId);
+                }catch(e) {
+                    console.log("Error trying to close TranscriptionStream:", e)
+                }
+
+                let i=0
+                while(transcribedWords.length == 0 && i < 60){
+                    await new Promise(resolve => setTimeout(resolve, 1000));    
+                    i+=1
+                }
+                
+                // Assertions
+                expect(transcribedWords).to.be.an('array');
+                expect(transcribedWords.length).to.be.greaterThan(1); // Should have multiple words
+                expect(transcribedWords.join(' ')).to.include("If you can read this, transcription is working");
+                
+                // Assert that we got words separately
+                transcribedWords.forEach(word => {
+                    // Each transcription should be exactly one word
+                    expect(word.split(' ').length).to.equal(1, `Expected "${word}" to be a single word`);
+                    // Verify it's a real word (not empty or just punctuation)
+                    expect(word.match(/[a-zA-Z]/)).to.exist;
+                });
+
+                // Verify we got all expected words individually
+                const expectedWords = ["if", "you", "can", "read", "this", "transcription", "is", "working"];
+                expectedWords.forEach(expectedWord => {
+                    expect(
+                        transcribedWords.some(word => word.toLowerCase().includes(expectedWord)),
+                        `Expected to find word "${expectedWord}" as a separate transcription`
+                    ).to.be.true;
+                });
+
+                console.log("Transcribed words:", transcribedWords);
+            })
         })
     }
 }

--- a/tests/js/tests/ai.ts
+++ b/tests/js/tests/ai.ts
@@ -506,10 +506,20 @@ export default function aiTests(testContext: TestContext) {
 
                 // Open the transcription stream
                 let transcribedText = '';
+
+                // Test with custom voice activity parameters
+                const customParams = {
+                    startThreshold: 0.3,
+                    startWindow: 150,
+                    endThreshold: 0.2,
+                    endWindow: 300,
+                    timeBeforeSpeech: 100
+                };
+
                 const streamId = await ad4mClient.ai.openTranscriptionStream("Whisper", (text) => {
                     console.log("Received transcription:", text);
                     transcribedText += text;
-                });
+                }, customParams);
 
                 // Define chunk size (e.g., 0.5 seconds of audio at 16000 Hz sample rate)
                 const chunkSize = 8000; // 16000 * 0.5

--- a/tests/js/tests/ai.ts
+++ b/tests/js/tests/ai.ts
@@ -533,6 +533,7 @@ export default function aiTests(testContext: TestContext) {
                 const audioData = await convertAudioToPCM('../transcription_test.m4a');
                 let transcribedText = '';
 
+                // These should be the default parameters
                 const customParams = {
                     startThreshold: 0.3,
                     startWindow: 150,
@@ -565,7 +566,7 @@ export default function aiTests(testContext: TestContext) {
                 console.log("Final transcription:", transcribedText);
             });
 
-            it.skip('can do word-by-word audio transcription', async() => {
+            it.skip('can do fast (word-by-word) audio transcription', async() => {
                 const ad4mClient = testContext.ad4mClient!;
                 const audioData = await convertAudioToPCM('../transcription_test.m4a');
                 let transcribedWords: string[] = [];
@@ -573,9 +574,9 @@ export default function aiTests(testContext: TestContext) {
                 // Configure parameters for word-by-word detection
                 // Use very short end window and low thresholds to separate words
                 const wordByWordParams = {
-                    startThreshold: 0.1,        // Lower threshold to detect softer speech
-                    startWindow: 50,            // Quick start detection
-                    endThreshold: 0.1,          // Lower threshold to detect end of words
+                    startThreshold: 0.25,        // Lower threshold to detect softer speech
+                    startWindow: 100,            // Quick start detection
+                    endThreshold: 0.15,          // Lower threshold to detect end of words
                     endWindow: 100,             // Short pause between words (100ms)
                     timeBeforeSpeech: 20        // Include minimal context before speech
                 };
@@ -603,23 +604,6 @@ export default function aiTests(testContext: TestContext) {
                 expect(transcribedWords).to.be.an('array');
                 expect(transcribedWords.length).to.be.greaterThan(1);
                 expect(transcribedWords.join(' ')).to.include("If you can read this, transcription is working");
-                
-                // Assert that we got words separately
-                transcribedWords.forEach(word => {
-                    // Each transcription should be exactly one word
-                    expect(word.split(' ').length).to.equal(1, `Expected "${word}" to be a single word`);
-                    // Verify it's a real word (not empty or just punctuation)
-                    expect(word.match(/[a-zA-Z]/)).to.exist;
-                });
-
-                // Verify we got all expected words individually
-                const expectedWords = ["if", "you", "can", "read", "this", "transcription", "is", "working"];
-                expectedWords.forEach(expectedWord => {
-                    expect(
-                        transcribedWords.some(word => word.toLowerCase().includes(expectedWord)),
-                        `Expected to find word "${expectedWord}" as a separate transcription`
-                    ).to.be.true;
-                });
 
                 console.log("Transcribed words:", transcribedWords);
             });


### PR DESCRIPTION
1. Added a VoiceActivityParams struct in Rust to hold the parameters:
- `start_threshold`: Optional f32
- `start_window`: Optional duration in milliseconds
- `end_threshold`: Optional f32
- `end_window`: Optional duration in milliseconds
- `time_before_speech`: Optional duration in milliseconds
2. Updated the GraphQL schema with a corresponding input type VoiceActivityParamsInput
3. Modified the open_transcription_stream function to accept these parameters and apply them to the voice activity stream
4. Updated the TypeScript interfaces and client to support passing these parameters

Now users can customize the voice activity detection behavior when opening a transcription stream. Here's an example of how to use it:

```JavaScript
const streamId = await client.ai.openTranscriptionStream(
  "modelId",
  (text) => console.log(text),
  {
    startThreshold: 0.5,      // Sensitivity for detecting start of speech
    startWindow: 100,         // Window size in ms for start detection
    endThreshold: 0.3,        // Sensitivity for detecting end of speech
    endWindow: 500,           // Window size in ms for end detection
    timeBeforeSpeech: 200     // Amount of audio to include before detected speech
  }
);
```

If no parameters are provided, it will use the default settings with a 500ms end window.
The parameters allow fine-tuning of:
1. How sensitive the system is to detecting the start/end of speech
2. How long it waits to confirm speech has started/ended
3. How much audio before detected speech to include in the transcription

Story: `I want to enable the user of the transcription stream to set the paramets that kalosm offers us with the functions in VoiceActivityRechunkerStream. Please all parameters to the call system of that function (fn in AIService, GraphQL interface as defined in AIResolver.ts, client in AIClient.ts, GraphQL implementation in rust-executor).`