### PR TITLE
Fix multiple synchronous addSignalHandler calls losing the first handler

### DIFF
--- a/core/src/neighbourhood/NeighbourhoodClient.ts
+++ b/core/src/neighbourhood/NeighbourhoodClient.ts
@@ -261,10 +261,10 @@ export class NeighbourhoodClient {
         let handlersForPerspective = this.#signalHandlers.get(perspectiveUUID)
         if (!handlersForPerspective) {
             handlersForPerspective = []
+            this.#signalHandlers.set(perspectiveUUID, handlersForPerspective)
             await this.subscribeToSignals(perspectiveUUID)
         }
         handlersForPerspective.push(handler)
-        this.#signalHandlers.set(perspectiveUUID, handlersForPerspective)
     }
 
     removeSignalHandler(perspectiveUUID: string, handler: TelepresenceSignalCallback): void {
@@ -273,8 +273,10 @@ export class NeighbourhoodClient {
             const index = handlersForPerspective.indexOf(handler)
             if (index > -1) {
                 handlersForPerspective.splice(index, 1)
+                if (!handlersForPerspective.length) {
+                    this.#signalHandlers.delete(perspectiveUUID)
+                }
             }
         }
-        this.#signalHandlers.set(perspectiveUUID, handlersForPerspective)
     }
 }

--- a/core/src/neighbourhood/NeighbourhoodProxy.test.ts
+++ b/core/src/neighbourhood/NeighbourhoodProxy.test.ts
@@ -6,6 +6,7 @@ import { NeighbourhoodProxy } from "./NeighbourhoodProxy";
 describe("NeighbourhoodProxy", () => {
   it("should add multiple signal handlers", async () => {
     const neighbourhoodURI = "did://123";
+
     const mockApolloClient = {
       subscribe: () => ({
         subscribe: () =>
@@ -16,18 +17,29 @@ describe("NeighbourhoodProxy", () => {
           }),
       }),
     } as any;
+
+    const neighbourhoodClient = new NeighbourhoodClient(mockApolloClient);
     const neighbourhoodProxy = new NeighbourhoodProxy(
-      new NeighbourhoodClient(mockApolloClient),
+      neighbourhoodClient,
       neighbourhoodURI
     );
-    const handler1 = (payload: LinkExpression) => {};
-    const handler2 = (payload: LinkExpression) => {};
+
+    let callbacks = 0;
+
+    const handler1 = () => {
+      callbacks++;
+    };
+    const handler2 = () => {
+      callbacks++;
+    };
 
     // Add multiple signal handlers in paralell
     const promise = neighbourhoodProxy.addSignalHandler(handler1);
     neighbourhoodProxy.addSignalHandler(handler2);
     await promise;
 
-    expect(neighbourhoodProxy["signalHandlers"].length).toBe(2);
+    neighbourhoodClient.dispatchSignal(neighbourhoodURI, true);
+
+    expect(callbacks).toBe(2);
   });
 });

--- a/core/src/neighbourhood/NeighbourhoodProxy.test.ts
+++ b/core/src/neighbourhood/NeighbourhoodProxy.test.ts
@@ -1,3 +1,4 @@
+import { ApolloClient } from "@apollo/client";
 import { LinkExpression } from "../links/Links";
 import { NeighbourhoodClient } from "./NeighbourhoodClient";
 import { NeighbourhoodProxy } from "./NeighbourhoodProxy";
@@ -6,13 +7,14 @@ describe("NeighbourhoodProxy", () => {
   it("should add multiple signal handlers", async () => {
     const neighbourhoodURI = "did://123";
     const mockApolloClient = {
-      subscribe: () => {
-        return new Promise((resolve) => {
-          setTimeout(() => {
-            resolve({ subscribe: () => {} });
-          }, 10);
-        });
-      },
+      subscribe: () => ({
+        subscribe: () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve({});
+            }, 10);
+          }),
+      }),
     } as any;
     const neighbourhoodProxy = new NeighbourhoodProxy(
       new NeighbourhoodClient(mockApolloClient),

--- a/core/src/neighbourhood/NeighbourhoodProxy.test.ts
+++ b/core/src/neighbourhood/NeighbourhoodProxy.test.ts
@@ -1,0 +1,32 @@
+import { LinkExpression } from "../links/Links";
+import { NeighbourhoodClient } from "./NeighbourhoodClient";
+import { NeighbourhoodProxy } from "./NeighbourhoodProxy";
+
+describe("NeighbourhoodProxy", () => {
+  it("should add multiple signal handlers", async () => {
+    const neighbourhoodURI = "did://123";
+    const subscribeCB = () => {};
+    const mockApolloClient = {
+      subscribe: () => {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({ subscribe: () => {} });
+          }, 10);
+        });
+      },
+    } as any;
+    const neighbourhoodProxy = new NeighbourhoodProxy(
+      new NeighbourhoodClient(mockApolloClient),
+      neighbourhoodURI
+    );
+    const handler1 = (payload: LinkExpression) => {};
+    const handler2 = (payload: LinkExpression) => {};
+
+    // Add multiple signal handlers in paralell
+    const promise = neighbourhoodProxy.addSignalHandler(handler1);
+    neighbourhoodProxy.addSignalHandler(handler2);
+    await promise;
+
+    expect(neighbourhoodProxy["signalHandlers"].length).toBe(2);
+  });
+});

--- a/core/src/neighbourhood/NeighbourhoodProxy.test.ts
+++ b/core/src/neighbourhood/NeighbourhoodProxy.test.ts
@@ -5,7 +5,6 @@ import { NeighbourhoodProxy } from "./NeighbourhoodProxy";
 describe("NeighbourhoodProxy", () => {
   it("should add multiple signal handlers", async () => {
     const neighbourhoodURI = "did://123";
-    const subscribeCB = () => {};
     const mockApolloClient = {
       subscribe: () => {
         return new Promise((resolve) => {


### PR DESCRIPTION
Upstream push of https://github.com/coasys/ad4m/pull/572