### PR TITLE
Install missing languge during expression get

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 - Ad4mConnect detects running local ADAM agent on first open - no need to click try again [PR#570](https://github.com/coasys/ad4m/pull/570)
 - Fix multiple synchronous addSignalHandler calls losing the first handler - fixing usage of NH.sendSignal() [PR#576](https://github.com/coasys/ad4m/pull/576)
 - Fix flaky Prolog subscriptions [PR#589](https://github.com/coasys/ad4m/pull/589)
+- Install missing language during expression get [PR#594](https://github.com/coasys/ad4m/pull/594)
 
 ### Added
 - Prolog predicates needed in new Flux mention notification trigger:

--- a/executor/src/core/LanguageController.ts
+++ b/executor/src/core/LanguageController.ts
@@ -1055,7 +1055,12 @@ export default class LanguageController {
                     }
                 }
             } else {
-                const lang = this.languageForExpression(ref);
+                let lang
+                try {
+                    lang = this.languageForExpression(ref);
+                }catch(e) {
+                    lang = await this.languageByRef(ref.language);
+                }
                 if (!lang.expressionAdapter) {
                     throw Error("Language does not have an expresionAdapter!")
                 };


### PR DESCRIPTION
New languages are most likely discovered through expression URLs to that language. When an app tries to get those and we don't have that language yet, we should try to install it. The old LanguageController code was still missing this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Automatically installs any missing language during expression access, ensuring smoother operation.
	- Improved error handling with a fallback approach for retrieving required languages, enhancing overall system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->