### PR TITLE
Fix crash when creating Flux channel with all Plugins

### DIFF
--- a/rust-executor/src/prolog_service/engine.rs
+++ b/rust-executor/src/prolog_service/engine.rs
@@ -172,6 +172,12 @@ impl PrologEngine {
         Ok(())
     }
 
+
+    // There two levels of error handling here:
+    // 1. The query can fail and Prolog returns an error
+    //    This is represented as a QueryResult with an error string
+    // 2. The Prolog engine can panic and we don't have a result
+    //    This is represented with the outer Result
     pub async fn run_query(&self, query: String) -> Result<QueryResult, Error> {
         let (response_sender, response_receiver) = mpsc::channel();
         self.request_sender

--- a/rust-executor/src/prolog_service/engine.rs
+++ b/rust-executor/src/prolog_service/engine.rs
@@ -172,7 +172,6 @@ impl PrologEngine {
         Ok(())
     }
 
-
     // There two levels of error handling here:
     // 1. The query can fail and Prolog returns an error
     //    This is represented as a QueryResult with an error string

--- a/rust-executor/src/prolog_service/engine.rs
+++ b/rust-executor/src/prolog_service/engine.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use deno_core::anyhow::Error;
-use scryer_prolog::{LeafAnswer, MachineBuilder, Term};
+use scryer_prolog::MachineBuilder;
 use tokio::task;
 
 use super::types::{query_result_from_leaf_answer, QueryResult};

--- a/rust-executor/src/prolog_service/engine.rs
+++ b/rust-executor/src/prolog_service/engine.rs
@@ -26,7 +26,6 @@ pub enum PrologServiceResponse {
 
 struct SendableReceiver<T>(Arc<Mutex<mpsc::Receiver<T>>>);
 
-unsafe impl<T> Send for SendableReceiver<T> {}
 unsafe impl<T> Sync for SendableReceiver<T> {}
 
 pub struct PrologEngine {

--- a/rust-executor/src/prolog_service/engine_pool.rs
+++ b/rust-executor/src/prolog_service/engine_pool.rs
@@ -87,7 +87,12 @@ impl PrologEnginePool {
         join_all(futures).await.into_iter().collect()
     }
 
-    async fn handle_engine_error(&self, engine_idx: usize, error: impl std::fmt::Display, query: &str) -> Result<QueryResult, Error> {
+    async fn handle_engine_error(
+        &self,
+        engine_idx: usize,
+        error: impl std::fmt::Display,
+        query: &str,
+    ) -> Result<QueryResult, Error> {
         log::error!("Prolog engine error: {}", error);
         log::error!("when running query: {}", query);
         let mut engines = self.engines.write().await;

--- a/rust-executor/src/prolog_service/engine_pool.rs
+++ b/rust-executor/src/prolog_service/engine_pool.rs
@@ -129,8 +129,11 @@ impl PrologEnginePool {
         };
 
         let result = match result {
+            // Outer Result is an error -> engine panicked
             Err(e) => self.handle_engine_error(engine_idx, e, &query).await,
-            Ok(Err(e)) => self.handle_engine_error(engine_idx, e, &query).await,
+            // Inner Result is an error -> query failed
+            Ok(Err(e)) => Ok(Err(e)),
+            // Inner Result is a QueryResolution -> query succeeded
             Ok(Ok(mut result)) => {
                 // Postprocess result to replace small cache IDs with huge vector URLs
                 // In-place and async/parallel processing of all values in all matches

--- a/rust-executor/src/prolog_service/mod.rs
+++ b/rust-executor/src/prolog_service/mod.rs
@@ -134,7 +134,7 @@ mod prolog_test {
         let result = service
             .run_query(perspective_id.clone(), query)
             .await
-            .expect("Error running query");
+            .expect("no error running query");
 
         assert_eq!(
             result,
@@ -152,7 +152,7 @@ mod prolog_test {
         let result = service
             .run_query(perspective_id.clone(), query)
             .await
-            .expect("Error running query");
+            .expect("no error running query");
 
         assert_eq!(result, Ok(QueryResolution::True));
 


### PR DESCRIPTION
# Fix Flaky Crashes in PrologEngine by Handling Lazy Iterator Panics and Removing Tokio Runtime

This PR resolves flaky crashes in the PrologEngine under high-load conditions, where the application aborted due to a double panic during Scryer Prolog query execution. The issue was introduced by a Scryer Prolog update (commit 55f07af) that changed `run_query` to return a lazy iterator, deferring Prolog engine execution to the iterator’s `next()` method. Additionally, the PR improves performance by removing an unnecessary Tokio runtime from the Scryer Prolog thread.

## Root Cause
- The Scryer Prolog update made run_query return a lazy iterator, causing panics (e.g., at `src/machine/mod.rs:1204`) to occur during `collect::<Result<Vec<LeafAnswer>, Term>>` in `PrologEngine::spawn`.
- An initial panic (e.g., from allocation failure or Prolog engine error) was caught by `catch_unwind`, but a secondary panic during cleanup (e.g., dropping the iterator or Vec) triggered panic_in_cleanup, causing an abort.
- The original code used a Tokio runtime in the Scryer thread for async channels, adding overhead and complicating panic handling in the current_thread scheduler.

## Changes
- Replaced `collect` with a manual loop in `PrologEngine::spawn`, wrapping each `iterator.next()` call in `std::panic::catch_unwind` to catch panics from the Prolog engine at the source.
- Added a MAX_RESULTS limit (1,000,000) to cap Vec growth, preventing allocation failures.
- Hardened cleanup logic by safely handling mpsc::Sender errors and explicitly resetting the Machine on panic.
- Removed the Tokio runtime from the Scryer thread, replacing async channels (tokio::sync::mpsc) with synchronous ones (std::sync::mpsc) and moving async receiver logic to the caller via std::thread::spawn.
- Replaced tokio::task::spawn_blocking with std::thread::spawn for receiving responses, reducing Tokio worker thread contention.
- Added logging for query result sizes and warnings for truncated results to aid debugging.
- Fixed actual handling of panics in the engine pool to invalidate broken engine (we didn't see that error before fixing the panic catching

## Impact
- Fixes Crashes: The loop-based approach catches panics in next(), avoids collect allocation failures, and prevents secondary cleanup panics, ensuring robust query execution.
- Performance Improvement: Eliminating the Tokio runtime reduces overhead (e.g., runtime initialization, async scheduling), resulting in faster Scryer Prolog query execution.
- Better Diagnostics: Logging result counts helps identify large queries that could strain resources.

**Maintains Functionality:** Preserves the async interface for run_query and load_module_string while isolating Prolog execution.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling during query execution, ensuring that engine failures are logged and problematic engines are invalidated to prevent further issues.
  - Enhanced panic detection and error reporting for query iteration, providing clearer diagnostic messages.
  - Added a limit on query result size to prevent excessive resource use, with warnings logged when the limit is reached.

- **Refactor**
  - Switched internal communication from asynchronous to synchronous channels, resulting in more predictable and robust request processing.
  - Consolidated error handling logic for engine errors into a dedicated method for consistency and maintainability.
  - Updated query execution to process results iteratively with per-step panic handling for increased stability.

- **Chores**
  - Updated internal test imports without affecting user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->