### PR TITLE
Neighbourhood signal broadcast loopback

### DIFF
--- a/core/src/neighbourhood/NeighbourhoodClient.ts
+++ b/core/src/neighbourhood/NeighbourhoodClient.ts
@@ -184,35 +184,39 @@ export class NeighbourhoodClient {
         return neighbourhoodSendSignalU
     }
 
-    async sendBroadcast(perspectiveUUID: string, payload: Perspective): Promise<boolean> {
+    async sendBroadcast(perspectiveUUID: string, payload: Perspective, loopback: boolean = false): Promise<boolean> {
         const { neighbourhoodSendBroadcast } = unwrapApolloResult(await this.#apolloClient.mutate({
             mutation: gql`mutation neighbourhoodSendBroadcast(
                 $perspectiveUUID: String!,
-                $payload: PerspectiveInput!
+                $payload: PerspectiveInput!,
+                $loopback: Boolean
             ) {
                 neighbourhoodSendBroadcast(
                     perspectiveUUID: $perspectiveUUID,
-                    payload: $payload
+                    payload: $payload,
+                    loopback: $loopback
                 )
             }`,
-            variables: { perspectiveUUID, payload }
+            variables: { perspectiveUUID, payload, loopback }
         }))
 
         return neighbourhoodSendBroadcast
     }
 
-    async sendBroadcastU(perspectiveUUID: string, payload: PerspectiveUnsignedInput): Promise<boolean> {
+    async sendBroadcastU(perspectiveUUID: string, payload: PerspectiveUnsignedInput, loopback: boolean = false): Promise<boolean> {
         const { neighbourhoodSendBroadcastU } = unwrapApolloResult(await this.#apolloClient.mutate({
             mutation: gql`mutation neighbourhoodSendBroadcastU(
                 $perspectiveUUID: String!,
-                $payload: PerspectiveUnsignedInput!
+                $payload: PerspectiveUnsignedInput!,
+                $loopback: Boolean
             ) {
                 neighbourhoodSendBroadcastU(
                     perspectiveUUID: $perspectiveUUID,
-                    payload: $payload
+                    payload: $payload,
+                    loopback: $loopback
                 )
             }`,
-            variables: { perspectiveUUID, payload }
+            variables: { perspectiveUUID, payload, loopback }
         }))
 
         return neighbourhoodSendBroadcastU

--- a/core/src/neighbourhood/NeighbourhoodProxy.ts
+++ b/core/src/neighbourhood/NeighbourhoodProxy.ts
@@ -40,12 +40,12 @@ export class NeighbourhoodProxy {
         return await this.#client.sendSignalU(this.#pID, remoteAgentDid, payload)
     }
 
-    async sendBroadcast(payload: Perspective): Promise<boolean> {
-        return await this.#client.sendBroadcast(this.#pID, payload)
+    async sendBroadcast(payload: Perspective, loopback: boolean = false): Promise<boolean> {
+        return await this.#client.sendBroadcast(this.#pID, payload, loopback)
     }
 
-    async sendBroadcastU(payload: PerspectiveUnsignedInput): Promise<boolean> {
-        return await this.#client.sendBroadcastU(this.#pID, payload)
+    async sendBroadcastU(payload: PerspectiveUnsignedInput, loopback: boolean = false): Promise<boolean> {
+        return await this.#client.sendBroadcastU(this.#pID, payload, loopback)
     }
 
     async addSignalHandler(handler: (payload: PerspectiveExpression) => void): Promise<void> {

--- a/core/src/neighbourhood/NeighbourhoodResolver.ts
+++ b/core/src/neighbourhood/NeighbourhoodResolver.ts
@@ -84,12 +84,12 @@ export default class NeighbourhoodResolver {
     }
 
     @Mutation()
-    neighbourhoodSendBroadcast(@Arg('perspectiveUUID') perspectiveUUID: string, @Arg('payload') signal: PerspectiveInput): boolean {
+    neighbourhoodSendBroadcast(@Arg('perspectiveUUID') perspectiveUUID: string, @Arg('payload') signal: PerspectiveInput, @Arg('loopback', { nullable: true }) loopback?: boolean): boolean {
         return true
     }
 
     @Mutation()
-    neighbourhoodSendBroadcastU(@Arg('perspectiveUUID') perspectiveUUID: string, @Arg('payload') signal: PerspectiveUnsignedInput): boolean {
+    neighbourhoodSendBroadcastU(@Arg('perspectiveUUID') perspectiveUUID: string, @Arg('payload') signal: PerspectiveUnsignedInput, @Arg('loopback', { nullable: true }) loopback?: boolean): boolean {
         return true
     }
 

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -546,6 +546,7 @@ impl Mutation {
         context: &RequestContext,
         payload: PerspectiveInput,
         #[allow(non_snake_case)] perspectiveUUID: String,
+        loopback: Option<bool>,
     ) -> FieldResult<bool> {
         let uuid = perspectiveUUID;
         check_capability(&context.capabilities, &NEIGHBOURHOOD_UPDATE_CAPABILITY)?;
@@ -556,7 +557,7 @@ impl Mutation {
                 "No perspective found with uuid {}",
                 uuid
             )))?
-            .send_broadcast(perspective.into())
+            .send_broadcast(perspective.into(), loopback.unwrap_or(false))
             .await
             .map_err(|e| FieldError::from(e.to_string()))?;
         Ok(true)
@@ -567,6 +568,7 @@ impl Mutation {
         context: &RequestContext,
         payload: PerspectiveUnsignedInput,
         #[allow(non_snake_case)] perspectiveUUID: String,
+        loopback: Option<bool>,
     ) -> FieldResult<bool> {
         let uuid = perspectiveUUID;
         check_capability(&context.capabilities, &NEIGHBOURHOOD_UPDATE_CAPABILITY)?;
@@ -587,7 +589,7 @@ impl Mutation {
                 "No perspective found with uuid {}",
                 uuid
             )))?
-            .send_broadcast(perspective.into())
+            .send_broadcast(perspective.into(), loopback.unwrap_or(false))
             .await
             .map_err(|e| FieldError::from(e.to_string()))?;
         Ok(true)

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -1398,13 +1398,19 @@ impl PerspectiveInstance {
         }
     }
 
-    pub async fn send_broadcast(&self, payload: PerspectiveExpression, loopback: bool) -> Result<(), AnyError> {
+    pub async fn send_broadcast(
+        &self,
+        payload: PerspectiveExpression,
+        loopback: bool,
+    ) -> Result<(), AnyError> {
         if loopback {
             // send back to all clients through neighbourhood signal subscription
             let payload_clone = payload.clone();
             let self_clone = self.clone();
             tokio::spawn(async move {
-                self_clone.telepresence_signal_from_link_language(payload_clone).await;
+                self_clone
+                    .telepresence_signal_from_link_language(payload_clone)
+                    .await;
             });
         }
 

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -1398,7 +1398,16 @@ impl PerspectiveInstance {
         }
     }
 
-    pub async fn send_broadcast(&self, payload: PerspectiveExpression) -> Result<(), AnyError> {
+    pub async fn send_broadcast(&self, payload: PerspectiveExpression, loopback: bool) -> Result<(), AnyError> {
+        if loopback {
+            // send back to all clients through neighbourhood signal subscription
+            let payload_clone = payload.clone();
+            let self_clone = self.clone();
+            tokio::spawn(async move {
+                self_clone.telepresence_signal_from_link_language(payload_clone).await;
+            });
+        }
+
         let mut link_language_guard = self.link_language.lock().await;
         if let Some(link_language) = link_language_guard.as_mut() {
             link_language.send_broadcast(payload).await


### PR DESCRIPTION
Fixes #567

1. Added the loopback parameter to the GraphQL mutation definitions in MutationDefinitions.ts
2. Updated the Rust mutation resolvers in mutation_resolvers.rs to handle the loopback parameter for both neighbourhoodSendBroadcast and neighbourhoodSendBroadcastU
3. Implemented the loopback functionality in the NeighbourhoodController's send_broadcast method, which now processes the broadcast locally when loopback is enabled
4. Updated the TypeScript resolver definitions in NeighbourhoodResolver.ts to include the loopback parameter

The implementation ensures that when loopback is enabled:
1. The broadcast is sent to all connected agents as usual
2. The broadcast is also processed locally through the signal handler for the same perspective
This allows the same agent to receive their own broadcasts when needed, which is crucial for multi-device syncing
