### PR TITLE
DB JSON export/import

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -50,6 +50,7 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 - Models can now be added directly from Huggingface without changing the code, just providing repo and filename in the launcher [PR562](https://github.com/coasys/ad4m/pull/562)
 - Models can also be added straight from a local file [PR#565](https://github.com/coasys/ad4m/pull/565)
 - Enable fine-tuning of voice detection parameters for transcription streams [PR#566](https://github.com/coasys/ad4m/pull/566)
+- DB and Perspective to JSON exports and imports [PR#569](https://github.com/coasys/ad4m/pull/569)
 
 ### Changed
 - Partially migrated the Runtime service to Rust. (DM language installation for agents is pending.) [PR#466](https://github.com/coasys/ad4m/pull/466)

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -30,3 +30,4 @@ export * from './subject/SubjectEntity'
 export * from "./agent/AgentClient";
 export * from "./ai/AIClient"
 export * from "./ai/Tasks"
+export * from "./runtime/RuntimeResolver"

--- a/core/src/runtime/RuntimeClient.ts
+++ b/core/src/runtime/RuntimeClient.ts
@@ -1,7 +1,7 @@
 import { ApolloClient, gql } from "@apollo/client/core"
 import { Perspective, PerspectiveExpression } from "../perspectives/Perspective"
 import unwrapApolloResult from "../unwrapApolloResult"
-import { RuntimeInfo, ExceptionInfo, SentMessage, NotificationInput, Notification, TriggeredNotification } from "./RuntimeResolver"
+import { RuntimeInfo, ExceptionInfo, SentMessage, NotificationInput, Notification, TriggeredNotification, ImportResult } from "./RuntimeResolver"
 
 const PERSPECTIVE_EXPRESSION_FIELDS = `
 author
@@ -297,10 +297,22 @@ export class RuntimeClient {
         return runtimeExportDb
     }
 
-    async importDb(filePath: string): Promise<boolean> {
+    async importDb(filePath: string): Promise<ImportResult> {
         const { runtimeImportDb } = unwrapApolloResult(await this.#apolloClient.mutate({
             mutation: gql`mutation runtimeImportDb($filePath: String!) {
-                runtimeImportDb(filePath: $filePath)
+                runtimeImportDb(filePath: $filePath) {
+                    perspectives { total imported failed omitted errors }
+                    links { total imported failed omitted errors }
+                    expressions { total imported failed omitted errors }
+                    perspective_diffs { total imported failed omitted errors }
+                    notifications { total imported failed omitted errors }
+                    models { total imported failed omitted errors }
+                    default_models { total imported failed omitted errors }
+                    tasks { total imported failed omitted errors }
+                    friends { total imported failed omitted errors }
+                    trusted_agents { total imported failed omitted errors }
+                    known_link_languages { total imported failed omitted errors }
+                }
             }`,
             variables: { filePath }
         }))

--- a/core/src/runtime/RuntimeClient.ts
+++ b/core/src/runtime/RuntimeClient.ts
@@ -336,6 +336,25 @@ export class RuntimeClient {
         return runtimeRemoveNotification
     }
 
+    async exportPerspective(uuid: string, filePath: string): Promise<boolean> {
+        const { runtimeExportPerspective } = unwrapApolloResult(await this.#apolloClient.mutate({
+            mutation: gql`mutation runtimeExportPerspective($perspectiveUuid: String!, $filePath: String!) {
+                runtimeExportPerspective(perspectiveUuid: $perspectiveUuid, filePath: $filePath)
+            }`,
+            variables: { perspectiveUuid: uuid, filePath }
+        }))
+        return runtimeExportPerspective
+    }
+
+    async importPerspective(filePath: string): Promise<boolean> {
+        const { runtimeImportPerspective } = unwrapApolloResult(await this.#apolloClient.mutate({
+            mutation: gql`mutation runtimeImportPerspective($filePath: String!) {
+                runtimeImportPerspective(filePath: $filePath)
+            }`,
+            variables: { filePath }
+        }))
+        return runtimeImportPerspective
+    }
 
     addNotificationTriggeredCallback(cb: NotificationTriggeredCallback) {
         this.#notificationTriggeredCallbacks.push(cb)

--- a/core/src/runtime/RuntimeClient.ts
+++ b/core/src/runtime/RuntimeClient.ts
@@ -287,6 +287,26 @@ export class RuntimeClient {
         return runtimeGrantNotification
     }
 
+    async exportDb(filePath: string): Promise<boolean> {
+        const { runtimeExportDb } = unwrapApolloResult(await this.#apolloClient.mutate({
+            mutation: gql`mutation runtimeExportDb($filePath: String!) {
+                runtimeExportDb(filePath: $filePath)
+            }`,
+            variables: { filePath }
+        }))
+        return runtimeExportDb
+    }
+
+    async importDb(filePath: string): Promise<boolean> {
+        const { runtimeImportDb } = unwrapApolloResult(await this.#apolloClient.mutate({
+            mutation: gql`mutation runtimeImportDb($filePath: String!) {
+                runtimeImportDb(filePath: $filePath)
+            }`,
+            variables: { filePath }
+        }))
+        return runtimeImportDb
+    }
+
     async notifications(): Promise<Notification[]> {
         const { runtimeNotifications } = unwrapApolloResult(await this.#apolloClient.query({
             query: gql`query runtimeNotifications {

--- a/core/src/runtime/RuntimeClient.ts
+++ b/core/src/runtime/RuntimeClient.ts
@@ -304,14 +304,14 @@ export class RuntimeClient {
                     perspectives { total imported failed omitted errors }
                     links { total imported failed omitted errors }
                     expressions { total imported failed omitted errors }
-                    perspective_diffs { total imported failed omitted errors }
+                    perspectiveDiffs { total imported failed omitted errors }
                     notifications { total imported failed omitted errors }
                     models { total imported failed omitted errors }
-                    default_models { total imported failed omitted errors }
+                    defaultModels { total imported failed omitted errors }
                     tasks { total imported failed omitted errors }
                     friends { total imported failed omitted errors }
-                    trusted_agents { total imported failed omitted errors }
-                    known_link_languages { total imported failed omitted errors }
+                    trustedAgents { total imported failed omitted errors }
+                    knownLinkLanguages { total imported failed omitted errors }
                 }
             }`,
             variables: { filePath }

--- a/core/src/runtime/RuntimeResolver.ts
+++ b/core/src/runtime/RuntimeResolver.ts
@@ -168,7 +168,7 @@ export class ImportResult {
     expressions: ImportStats;
 
     @Field()
-    perspective_diffs: ImportStats;
+    perspectiveDiffs: ImportStats;
 
     @Field()
     notifications: ImportStats;
@@ -177,7 +177,7 @@ export class ImportResult {
     models: ImportStats;
 
     @Field()
-    default_models: ImportStats;
+    defaultModels: ImportStats;
 
     @Field()
     tasks: ImportStats;
@@ -186,10 +186,10 @@ export class ImportResult {
     friends: ImportStats;
 
     @Field()
-    trusted_agents: ImportStats;
+    trustedAgents: ImportStats;
 
     @Field()
-    known_link_languages: ImportStats;
+    knownLinkLanguages: ImportStats;
 }
 
 /**

--- a/core/src/runtime/RuntimeResolver.ts
+++ b/core/src/runtime/RuntimeResolver.ts
@@ -336,5 +336,15 @@ export default class RuntimeResolver {
             }
         }
     }
+
+    @Mutation()
+    runtimeExportDb(@Arg("filePath", type => String) filePath: string): boolean {
+        return true
+    }
+
+    @Mutation()
+    runtimeImportDb(@Arg("filePath", type => String) filePath: string): boolean {
+        return true
+    }
 }
 

--- a/core/src/runtime/RuntimeResolver.ts
+++ b/core/src/runtime/RuntimeResolver.ts
@@ -346,5 +346,18 @@ export default class RuntimeResolver {
     runtimeImportDb(@Arg("filePath", type => String) filePath: string): boolean {
         return true
     }
+
+    @Mutation()
+    runtimeExportPerspective(
+        @Arg("perspectiveUuid", type => String) perspectiveUuid: string,
+        @Arg("filePath", type => String) filePath: string
+    ): boolean {
+        return true
+    }
+
+    @Mutation()
+    runtimeImportPerspective(@Arg("filePath", type => String) filePath: string): boolean {
+        return true
+    }
 }
 

--- a/core/src/runtime/RuntimeResolver.ts
+++ b/core/src/runtime/RuntimeResolver.ts
@@ -138,6 +138,60 @@ export class TriggeredNotification {
     triggerMatch: string;
 }
 
+@ObjectType()
+export class ImportStats {
+    @Field()
+    total: number;
+
+    @Field()
+    imported: number;
+
+    @Field()
+    failed: number;
+
+    @Field()
+    omitted: number;
+
+    @Field(type => [String])
+    errors: string[];
+}
+
+@ObjectType()
+export class ImportResult {
+    @Field()
+    perspectives: ImportStats;
+
+    @Field()
+    links: ImportStats;
+
+    @Field()
+    expressions: ImportStats;
+
+    @Field()
+    perspective_diffs: ImportStats;
+
+    @Field()
+    notifications: ImportStats;
+
+    @Field()
+    models: ImportStats;
+
+    @Field()
+    default_models: ImportStats;
+
+    @Field()
+    tasks: ImportStats;
+
+    @Field()
+    friends: ImportStats;
+
+    @Field()
+    trusted_agents: ImportStats;
+
+    @Field()
+    known_link_languages: ImportStats;
+}
+
 /**
  * Resolver classes are used here to define the GraphQL schema 
  * (through the type-graphql annotations)

--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -708,8 +708,18 @@ impl Ad4mDb {
     }
 
     pub fn remove_perspective(&self, uuid: &str) -> Ad4mDbResult<()> {
+        // Delete the perspective handle itself
         self.conn
             .execute("DELETE FROM perspective_handle WHERE uuid = ?1", [uuid])?;
+
+        // Delete all links associated with this perspective
+        self.conn
+            .execute("DELETE FROM link WHERE perspective = ?1", [uuid])?;
+
+        // Delete all pending diffs associated with this perspective
+        self.conn
+            .execute("DELETE FROM pending_diff WHERE perspective = ?1", [uuid])?;
+
         Ok(())
     }
 

--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -1571,7 +1571,7 @@ impl Ad4mDb {
                         perspective["name"].as_str(),
                         perspective.get("neighbourhood").and_then(|n| n.as_str()),  // Fixed: properly handle optional JSON string
                         perspective["shared_url"].as_str(),
-                        state.as_str()
+                        perspective["state"].as_str().unwrap_or(state.as_str())
                     ],
                 )?;
             }

--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -1573,7 +1573,7 @@ impl Ad4mDb {
                             .get("uuid")
                             .and_then(|u| u.as_str())
                             .unwrap_or("<unknown>");
-                        match {
+                        let result = {
                             let state = if perspective.get("shared_url").is_some() {
                                 serde_json::to_string(
                                     &PerspectiveState::NeighbourhoodCreationInitiated,
@@ -1593,7 +1593,9 @@ impl Ad4mDb {
                                     perspective["state"].as_str().unwrap_or(state.as_str())
                                 ],
                             )
-                        } {
+                        };
+
+                        match result {
                             Ok(_) => {
                                 log::info!("Successfully imported perspective: {} ({})", name, uuid)
                             }

--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -1573,7 +1573,7 @@ impl Ad4mDb {
                             .get("uuid")
                             .and_then(|u| u.as_str())
                             .unwrap_or("<unknown>");
-                        match (|| {
+                        match {
                             let state = if perspective.get("shared_url").is_some() {
                                 serde_json::to_string(
                                     &PerspectiveState::NeighbourhoodCreationInitiated,
@@ -1593,7 +1593,7 @@ impl Ad4mDb {
                                     perspective["state"].as_str().unwrap_or(state.as_str())
                                 ],
                             )
-                        })() {
+                        } {
                             Ok(_) => {
                                 log::info!("Successfully imported perspective: {} ({})", name, uuid)
                             }

--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -1,5 +1,6 @@
 use crate::graphql::graphql_types::{
-    AIModelLoadingStatus, EntanglementProof, ImportResult, LinkStatus, ModelInput, NotificationInput, PerspectiveExpression, PerspectiveHandle, PerspectiveState, SentMessage
+    AIModelLoadingStatus, EntanglementProof, ImportResult, LinkStatus, ModelInput,
+    NotificationInput, PerspectiveExpression, PerspectiveHandle, PerspectiveState, SentMessage,
 };
 use crate::types::{
     AIPromptExamples, AITask, Expression, ExpressionProof, Link, LinkExpression, LocalModel, Model,
@@ -717,8 +718,10 @@ impl Ad4mDb {
             .execute("DELETE FROM link WHERE perspective = ?1", [uuid])?;
 
         // Delete all pending diffs associated with this perspective
-        self.conn
-            .execute("DELETE FROM perspective_diff WHERE perspective = ?1", [uuid])?;
+        self.conn.execute(
+            "DELETE FROM perspective_diff WHERE perspective = ?1",
+            [uuid],
+        )?;
 
         Ok(())
     }
@@ -1604,7 +1607,10 @@ impl Ad4mDb {
                             }
                             Err(e) => {
                                 result.perspectives.failed += 1;
-                                result.perspectives.errors.push(format!("Failed to import perspective {} ({}): {}", name, uuid, e));
+                                result.perspectives.errors.push(format!(
+                                    "Failed to import perspective {} ({}): {}",
+                                    name, uuid, e
+                                ));
                                 log::warn!(
                                     "Failed to import perspective {} ({}): {}",
                                     name,
@@ -1617,7 +1623,10 @@ impl Ad4mDb {
                 }
                 Err(e) => {
                     result.perspectives.failed = 1;
-                    result.perspectives.errors.push(format!("Failed to parse perspectives: {}", e));
+                    result
+                        .perspectives
+                        .errors
+                        .push(format!("Failed to parse perspectives: {}", e));
                     log::warn!("Failed to parse perspectives: {}", e)
                 }
             }
@@ -1670,7 +1679,10 @@ impl Ad4mDb {
                 }
                 Err(e) => {
                     result.links.failed = 1;
-                    result.links.errors.push(format!("Failed to parse links: {}", e));
+                    result
+                        .links
+                        .errors
+                        .push(format!("Failed to parse links: {}", e));
                     log::warn!("Failed to parse links: {}", e)
                 }
             }
@@ -1690,7 +1702,10 @@ impl Ad4mDb {
                             Ok(_) => result.expressions.imported += 1,
                             Err(e) => {
                                 result.expressions.failed += 1;
-                                result.expressions.errors.push(format!("Failed to import expression {}: {}", expr.url, e));
+                                result.expressions.errors.push(format!(
+                                    "Failed to import expression {}: {}",
+                                    expr.url, e
+                                ));
                                 log::warn!("Failed to import expression {}: {}", expr.url, e)
                             }
                         }
@@ -1698,7 +1713,10 @@ impl Ad4mDb {
                 }
                 Err(e) => {
                     result.expressions.failed = 1;
-                    result.expressions.errors.push(format!("Failed to parse expressions: {}", e));
+                    result
+                        .expressions
+                        .errors
+                        .push(format!("Failed to parse expressions: {}", e));
                     log::warn!("Failed to parse expressions: {}", e)
                 }
             }
@@ -1751,7 +1769,10 @@ impl Ad4mDb {
                 }
                 Err(e) => {
                     result.perspective_diffs.failed = 1;
-                    result.perspective_diffs.errors.push(format!("Failed to parse perspective diffs: {}", e));
+                    result
+                        .perspective_diffs
+                        .errors
+                        .push(format!("Failed to parse perspective diffs: {}", e));
                     log::warn!("Failed to parse perspective diffs: {}", e)
                 }
             }
@@ -1795,7 +1816,10 @@ impl Ad4mDb {
                 }
                 Err(e) => {
                     result.notifications.failed = 1;
-                    result.notifications.errors.push(format!("Failed to parse notifications: {}", e));
+                    result
+                        .notifications
+                        .errors
+                        .push(format!("Failed to parse notifications: {}", e));
                     log::warn!("Failed to parse notifications: {}", e)
                 }
             }
@@ -1842,7 +1866,10 @@ impl Ad4mDb {
                 }
                 Err(e) => {
                     result.models.failed = 1;
-                    result.models.errors.push(format!("Failed to parse models: {}", e));
+                    result
+                        .models
+                        .errors
+                        .push(format!("Failed to parse models: {}", e));
                     log::warn!("Failed to parse models: {}", e)
                 }
             }
@@ -1867,7 +1894,10 @@ impl Ad4mDb {
                             Ok(_) => result.default_models.imported += 1,
                             Err(e) => {
                                 result.default_models.failed += 1;
-                                result.default_models.errors.push(format!("Failed to import default model mapping for type {}: {}", model_type, e));
+                                result.default_models.errors.push(format!(
+                                    "Failed to import default model mapping for type {}: {}",
+                                    model_type, e
+                                ));
                                 log::warn!(
                                     "Failed to import default model mapping for type {}: {}",
                                     model_type,
@@ -1879,7 +1909,10 @@ impl Ad4mDb {
                 }
                 Err(e) => {
                     result.default_models.failed = 1;
-                    result.default_models.errors.push(format!("Failed to parse default models: {}", e));
+                    result
+                        .default_models
+                        .errors
+                        .push(format!("Failed to parse default models: {}", e));
                     log::warn!("Failed to parse default models: {}", e)
                 }
             }
@@ -1921,7 +1954,10 @@ impl Ad4mDb {
                 }
                 Err(e) => {
                     result.tasks.failed = 1;
-                    result.tasks.errors.push(format!("Failed to parse tasks: {}", e));
+                    result
+                        .tasks
+                        .errors
+                        .push(format!("Failed to parse tasks: {}", e));
                     log::warn!("Failed to parse tasks: {}", e)
                 }
             }
@@ -1960,7 +1996,10 @@ impl Ad4mDb {
                             Ok(_) => result.friends.imported += 1,
                             Err(e) => {
                                 result.friends.failed += 1;
-                                result.friends.errors.push(format!("Failed to import friend {}: {}", friend, e));
+                                result
+                                    .friends
+                                    .errors
+                                    .push(format!("Failed to import friend {}: {}", friend, e));
                                 log::warn!("Failed to import friend {}: {}", friend, e)
                             }
                         }
@@ -1968,7 +2007,10 @@ impl Ad4mDb {
                 }
                 Err(e) => {
                     result.friends.failed = 1;
-                    result.friends.errors.push(format!("Failed to parse friends: {}", e));
+                    result
+                        .friends
+                        .errors
+                        .push(format!("Failed to parse friends: {}", e));
                     log::warn!("Failed to parse friends: {}", e)
                 }
             }
@@ -1988,7 +2030,10 @@ impl Ad4mDb {
                             Ok(_) => result.trusted_agents.imported += 1,
                             Err(e) => {
                                 result.trusted_agents.failed += 1;
-                                result.trusted_agents.errors.push(format!("Failed to import trusted agent {}: {}", agent, e));
+                                result.trusted_agents.errors.push(format!(
+                                    "Failed to import trusted agent {}: {}",
+                                    agent, e
+                                ));
                                 log::warn!("Failed to import trusted agent {}: {}", agent, e)
                             }
                         }
@@ -1996,7 +2041,10 @@ impl Ad4mDb {
                 }
                 Err(e) => {
                     result.trusted_agents.failed = 1;
-                    result.trusted_agents.errors.push(format!("Failed to parse trusted agents: {}", e));
+                    result
+                        .trusted_agents
+                        .errors
+                        .push(format!("Failed to parse trusted agents: {}", e));
                     log::warn!("Failed to parse trusted agents: {}", e)
                 }
             }
@@ -2016,7 +2064,10 @@ impl Ad4mDb {
                             Ok(_) => result.known_link_languages.imported += 1,
                             Err(e) => {
                                 result.known_link_languages.failed += 1;
-                                result.known_link_languages.errors.push(format!("Failed to import known link language {}: {}", language, e));
+                                result.known_link_languages.errors.push(format!(
+                                    "Failed to import known link language {}: {}",
+                                    language, e
+                                ));
                                 log::warn!(
                                     "Failed to import known link language {}: {}",
                                     language,
@@ -2028,7 +2079,10 @@ impl Ad4mDb {
                 }
                 Err(e) => {
                     result.known_link_languages.failed = 1;
-                    result.known_link_languages.errors.push(format!("Failed to parse known link languages: {}", e));
+                    result
+                        .known_link_languages
+                        .errors
+                        .push(format!("Failed to parse known link languages: {}", e));
                     log::warn!("Failed to parse known link languages: {}", e)
                 }
             }

--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -1639,21 +1639,6 @@ impl Ad4mDb {
                     result.links.total = links.len() as i32;
                     log::debug!("Importing {} links", links.len());
                     for (link, signature, key) in links {
-                        let link_expr = serde_json::json!({
-                            "author": link.author,
-                            "timestamp": link.timestamp,
-                            "data": {
-                                "source": link.source,
-                                "predicate": link.predicate,
-                                "target": link.target
-                            },
-                            "proof": {
-                                "signature": signature,
-                                "key": key,
-                                "valid": true
-                            }
-                        });
-
                         match self.conn.execute(
                             "INSERT INTO link (perspective, source, predicate, target, author, timestamp, signature, key, status) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
                             params![

--- a/rust-executor/src/graphql/graphql_types.rs
+++ b/rust-executor/src/graphql/graphql_types.rs
@@ -1001,3 +1001,57 @@ impl From<VoiceActivityParamsInput> for crate::ai_service::VoiceActivityParams {
         }
     }
 }
+
+#[derive(GraphQLObject, Debug, serde::Serialize)]
+pub struct ImportStats {
+    pub total: i32,
+    pub imported: i32,
+    pub failed: i32,
+    pub omitted: i32,
+    pub errors: Vec<String>,
+}
+
+#[derive(GraphQLObject, Debug, serde::Serialize)]
+pub struct ImportResult {
+    pub perspectives: ImportStats,
+    pub links: ImportStats,
+    pub expressions: ImportStats,
+    pub perspective_diffs: ImportStats,
+    pub notifications: ImportStats,
+    pub models: ImportStats,
+    pub default_models: ImportStats,
+    pub tasks: ImportStats,
+    pub friends: ImportStats,
+    pub trusted_agents: ImportStats,
+    pub known_link_languages: ImportStats,
+}
+
+impl ImportStats {
+    pub fn new() -> Self {
+        Self {
+            total: 0,
+            imported: 0,
+            failed: 0,
+            omitted: 0,
+            errors: Vec::new(),
+        }
+    }
+}
+
+impl ImportResult {
+    pub fn new() -> Self {
+        Self {
+            perspectives: ImportStats::new(),
+            links: ImportStats::new(),
+            expressions: ImportStats::new(),
+            perspective_diffs: ImportStats::new(),
+            notifications: ImportStats::new(),
+            models: ImportStats::new(),
+            default_models: ImportStats::new(),
+            tasks: ImportStats::new(),
+            friends: ImportStats::new(),
+            trusted_agents: ImportStats::new(),
+            known_link_languages: ImportStats::new(),
+        }
+    }
+}

--- a/rust-executor/src/graphql/graphql_types.rs
+++ b/rust-executor/src/graphql/graphql_types.rs
@@ -1026,6 +1026,12 @@ pub struct ImportResult {
     pub known_link_languages: ImportStats,
 }
 
+impl Default for ImportStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ImportStats {
     pub fn new() -> Self {
         Self {
@@ -1035,6 +1041,12 @@ impl ImportStats {
             omitted: 0,
             errors: Vec::new(),
         }
+    }
+}
+
+impl Default for ImportResult {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/rust-executor/src/graphql/graphql_types.rs
+++ b/rust-executor/src/graphql/graphql_types.rs
@@ -990,14 +990,14 @@ pub struct VoiceActivityParamsInput {
     pub time_before_speech: Option<i32>,
 }
 
-impl Into<crate::ai_service::VoiceActivityParams> for VoiceActivityParamsInput {
-    fn into(self) -> crate::ai_service::VoiceActivityParams {
+impl From<VoiceActivityParamsInput> for crate::ai_service::VoiceActivityParams {
+    fn from(val: VoiceActivityParamsInput) -> Self {
         crate::ai_service::VoiceActivityParams {
-            start_threshold: self.start_threshold.map(|x| x as f32),
-            start_window: self.start_window.map(|x| x as u64),
-            end_threshold: self.end_threshold.map(|x| x as f32),
-            end_window: self.end_window.map(|x| x as u64),
-            time_before_speech: self.time_before_speech.map(|x| x as u64),
+            start_threshold: val.start_threshold.map(|x| x as f32),
+            start_window: val.start_window.map(|x| x as u64),
+            end_threshold: val.end_threshold.map(|x| x as f32),
+            end_window: val.end_window.map(|x| x as u64),
+            time_before_speech: val.time_before_speech.map(|x| x as u64),
         }
     }
 }

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -5,7 +5,9 @@ use crate::{
     ai_service::AIService,
     neighbourhoods::{self, install_neighbourhood},
     perspectives::{
-        self, add_perspective, export_perspective, get_perspective, import_perspective, perspective_instance::{PerspectiveInstance, SdnaType}, remove_perspective, update_perspective, SerializedPerspective
+        self, add_perspective, export_perspective, get_perspective, import_perspective,
+        perspective_instance::{PerspectiveInstance, SdnaType},
+        remove_perspective, update_perspective, SerializedPerspective,
     },
     types::{AITask, DecoratedLinkExpression, Link, LinkExpression, ModelType},
 };
@@ -1257,13 +1259,14 @@ impl Mutation {
             )
         })?;
 
-        let result = Ad4mDb::with_global_instance(|db| db.import_from_json(json_data)).map_err(|e| {
-            log::error!("Failed to import database: {}", e);
-            FieldError::new(
-                format!("Failed to import database: {}", e),
-                graphql_value!({ "error": e.to_string() }),
-            )
-        })?;
+        let result =
+            Ad4mDb::with_global_instance(|db| db.import_from_json(json_data)).map_err(|e| {
+                log::error!("Failed to import database: {}", e);
+                FieldError::new(
+                    format!("Failed to import database: {}", e),
+                    graphql_value!({ "error": e.to_string() }),
+                )
+            })?;
 
         perspectives::initialize_from_db();
 

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -1486,12 +1486,12 @@ impl Mutation {
         check_capability(&context.capabilities, &AGENT_UPDATE_CAPABILITY)?;
 
         // Export the perspective
-        let serialized = export_perspective(&perspective_uuid)
-            .await
-            .map_err(|e| FieldError::new(
+        let serialized = export_perspective(&perspective_uuid).await.map_err(|e| {
+            FieldError::new(
                 "Failed to export perspective",
                 graphql_value!({ "error": e.to_string() }),
-            ))?;
+            )
+        })?;
 
         // Write to file
         std::fs::write(&file_path, serde_json::to_string_pretty(&serialized)?).map_err(|e| {
@@ -1527,14 +1527,12 @@ impl Mutation {
         })?;
 
         // Import the perspective
-        import_perspective(serialized)
-            .await
-            .map_err(|e| {
-                FieldError::new(
-                    format!("Failed to import perspective: {}", e),
-                    graphql_value!({ "error": e.to_string() }),
-                )
-            })?;
+        import_perspective(serialized).await.map_err(|e| {
+            FieldError::new(
+                format!("Failed to import perspective: {}", e),
+                graphql_value!({ "error": e.to_string() }),
+            )
+        })?;
 
         Ok(true)
     }

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -1241,7 +1241,7 @@ impl Mutation {
         &self,
         context: &RequestContext,
         file_path: String,
-    ) -> FieldResult<bool> {
+    ) -> FieldResult<ImportResult> {
         check_capability(&context.capabilities, &AGENT_UPDATE_CAPABILITY)?;
 
         // Read from file
@@ -1259,7 +1259,7 @@ impl Mutation {
             )
         })?;
 
-        Ad4mDb::with_global_instance(|db| db.import_from_json(json_data)).map_err(|e| {
+        let result = Ad4mDb::with_global_instance(|db| db.import_from_json(json_data)).map_err(|e| {
             log::error!("Failed to import database: {}", e);
             FieldError::new(
                 format!("Failed to import database: {}", e),
@@ -1267,7 +1267,7 @@ impl Mutation {
             )
         })?;
 
-        Ok(true)
+        Ok(result)
     }
 
     async fn ai_add_model(

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -1260,6 +1260,7 @@ impl Mutation {
         })?;
 
         Ad4mDb::with_global_instance(|db| db.import_from_json(json_data)).map_err(|e| {
+            log::error!("Failed to import database: {}", e);
             FieldError::new(
                 format!("Failed to import database: {}", e),
                 graphql_value!({ "error": e.to_string() }),

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -1247,14 +1247,14 @@ impl Mutation {
         // Read from file
         let json_str = std::fs::read_to_string(&file_path).map_err(|e| {
             FieldError::new(
-                "Failed to read import file",
+                format!("Failed to read import file '{}': {}", file_path, e),
                 graphql_value!({ "error": e.to_string() }),
             )
         })?;
 
         let json_data: serde_json::Value = serde_json::from_str(&json_str).map_err(|e| {
             FieldError::new(
-                "Failed to parse JSON data",
+                format!("Failed to parse JSON data: {}", e),
                 graphql_value!({ "error": e.to_string() }),
             )
         })?;
@@ -1514,14 +1514,14 @@ impl Mutation {
         // Read from file
         let json_str = std::fs::read_to_string(&file_path).map_err(|e| {
             FieldError::new(
-                "Failed to read import file",
+                format!("Failed to read import file '{}': {}", file_path, e),
                 graphql_value!({ "error": e.to_string() }),
             )
         })?;
 
         let serialized: SerializedPerspective = serde_json::from_str(&json_str).map_err(|e| {
             FieldError::new(
-                "Failed to parse perspective data",
+                format!("Failed to parse perspective data: {}", e),
                 graphql_value!({ "error": e.to_string() }),
             )
         })?;
@@ -1531,7 +1531,7 @@ impl Mutation {
             .await
             .map_err(|e| {
                 FieldError::new(
-                    "Failed to import perspective",
+                    format!("Failed to import perspective: {}", e),
                     graphql_value!({ "error": e.to_string() }),
                 )
             })?;

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -5,9 +5,7 @@ use crate::{
     ai_service::AIService,
     neighbourhoods::{self, install_neighbourhood},
     perspectives::{
-        add_perspective, export_perspective, get_perspective, import_perspective,
-        perspective_instance::{PerspectiveInstance, SdnaType},
-        remove_perspective, update_perspective, SerializedPerspective,
+        self, add_perspective, export_perspective, get_perspective, import_perspective, perspective_instance::{PerspectiveInstance, SdnaType}, remove_perspective, update_perspective, SerializedPerspective
     },
     types::{AITask, DecoratedLinkExpression, Link, LinkExpression, ModelType},
 };
@@ -1266,6 +1264,8 @@ impl Mutation {
                 graphql_value!({ "error": e.to_string() }),
             )
         })?;
+
+        perspectives::initialize_from_db();
 
         Ok(result)
     }

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -1211,6 +1211,58 @@ impl Mutation {
         Ok(true)
     }
 
+    async fn runtime_export_db(
+        &self,
+        context: &RequestContext,
+        file_path: String,
+    ) -> FieldResult<bool> {
+        check_capability(&context.capabilities, &AGENT_UPDATE_CAPABILITY)?;
+        
+        let json_data = Ad4mDb::with_global_instance(|db| db.export_all_to_json())
+            .map_err(|e| FieldError::new(
+                "Failed to export database",
+                graphql_value!({ "error": e.to_string() })
+            ))?;
+
+        // Write to file
+        std::fs::write(&file_path, serde_json::to_string_pretty(&json_data)?)
+            .map_err(|e| FieldError::new(
+                "Failed to write export file",
+                graphql_value!({ "error": e.to_string() })
+            ))?;
+
+        Ok(true)
+    }
+
+    async fn runtime_import_db(
+        &self,
+        context: &RequestContext,
+        file_path: String,
+    ) -> FieldResult<bool> {
+        check_capability(&context.capabilities, &AGENT_UPDATE_CAPABILITY)?;
+
+        // Read from file
+        let json_str = std::fs::read_to_string(&file_path)
+            .map_err(|e| FieldError::new(
+                "Failed to read import file",
+                graphql_value!({ "error": e.to_string() })
+            ))?;
+
+        let json_data: serde_json::Value = serde_json::from_str(&json_str)
+            .map_err(|e| FieldError::new(
+                "Failed to parse JSON data",
+                graphql_value!({ "error": e.to_string() })
+            ))?;
+
+        Ad4mDb::with_global_instance(|db| db.import_from_json(json_data))
+            .map_err(|e| FieldError::new(
+                "Failed to import database",
+                graphql_value!({ "error": e.to_string() })
+            ))?;
+
+        Ok(true)
+    }
+
     async fn ai_add_model(
         &self,
         context: &RequestContext,

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -1261,7 +1261,7 @@ impl Mutation {
 
         Ad4mDb::with_global_instance(|db| db.import_from_json(json_data)).map_err(|e| {
             FieldError::new(
-                "Failed to import database",
+                format!("Failed to import database: {}", e),
                 graphql_value!({ "error": e.to_string() }),
             )
         })?;

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -1217,19 +1217,22 @@ impl Mutation {
         file_path: String,
     ) -> FieldResult<bool> {
         check_capability(&context.capabilities, &AGENT_UPDATE_CAPABILITY)?;
-        
-        let json_data = Ad4mDb::with_global_instance(|db| db.export_all_to_json())
-            .map_err(|e| FieldError::new(
-                "Failed to export database",
-                graphql_value!({ "error": e.to_string() })
-            ))?;
+
+        let json_data =
+            Ad4mDb::with_global_instance(|db| db.export_all_to_json()).map_err(|e| {
+                FieldError::new(
+                    "Failed to export database",
+                    graphql_value!({ "error": e.to_string() }),
+                )
+            })?;
 
         // Write to file
-        std::fs::write(&file_path, serde_json::to_string_pretty(&json_data)?)
-            .map_err(|e| FieldError::new(
+        std::fs::write(&file_path, serde_json::to_string_pretty(&json_data)?).map_err(|e| {
+            FieldError::new(
                 "Failed to write export file",
-                graphql_value!({ "error": e.to_string() })
-            ))?;
+                graphql_value!({ "error": e.to_string() }),
+            )
+        })?;
 
         Ok(true)
     }
@@ -1242,23 +1245,26 @@ impl Mutation {
         check_capability(&context.capabilities, &AGENT_UPDATE_CAPABILITY)?;
 
         // Read from file
-        let json_str = std::fs::read_to_string(&file_path)
-            .map_err(|e| FieldError::new(
+        let json_str = std::fs::read_to_string(&file_path).map_err(|e| {
+            FieldError::new(
                 "Failed to read import file",
-                graphql_value!({ "error": e.to_string() })
-            ))?;
+                graphql_value!({ "error": e.to_string() }),
+            )
+        })?;
 
-        let json_data: serde_json::Value = serde_json::from_str(&json_str)
-            .map_err(|e| FieldError::new(
+        let json_data: serde_json::Value = serde_json::from_str(&json_str).map_err(|e| {
+            FieldError::new(
                 "Failed to parse JSON data",
-                graphql_value!({ "error": e.to_string() })
-            ))?;
+                graphql_value!({ "error": e.to_string() }),
+            )
+        })?;
 
-        Ad4mDb::with_global_instance(|db| db.import_from_json(json_data))
-            .map_err(|e| FieldError::new(
+        Ad4mDb::with_global_instance(|db| db.import_from_json(json_data)).map_err(|e| {
+            FieldError::new(
                 "Failed to import database",
-                graphql_value!({ "error": e.to_string() })
-            ))?;
+                graphql_value!({ "error": e.to_string() }),
+            )
+        })?;
 
         Ok(true)
     }

--- a/rust-executor/src/perspectives/mod.rs
+++ b/rust-executor/src/perspectives/mod.rs
@@ -447,6 +447,8 @@ mod tests {
         assert_eq!(imported_links[0].author, test_link.author);
         assert_eq!(imported_links[0].data.source, test_link.data.source);
         assert_eq!(imported_links[0].proof.signature, test_link.proof.signature);
+
+        remove_perspective(&handle.uuid).await;
     }
 
     // Additional tests for other functions can be added here

--- a/tests/js/tests/runtime.ts
+++ b/tests/js/tests/runtime.ts
@@ -302,6 +302,40 @@ export default function runtimeTests(testContext: TestContext) {
             expect(match.Target).to.equal("test://target2")
         })
 
+        it("can export and import database", async () => {
+            const ad4mClient = testContext.ad4mClient!
+            const exportPath = "./tst-tmp/db_export.json"
+            const importPath = "./tst-tmp/db_import.json"
+
+            // Add some test data
+            await ad4mClient.runtime.addTrustedAgents(["test-agent-1", "test-agent-2"])
+            await ad4mClient.runtime.addFriends(["test-friend-1", "test-friend-2"])
+            
+            // Export the database
+            const exported = await ad4mClient.runtime.exportDb(exportPath)
+            expect(exported).to.be.true
+
+            // Verify export file exists
+            expect(fs.existsSync(exportPath)).to.be.true
+
+            // Clear some data
+            await ad4mClient.runtime.removeFriends(["test-friend-1", "test-friend-2"])
+            await ad4mClient.runtime.deleteTrustedAgents(["test-agent-1", "test-agent-2"])
+
+            // Import the database
+            const imported = await ad4mClient.runtime.importDb(exportPath)
+            expect(imported).to.be.true
+
+            // Verify data was restored
+            const trustedAgents = await ad4mClient.runtime.getTrustedAgents()
+            expect(trustedAgents).to.include.members(["test-agent-1", "test-agent-2"])
+
+            const friends = await ad4mClient.runtime.friends()
+            expect(friends).to.include.members(["test-friend-1", "test-friend-2"])
+
+            // Clean up test files
+            fs.unlinkSync(exportPath)
+        })
 
          
         // See comments on the imports at the top

--- a/tests/js/tests/runtime.ts
+++ b/tests/js/tests/runtime.ts
@@ -324,7 +324,29 @@ export default function runtimeTests(testContext: TestContext) {
 
             // Import the database
             const imported = await ad4mClient.runtime.importDb(exportPath)
-            expect(imported).to.be.true
+            expect(imported).to.have.property('perspectives')
+            expect(imported).to.have.property('links')
+            expect(imported).to.have.property('expressions')
+            expect(imported).to.have.property('perspectiveDiffs')
+            expect(imported).to.have.property('notifications')
+            expect(imported).to.have.property('models')
+            expect(imported).to.have.property('defaultModels')
+            expect(imported).to.have.property('tasks')
+            expect(imported).to.have.property('friends')
+            expect(imported).to.have.property('trustedAgents')
+            expect(imported).to.have.property('knownLinkLanguages')
+
+            // Each property should have the ImportStats structure
+            const checkImportStats = (stats: any) => {
+                expect(stats).to.have.property('total')
+                expect(stats).to.have.property('imported')
+                expect(stats).to.have.property('failed')
+                expect(stats).to.have.property('omitted')
+                expect(stats).to.have.property('errors')
+                expect(stats.errors).to.be.an('array')
+            }
+
+            Object.values(imported).forEach(checkImportStats)
 
             // Verify data was restored
             const trustedAgents = await ad4mClient.runtime.getTrustedAgents()

--- a/ui/src/components/Navigation.tsx
+++ b/ui/src/components/Navigation.tsx
@@ -50,12 +50,10 @@ const Navigation = ({ did, opened, setOpened }: Props) => {
         variant="tab"
       >
         <j-tab-item value="/apps">Apps</j-tab-item>
-        {expertMode && <j-tab-item value="/language">Languages</j-tab-item>}
-        {expertMode && (
-          <j-tab-item value="/perspective">Perspectives</j-tab-item>
-        )}
+        <j-tab-item value="/perspective">Perspectives</j-tab-item>
         <j-tab-item value="/ai">AI</j-tab-item>
         <j-tab-item value="/settings">Settings</j-tab-item>
+        {expertMode && <j-tab-item value="/language">Languages</j-tab-item>}
       </j-tabs>
 
       <Outlet />

--- a/ui/src/components/Settings.tsx
+++ b/ui/src/components/Settings.tsx
@@ -284,6 +284,7 @@ const Profile = (props: Props) => {
       setTimeout(() => setImportStatus(""), 3000);
     } catch (error) {
       console.error("Import failed:", error);
+      alert("Import failed: " + error);
       setImportStatus("Import failed!");
       setTimeout(() => setImportStatus(""), 3000);
     }

--- a/ui/src/components/Settings.tsx
+++ b/ui/src/components/Settings.tsx
@@ -1,9 +1,9 @@
-import { Agent, Literal } from "@coasys/ad4m";
+import { Agent, ImportResult, ImportStats, Literal } from "@coasys/ad4m";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { open } from "@tauri-apps/plugin-shell";
-import { save as dialogSave, open as dialogOpen } from "@tauri-apps/plugin-dialog";
+import { save as dialogSave, open as dialogOpen, message as dialogMessage, type MessageDialogOptions } from "@tauri-apps/plugin-dialog";
 import { useCallback, useContext, useEffect, useState } from "react";
 import QRCode from "react-qr-code";
 import { PREDICATE_FIRSTNAME, PREDICATE_LASTNAME, PREDICATE_USERNAME } from "../constants/triples";
@@ -289,14 +289,14 @@ const Profile = (props: Props) => {
             `- ${importResult.perspectives.imported} of ${importResult.perspectives.total} perspectives`,
             `- ${importResult.links.imported} of ${importResult.links.total} links`,
             `- ${importResult.expressions.imported} of ${importResult.expressions.total} expressions`,
-            `- ${importResult.perspective_diffs.imported} of ${importResult.perspective_diffs.total} perspective diffs`,
+            `- ${importResult.perspectiveDiffs.imported} of ${importResult.perspectiveDiffs.total} perspective diffs`,
             `- ${importResult.notifications.imported} of ${importResult.notifications.total} notifications`,
             `- ${importResult.models.imported} of ${importResult.models.total} models`,
-            `- ${importResult.default_models.imported} of ${importResult.default_models.total} default models`,
+            `- ${importResult.defaultModels.imported} of ${importResult.defaultModels.total} default models`,
             `- ${importResult.tasks.imported} of ${importResult.tasks.total} tasks`,
             `- ${importResult.friends.imported} of ${importResult.friends.total} friends`,
-            `- ${importResult.trusted_agents.imported} of ${importResult.trusted_agents.total} trusted agents`,
-            `- ${importResult.known_link_languages.imported} of ${importResult.known_link_languages.total} known link languages`,
+            `- ${importResult.trustedAgents.imported} of ${importResult.trustedAgents.total} trusted agents`,
+            `- ${importResult.knownLinkLanguages.imported} of ${importResult.knownLinkLanguages.total} known link languages`,
           ];
 
           // Add error summary if there are any errors

--- a/ui/src/components/Settings.tsx
+++ b/ui/src/components/Settings.tsx
@@ -382,12 +382,14 @@ const Profile = (props: Props) => {
         </j-button>
       </j-box>
       <j-box px="500" my="500">
-        <j-button onClick={handleExport} variant="ghost">
+        <j-button onClick={handleExport} full variant="ghost">
+          <j-icon size="sm" slot="start" name="download"></j-icon>
           {exportStatus || "Export Database"}
         </j-button>
       </j-box>
       <j-box px="500" my="500">
-        <j-button onClick={handleImport} variant="ghost">
+        <j-button onClick={handleImport} full variant="ghost">
+          <j-icon size="sm" slot="start" name="upload"></j-icon>
           {importStatus || "Import Database"}
         </j-button>
       </j-box>

--- a/ui/src/components/Settings.tsx
+++ b/ui/src/components/Settings.tsx
@@ -293,19 +293,13 @@ const Profile = (props: Props) => {
   return (
     <div>
       <j-box px="500" my="500">
-        <j-toggle full="" checked={expertMode} onChange={(e) => toggleExpertMode()}>
-          Advanced mode
-        </j-toggle>
-      </j-box>
-
-      <j-box px="500" my="500">
         <j-toggle
           checked={!!proxy}
           onChange={(e) => {
             e.target.checked ? setupProxy(e) : stopProxy(e);
           }}
         >
-          Proxy
+          Enable remote access via proxy
         </j-toggle>
 
         {loadingProxy && <j-spinner size="sm"></j-spinner>}
@@ -317,7 +311,7 @@ const Profile = (props: Props) => {
               <ActionButton title="QR Code" onClick={showProxyQRCode} icon="qr-code-scan" />
               <ActionButton
                 title="Open GraphQL"
-                onClick={() => open(url.replace("ws", "http"))}
+                onClick={() => open(proxy.replace("wss", "https").replace("graphql", "playground"))}
                 icon="box-arrow-up-right"
               />
             </j-flex>
@@ -326,21 +320,52 @@ const Profile = (props: Props) => {
       </j-box>
 
       <j-box px="500" my="500">
-        <j-button onClick={() => settrustedAgentModalOpen(true)} full variant="secondary">
-          <j-icon size="sm" slot="start" name="shield-check"></j-icon>
-          Show trusted agents
+        <j-button onClick={openLogs} full variant="primary">
+          <j-icon size="sm" slot="start" name="clipboard"></j-icon>
+          Show logs
         </j-button>
+      </j-box>
+
+      <j-box px="500" my="500">
+        <j-button onClick={() => setShowAgentSelection(true)} full variant="secondary">
+          <j-icon size="sm" slot="start" name="server"></j-icon>
+          Switch/create agent
+        </j-button>
+      </j-box>
+
+      <j-box px="500" my="500">
+        <j-toggle full="" checked={expertMode} onChange={(e) => toggleExpertMode()}>
+          Advanced mode
+        </j-toggle>
       </j-box>
 
       {expertMode && (
         <div>
+          <j-box px="500" my="500">
+            <j-button onClick={handleExport} full variant="ghost">
+              <j-icon size="sm" slot="start" name="download"></j-icon>
+              {exportStatus || "Export Database"}
+            </j-button>
+          </j-box>
+          <j-box px="500" my="500">
+            <j-button onClick={handleImport} full variant="ghost">
+              <j-icon size="sm" slot="start" name="upload"></j-icon>
+              {importStatus || "Import Database"}
+            </j-button>
+          </j-box>
+          <j-box px="500" my="500">
+            <j-button onClick={() => setClearAgentModalOpen(true)} full variant="ghost">
+              <j-icon size="sm" slot="start" name="trash"></j-icon>
+              Delete Agent
+            </j-button>
+          </j-box>
           <j-box px="500" my="500">
             <j-button
               onClick={() => {
                 getAgentInfo();
               }}
               full
-              variant="secondary"
+              variant="ghost"
             >
               <j-icon size="sm" slot="start" name={!copied ? "clipboard" : "clipboard-check"}></j-icon>
               Copy Holochain Agent Info(s)
@@ -353,47 +378,22 @@ const Profile = (props: Props) => {
                 setShowAddHcAgentInfos(true);
               }}
               full
-              variant="secondary"
+              variant="ghost"
             >
               <j-icon size="sm" slot="start" name="shield-check"></j-icon>
               Add Holochain Agent Info(s)
             </j-button>
           </j-box>
+          <j-box px="500" my="500">
+            <j-button onClick={() => settrustedAgentModalOpen(true)} full variant="ghost">
+              <j-icon size="sm" slot="start" name="shield-check"></j-icon>
+              Show trusted agents
+            </j-button>
+          </j-box>
+          <j-box px="500" my="500">
+          </j-box>
         </div>
       )}
-
-      <j-box px="500" my="500">
-        <j-button onClick={openLogs} full variant="secondary">
-          <j-icon size="sm" slot="start" name="clipboard"></j-icon>
-          Show logs
-        </j-button>
-      </j-box>
-
-      <j-box px="500" my="500">
-        <j-button onClick={() => setShowAgentSelection(true)} full variant="secondary">
-          <j-icon size="sm" slot="start" name="server"></j-icon>
-          Select agent
-        </j-button>
-      </j-box>
-
-      <j-box px="500" my="500">
-        <j-button onClick={() => setClearAgentModalOpen(true)} full variant="primary">
-          <j-icon size="sm" slot="start" name="trash"></j-icon>
-          Delete Agent
-        </j-button>
-      </j-box>
-      <j-box px="500" my="500">
-        <j-button onClick={handleExport} full variant="ghost">
-          <j-icon size="sm" slot="start" name="download"></j-icon>
-          {exportStatus || "Export Database"}
-        </j-button>
-      </j-box>
-      <j-box px="500" my="500">
-        <j-button onClick={handleImport} full variant="ghost">
-          <j-icon size="sm" slot="start" name="upload"></j-icon>
-          {importStatus || "Import Database"}
-        </j-button>
-      </j-box>
 
       {showAddHcAgentInfos && (
         <j-modal open={showAddHcAgentInfos} onToggle={(e: any) => setAddHcAgentInfos(e.target.open)}>


### PR DESCRIPTION
This allows us to start using ADAM and Flux productively, while still anticipating future version to have breaking changes. These exports are simple JSON files that can be read and transformed into any future DB format.

# Full DB export/import
Added ability to export and import the whole ADAM DB through the Settings UI. Writes all tables to a JSON file so it can be read by a future/incompatible version of ADAM.
![Screenshot 2025-02-20 at 13 03 06](https://github.com/user-attachments/assets/4dec2024-b96f-4482-bcc1-a5acebd3d735)


# Perspective export/import
Single perspectives can also be exported and imported. These JSON files are closer to the Perspective TS types, basically a merger of the core [Perspective](https://github.com/coasys/ad4m/blob/4cea26bc4ba3cac5e58848b945605a20243eb436/core/src/perspectives/Perspective.ts#L19) class (property `links: LinkExpression[]`, with the [PerspectiveHandle](https://github.com/coasys/ad4m/blob/4cea26bc4ba3cac5e58848b945605a20243eb436/core/src/perspectives/PerspectiveHandle.ts#L16) which holds `name`, `UUID` etc.
![Screenshot 2025-02-20 at 13 02 53](https://github.com/user-attachments/assets/5775ac91-1d5a-48cb-bbe3-71e2b5d4668b)
![Screenshot 2025-02-20 at 13 02 56](https://github.com/user-attachments/assets/c5a33064-58d0-43ae-ad47-95370d4cf4e4)
