### PR TITLE
Improved perspective handling in Vue useModel hook

### DIFF
--- a/ad4m-hooks/react/src/useModel.ts
+++ b/ad4m-hooks/react/src/useModel.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
-import { PerspectiveProxy, Ad4mModel, Query, PaginationResult } from "@coasys/ad4m";
+import { PerspectiveProxy, Ad4mModel, Query, PaginationResult, ModelQueryBuilder } from "@coasys/ad4m";
 
 type Props<T extends Ad4mModel> = {
   perspective: PerspectiveProxy;
@@ -25,6 +25,7 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
   const [error, setError] = useState<string>("");
   const [pageNumber, setPageNumber] = useState(1);
   const [totalCount, setTotalCount] = useState(0);
+  let modelQuery: ModelQueryBuilder<T|Ad4mModel> | null = null;
 
   async function ensureSubject() {
     if (typeof model !== "string") await perspective.ensureSDNASubjectClass(model);
@@ -48,7 +49,11 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
 
   async function subscribeToCollection() {
     try {
-      const modelQuery =
+      if(modelQuery) {
+        modelQuery.dispose();
+      }
+
+      modelQuery =
         typeof model === "string"
           ? Ad4mModel.query(perspective, query).overrideModelClassName(model)
           : model.query(perspective, query);

--- a/ad4m-hooks/vue/src/useModel.ts
+++ b/ad4m-hooks/vue/src/useModel.ts
@@ -24,7 +24,7 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
   const error = ref<string>("");
   const pageNumber = ref(1);
   const totalCount = ref(0);
-  let modelQuery: ModelQueryBuilder<T|Ad4mModel> | null = null;
+  const modelQueryRef = ref<ModelQueryBuilder<T|Ad4mModel> | null>(null);
 
   // Handle perspective as a ref/computed or direct value
   const isPerspectiveRef = perspective && typeof perspective === "object" && "value" in perspective;
@@ -72,9 +72,9 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
         return;
       }
 
-      if (modelQuery) modelQuery.dispose();
+      if (modelQueryRef.value) modelQueryRef.value.dispose();
 
-      modelQuery =
+      modelQueryRef.value =
         typeof model === "string"
           ? Ad4mModel.query(perspectiveRef.value, query).overrideModelClassName(model)
           : model.query(perspectiveRef.value, query);
@@ -82,7 +82,7 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
       if (pageSize) {
         // Handle paginated results
         const totalPageSize = pageSize * pageNumber.value;
-        const { results, totalCount: count } = await modelQuery.paginateSubscribe(
+        const { results, totalCount: count } = await modelQueryRef.value.paginateSubscribe(
           totalPageSize,
           1,
           paginateSubscribeCallback
@@ -91,7 +91,7 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
         totalCount.value = count as number;
       } else {
         // Handle non-paginated results
-        const results = await modelQuery.subscribe((results: Ad4mModel[]) => handleNewEntires(results as T[]));
+        const results = await modelQueryRef.value.subscribe((results: Ad4mModel[]) => handleNewEntires(results as T[]));
         entries.value = includeBaseExpressions(results as T[]);
       }
     } catch (err) {

--- a/ad4m-hooks/vue/src/useModel.ts
+++ b/ad4m-hooks/vue/src/useModel.ts
@@ -24,7 +24,7 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
   const error = ref<string>("");
   const pageNumber = ref(1);
   const totalCount = ref(0);
-  const modelQueryRef = ref<ModelQueryBuilder<T|Ad4mModel> | null>(null);
+  let modelQuery: ModelQueryBuilder<T|Ad4mModel> | null = null;
 
   // Handle perspective as a ref/computed or direct value
   const isPerspectiveRef = perspective && typeof perspective === "object" && "value" in perspective;
@@ -72,9 +72,9 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
         return;
       }
 
-      if (modelQueryRef.value) modelQueryRef.value.dispose();
+      if (modelQuery) modelQuery.dispose();
 
-      modelQueryRef.value =
+      modelQuery =
         typeof model === "string"
           ? Ad4mModel.query(perspectiveRef.value, query).overrideModelClassName(model)
           : model.query(perspectiveRef.value, query);
@@ -82,7 +82,7 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
       if (pageSize) {
         // Handle paginated results
         const totalPageSize = pageSize * pageNumber.value;
-        const { results, totalCount: count } = await modelQueryRef.value.paginateSubscribe(
+        const { results, totalCount: count } = await modelQuery.paginateSubscribe(
           totalPageSize,
           1,
           paginateSubscribeCallback
@@ -91,7 +91,7 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
         totalCount.value = count as number;
       } else {
         // Handle non-paginated results
-        const results = await modelQueryRef.value.subscribe((results: Ad4mModel[]) => handleNewEntires(results as T[]));
+        const results = await modelQuery.subscribe((results: Ad4mModel[]) => handleNewEntires(results as T[]));
         entries.value = includeBaseExpressions(results as T[]);
       }
     } catch (err) {

--- a/ad4m-hooks/vue/src/useModel.ts
+++ b/ad4m-hooks/vue/src/useModel.ts
@@ -1,5 +1,5 @@
 import { ref, Ref, watch, shallowRef, ComputedRef } from "vue";
-import { PerspectiveProxy, Ad4mModel, Query, PaginationResult } from "@coasys/ad4m";
+import { PerspectiveProxy, Ad4mModel, Query, PaginationResult, ModelQueryBuilder } from "@coasys/ad4m";
 
 type Props<T extends Ad4mModel> = {
   perspective: PerspectiveProxy | ComputedRef<PerspectiveProxy | null>;
@@ -24,6 +24,7 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
   const error = ref<string>("");
   const pageNumber = ref(1);
   const totalCount = ref(0);
+  let modelQuery: ModelQueryBuilder<T|Ad4mModel> | null = null;
 
   // Handle perspective as a ref/computed or direct value
   const isPerspectiveRef = perspective && typeof perspective === "object" && "value" in perspective;
@@ -71,7 +72,11 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
         return;
       }
 
-      const modelQuery =
+      if(modelQuery) {
+        modelQuery.dispose();
+      }
+
+      modelQuery =
         typeof model === "string"
           ? Ad4mModel.query(perspectiveRef.value, query).overrideModelClassName(model)
           : model.query(perspectiveRef.value, query);

--- a/ad4m-hooks/vue/src/useModel.ts
+++ b/ad4m-hooks/vue/src/useModel.ts
@@ -24,7 +24,7 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
   const error = ref<string>("");
   const pageNumber = ref(1);
   const totalCount = ref(0);
-  let modelQuery: ModelQueryBuilder<T|Ad4mModel> | null = null;
+  const modelQueryRef = ref<ModelQueryBuilder<T|Ad4mModel> | null>(null);
 
   // Handle perspective as a ref/computed or direct value
   const isPerspectiveRef = perspective && typeof perspective === "object" && "value" in perspective;
@@ -72,11 +72,9 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
         return;
       }
 
-      if(modelQuery) {
-        modelQuery.dispose();
-      }
+      if (modelQueryRef.value) modelQueryRef.value.dispose();
 
-      modelQuery =
+      modelQueryRef.value =
         typeof model === "string"
           ? Ad4mModel.query(perspectiveRef.value, query).overrideModelClassName(model)
           : model.query(perspectiveRef.value, query);
@@ -84,7 +82,7 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
       if (pageSize) {
         // Handle paginated results
         const totalPageSize = pageSize * pageNumber.value;
-        const { results, totalCount: count } = await modelQuery.paginateSubscribe(
+        const { results, totalCount: count } = await modelQueryRef.value.paginateSubscribe(
           totalPageSize,
           1,
           paginateSubscribeCallback
@@ -93,7 +91,7 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
         totalCount.value = count as number;
       } else {
         // Handle non-paginated results
-        const results = await modelQuery.subscribe((results: Ad4mModel[]) => handleNewEntires(results as T[]));
+        const results = await modelQueryRef.value.subscribe((results: Ad4mModel[]) => handleNewEntires(results as T[]));
         entries.value = includeBaseExpressions(results as T[]);
       }
     } catch (err) {
@@ -115,7 +113,7 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
   watch(
     perspectiveRef,
     async (newPerspective, oldPerspective) => {
-      if (newPerspective !== oldPerspective) {
+      if (!oldPerspective || newPerspective?.uuid !== oldPerspective?.uuid) {
         loading.value = true;
         entries.value = [];
         if (newPerspective) {

--- a/ad4m-hooks/vue/src/useModel.ts
+++ b/ad4m-hooks/vue/src/useModel.ts
@@ -1,8 +1,8 @@
-import { ref, Ref, watch, computed, shallowRef } from "vue";
+import { ref, Ref, watch, shallowRef, ComputedRef } from "vue";
 import { PerspectiveProxy, Ad4mModel, Query, PaginationResult } from "@coasys/ad4m";
 
 type Props<T extends Ad4mModel> = {
-  perspective: PerspectiveProxy | any;
+  perspective: PerspectiveProxy | ComputedRef<PerspectiveProxy | null>;
   model: string | ((new (...args: any[]) => T) & typeof Ad4mModel);
   query?: Query;
   pageSize?: number;
@@ -24,17 +24,21 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
   const error = ref<string>("");
   const pageNumber = ref(1);
   const totalCount = ref(0);
-  const subjectEnsured = ref(false);
-  const perspectiveRef = typeof perspective === "function" ? computed(() => perspective()) : shallowRef(perspective);
 
-  async function ensureSubject() {
-    try {
-      if (typeof model !== "string") await perspectiveRef.value.ensureSDNASubjectClass(model);
-      subjectEnsured.value = true;
-    } catch (e) {
-      console.error("Failed to ensure subject:", e);
-      error.value = e instanceof Error ? e.message : String(e);
-    }
+  // Handle perspective as a ref/computed or direct value
+  const isPerspectiveRef = perspective && typeof perspective === "object" && "value" in perspective;
+  const perspectiveValue = isPerspectiveRef ? (perspective as Ref<PerspectiveProxy | null>).value : perspective;
+  const perspectiveRef = shallowRef(perspectiveValue);
+
+  // Set up a watch if perspective is a ref/computed
+  if (isPerspectiveRef) {
+    watch(
+      () => (perspective as Ref<PerspectiveProxy | null>).value,
+      (newVal) => {
+        perspectiveRef.value = newVal;
+      },
+      { immediate: true }
+    );
   }
 
   function includeBaseExpressions(entries: T[]): T[] {
@@ -44,7 +48,6 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
   }
 
   function preserveEntryReferences(oldEntries: T[], newEntries: T[]): T[] {
-    // Merge new results into old results, preserving references for optimized rendering
     const existingMap = new Map(oldEntries.map((entry) => [entry.baseExpression, entry]));
     return newEntries.map((newEntry) => existingMap.get(newEntry.baseExpression) || newEntry);
   }
@@ -62,6 +65,12 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
 
   async function subscribeToCollection() {
     try {
+      // Return early if no perspective
+      if (!perspectiveRef.value) {
+        loading.value = false;
+        return;
+      }
+
       const modelQuery =
         typeof model === "string"
           ? Ad4mModel.query(perspectiveRef.value, query).overrideModelClassName(model)
@@ -97,35 +106,35 @@ export function useModel<T extends Ad4mModel>(props: Props<T>): Result<T> {
     }
   }
 
-  // First watch perspective changes
+  // Watch for perspective changes
   watch(
     perspectiveRef,
     async (newPerspective, oldPerspective) => {
-      if (newPerspective) {
-        // Reset state for new perspective
-        if (newPerspective !== oldPerspective) {
-          loading.value = true;
-          subjectEnsured.value = false;
+      if (newPerspective !== oldPerspective) {
+        loading.value = true;
+        entries.value = [];
+        if (newPerspective) {
+          try {
+            if (typeof model !== "string") {
+              await newPerspective.ensureSDNASubjectClass(model);
+            }
+            await subscribeToCollection();
+          } finally {
+            loading.value = false;
+          }
+        } else {
+          loading.value = false;
         }
-        // Ensure subject for new perspective
-        await ensureSubject();
       }
     },
     { immediate: true }
   );
 
-  // Then watch for when subject is ensured
-  watch(
-    subjectEnsured,
-    async (newValue) => {
-      if (newValue && perspectiveRef.value) await subscribeToCollection();
-    },
-    { immediate: true }
-  );
-
-  // Also watch for query/page changes after subject is ensured
+  // Watch for query/page changes
   watch([() => JSON.stringify(query), pageNumber], async () => {
-    if (subjectEnsured.value && perspectiveRef.value) await subscribeToCollection();
+    if (perspectiveRef.value) {
+      await subscribeToCollection();
+    }
   });
 
   return { entries, loading, error, totalCount, loadMore };


### PR DESCRIPTION
The hook now accepts ComputedRef<PerspectiveProxy | null> for the perspective property so that we can pass in computed references instead of functions, enabling reactivity without triggering unnecessary new subscriptions.

The new use of the hook in a Vue component looks like this:

    const { entries: channels } = useModel({
      perspective: computed(() => data.value.perspective),
      model: Channel,
    });
    
Instead of the old pattern:

    const { entries: channels } = useModel({
      perspective: () => data.value.perspective,
      model: Channel,
    });
    
Additionally, the perspective and subject ensured watchers in the previous implementation have been merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced dynamic update logic for the `perspective` property to ensure prompt and reliable reflections of changes.
	- Improved management of the model query lifecycle, ensuring proper cleanup of existing queries before new ones are created.
	- Streamlined error handling and state management for a smoother, more stable user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->