### PR TITLE
Ad4m model class name override & use of baseExpression in where queries

### DIFF
--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -387,8 +387,9 @@ export class Ad4mModel {
   }
 
   // Todo: Only return AllInstances (InstancesWithOffset, SortedInstances, & UnsortedInstances not required)
-  public static async queryToProlog(perspective: PerspectiveProxy, query: Query) {
+  public static async queryToProlog(perspective: PerspectiveProxy, query: Query, modelClassName?: string | null) {
     const { source, properties, collections, where, order, offset, limit, count } = query;
+    const className = modelClassName || (await this.getClassName(perspective));
 
     const instanceQueries = [
       buildAuthorAndTimestampQuery(),
@@ -402,7 +403,7 @@ export class Ad4mModel {
 
     const fullQuery = `
       findall([Base, Properties, Collections, Timestamp, Author], (
-        subject_class("${await this.getClassName(perspective)}", SubjectClass),
+        subject_class("${className}", SubjectClass),
         instance(SubjectClass, Base),
         ${instanceQueries.filter((q) => q).join(", ")}
       ), UnsortedInstances),
@@ -537,14 +538,15 @@ export class Ad4mModel {
     return { results, totalCount, pageSize, pageNumber };
   }
 
-  static async countQueryToProlog(perspective: PerspectiveProxy, query: Query = {}) {
+  static async countQueryToProlog(perspective: PerspectiveProxy, query: Query = {}, modelClassName?: string | null) {
     const { source, where } = query;
+    const className = modelClassName || (await this.getClassName(perspective));
     const instanceQueries = [buildAuthorAndTimestampQuery(), buildSourceQuery(source), buildWhereQuery(where)];
     const resultSetQueries = [buildCountQuery(true), buildOrderQuery(), buildOffsetQuery(), buildLimitQuery()];
 
     const fullQuery = `
       findall([Base, Properties, Collections, Timestamp, Author], (
-        subject_class("${await this.getClassName(perspective)}", SubjectClass),
+        subject_class("${className}", SubjectClass),
         instance(SubjectClass, Base),
         ${instanceQueries.filter((q) => q).join(", ")}
       ), UnsortedInstances),
@@ -820,6 +822,7 @@ export class Ad4mModel {
 export class ModelQueryBuilder<T extends Ad4mModel> {
   private perspective: PerspectiveProxy;
   private queryParams: Query = {};
+  private modelClassName: string | null = null;
   private ctor: typeof Ad4mModel;
 
   constructor(perspective: PerspectiveProxy, ctor: typeof Ad4mModel, query?: Query) {
@@ -945,6 +948,11 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
     return this;
   }
 
+  overrideModelClassName(className: string): ModelQueryBuilder<T> {
+    this.modelClassName = className;
+    return this;
+  }
+
   /**
    * Executes the query once and returns the results.
    * 
@@ -981,7 +989,7 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
    * ```
    */
   async subscribe(callback: (results: T[]) => void): Promise<T[]> {
-    const query = await this.ctor.queryToProlog(this.perspective, this.queryParams);
+    const query = await this.ctor.queryToProlog(this.perspective, this.queryParams, this.modelClassName);
     const subscription = await this.perspective.subscribeInfer(query);
 
     const processResults = async (result: AllInstancesResult) => {
@@ -1011,7 +1019,7 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
    * ```
    */
   async count(): Promise<number> {
-    const query = await this.ctor.countQueryToProlog(this.perspective, this.queryParams);
+    const query = await this.ctor.countQueryToProlog(this.perspective, this.queryParams, this.modelClassName);
     const result = await this.perspective.infer(query);
     return result?.[0]?.TotalCount || 0;
   }
@@ -1032,7 +1040,7 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
    * ```
    */
   async countSubscribe(callback: (count: number) => void): Promise<number> {
-    const query = await this.ctor.countQueryToProlog(this.perspective, this.queryParams);
+    const query = await this.ctor.countQueryToProlog(this.perspective, this.queryParams, this.modelClassName);
     const subscription = await this.perspective.subscribeInfer(query);
 
     const processResults = async (result: any) => {
@@ -1061,7 +1069,7 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
    */
   async paginate(pageSize: number, pageNumber: number): Promise<PaginationResult<T>> {
     const paginationQuery = { ...(this.queryParams || {}), limit: pageSize, offset: pageSize * (pageNumber - 1), count: true };
-    const prologQuery = await this.ctor.queryToProlog(this.perspective, paginationQuery);
+    const prologQuery = await this.ctor.queryToProlog(this.perspective, paginationQuery, this.modelClassName);
     const result = await this.perspective.infer(prologQuery);
     const { results, totalCount } = (await this.ctor.instancesFromPrologResult(this.perspective, paginationQuery, result)) as ResultsWithTotalCount<T>;
     return { results, totalCount, pageSize, pageNumber };
@@ -1090,7 +1098,7 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
     callback: (results: PaginationResult<T>) => void
   ): Promise<PaginationResult<T>> {
     const paginationQuery = { ...(this.queryParams || {}), limit: pageSize, offset: pageSize * (pageNumber - 1), count: true };
-    const prologQuery = await this.ctor.queryToProlog(this.perspective, paginationQuery);
+    const prologQuery = await this.ctor.queryToProlog(this.perspective, paginationQuery, this.modelClassName);
     const subscription = await this.perspective.subscribeInfer(prologQuery);
     
 

--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -94,7 +94,7 @@ function buildWhereQuery(where: Where = {}): string {
 
   return (Object.entries(where) as [string, WhereCondition][])
     .map(([key, value]) => {
-      const isSpecial = ["author", "timestamp"].includes(key);
+      const isSpecial = ["base", "author", "timestamp"].includes(key);
       const getter = `resolve_property(SubjectClass, Base, "${key}", Value${key}, _)`;
       // const getter = `property_getter(SubjectClass, Base, "${key}", URI), literal_from_url(URI, V, _)`;
       const field = capitalize(key);

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -2033,16 +2033,13 @@ describe("Prolog + Literals", () => {
                         @Property({
                             through: "image://data",
                             resolveLanguage: "literal",
-                            transform: (data: any) => data ? `data:image/png;base64,${data.data_base64}` : undefined,
+                            transform: (data: any) => data ? `data:image/png;base64,${data}` : undefined,
                         } as PropertyOptions)
                         image: string = "";
-
-                        @Property({
-                            through: "image://metadata",
-                            resolveLanguage: "literal",
-                            transform: (data: any) => data ? JSON.parse(data) : {},
-                        } as PropertyOptions)
-                        metadata: any = {};
+                        //TODO: having json objects as properties in our new queries breaks the JSON
+                        // construction of Prolog query results.
+                        // Need to find a way to make this work:
+                        //image: { data_base64: string } = { data_base64: "" };
                     }
 
                     // Register the ImagePost class
@@ -2050,17 +2047,15 @@ describe("Prolog + Literals", () => {
 
                     // Create a new image post
                     const post = new ImagePost(perspective!);
-                    const imageData = JSON.stringify({ data_base64: "abc123" });
-                    const metadata = { width: 100, height: 100 };
+                    const imageData = "abc123";
+                    //const imageData = { data_base64: "abc123" };
                     
                     post.image = imageData;
-                    post.metadata = JSON.stringify(metadata);
                     await post.save();
 
                     // Retrieve the post and check transformed values
                     const [retrieved] = await ImagePost.findAll(perspective!);
                     expect(retrieved.image).to.equal("data:image/png;base64,abc123");
-                    expect(retrieved.metadata).to.deep.equal(metadata);
                 });
             })
         })

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -2033,13 +2033,16 @@ describe("Prolog + Literals", () => {
                         @Property({
                             through: "image://data",
                             resolveLanguage: "literal",
-                            transform: (data: any) => data ? `data:image/png;base64,${data}` : undefined,
+                            transform: (data: any) => data ? `data:image/png;base64,${data.data_base64}` : undefined,
                         } as PropertyOptions)
                         image: string = "";
-                        //TODO: having json objects as properties in our new queries breaks the JSON
-                        // construction of Prolog query results.
-                        // Need to find a way to make this work:
-                        //image: { data_base64: string } = { data_base64: "" };
+
+                        @Property({
+                            through: "image://metadata",
+                            resolveLanguage: "literal",
+                            transform: (data: any) => data ? JSON.parse(data) : {},
+                        } as PropertyOptions)
+                        metadata: any = {};
                     }
 
                     // Register the ImagePost class
@@ -2047,15 +2050,17 @@ describe("Prolog + Literals", () => {
 
                     // Create a new image post
                     const post = new ImagePost(perspective!);
-                    const imageData = "abc123";
-                    //const imageData = { data_base64: "abc123" };
+                    const imageData = JSON.stringify({ data_base64: "abc123" });
+                    const metadata = { width: 100, height: 100 };
                     
                     post.image = imageData;
+                    post.metadata = JSON.stringify(metadata);
                     await post.save();
 
                     // Retrieve the post and check transformed values
                     const [retrieved] = await ImagePost.findAll(perspective!);
                     expect(retrieved.image).to.equal("data:image/png;base64,abc123");
+                    expect(retrieved.metadata).to.deep.equal(metadata);
                 });
             })
         })


### PR DESCRIPTION
- Option to use string name of subject class instead of full subject class definition when using ad4m model. Used in Kanban view and Table view in Flux.
- Option to use baseExpression in ad4m model where queries set up via 'base' param.