### PR TITLE
Harden Prolog query subscription setup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,7 +31,8 @@ This project _loosely_ adheres to [Semantic Versioning](https://semver.org/spec/
 - Fix expression content escaping issue that happened with Flux messages with URLs and mentions [PR#597](https://github.com/coasys/ad4m/pull/597)
 - Fix handling of wrong passphrase during unlock (was frozen) [PR#596](https://github.com/coasys/ad4m/pull/596)
 - Fix open buttons not working on Linux by using Tauri's opener plugin [PR#599](https://github.com/coasys/ad4m/pull/599)
-
+- Harden setup of query subscriptions with delayed init handshakes in all cases and resubscribing after timeout [PR#601](https://github.com/coasys/ad4m/pull/601)
+  
 ### Added
 - Prolog predicates needed in new Flux mention notification trigger:
  - agent_did/1

--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -28,7 +28,7 @@ export type Query = {
   count?: boolean;
 };
 
-export type AllInstancesResult = { AllInstances: Ad4mModel[]; TotalCount?: number };
+export type AllInstancesResult = { AllInstances: Ad4mModel[]; TotalCount?: number; isInit?: boolean };
 export type ResultsWithTotalCount<T> = { results: T[]; totalCount?: number };
 export type PaginationResult<T> = { results: T[]; totalCount?: number; pageSize: number; pageNumber: number };
 

--- a/core/src/perspectives/PerspectiveClient.ts
+++ b/core/src/perspectives/PerspectiveClient.ts
@@ -155,7 +155,7 @@ export class PerspectiveClient {
         return JSON.parse(perspectiveQueryProlog)
     }
 
-    async subscribeQuery(uuid: string, query: string): Promise<{ subscriptionId: string, result: AllInstancesResult }> {
+    async subscribeQuery(uuid: string, query: string): Promise<{ subscriptionId: string, result: AllInstancesResult, isInit?: boolean }> {
         const { perspectiveSubscribeQuery } = unwrapApolloResult(await this.#apolloClient.mutate({
             mutation: gql`mutation perspectiveSubscribeQuery($uuid: String!, $query: String!) {
                 perspectiveSubscribeQuery(uuid: $uuid, query: $query) {
@@ -167,12 +167,17 @@ export class PerspectiveClient {
         }))
         const { subscriptionId, result } = perspectiveSubscribeQuery
         let finalResult = result;
+        let isInit = false;
+        if(finalResult.startsWith("#init#")) {
+            finalResult = finalResult.substring(6)
+            isInit = true;
+        }
         try {
-            finalResult = JSON.parse(result)
+            finalResult = JSON.parse(finalResult)
         } catch (e) {
             console.error('Error parsing perspectiveSubscribeQuery result:', e)
         }
-        return { subscriptionId, result: finalResult }
+        return { subscriptionId, result: finalResult, isInit }
     }
 
     subscribeToQueryUpdates(subscriptionId: string, onData: (result: AllInstancesResult) => void): () => void {
@@ -189,8 +194,16 @@ export class PerspectiveClient {
             next: (result) => {
                 if (result.data && result.data.perspectiveQuerySubscription) {
                     let finalResult = result.data.perspectiveQuerySubscription;
+                    let isInit = false;
+                    if(finalResult.startsWith("#init#")) {
+                        finalResult = finalResult.substring(6)
+                        isInit = true;
+                    }
                     try {
-                        finalResult = JSON.parse(result.data.perspectiveQuerySubscription)
+                        finalResult = JSON.parse(finalResult)
+                        if(isInit) {
+                            finalResult.isInit = true;
+                        }
                     } catch (e) {
                         console.error('Error parsing perspectiveQuerySubscription:', e)
                     }

--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -87,7 +87,8 @@ export class QuerySubscriptionProxy {
         this.#initialized = new Promise<boolean>((resolve, reject) => {
             // Add timeout to prevent hanging promises
             this.#initTimeoutId = setTimeout(() => {
-                reject(new Error('Subscription initialization timed out after 30 seconds'));
+                reject(new Error('Subscription initialization timed out after 30 seconds. Resubscribing...'));
+                this.subscribe();
             }, 30000); // 30 seconds timeout
             
             // Subscribe to query updates

--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -61,7 +61,7 @@ export class QuerySubscriptionProxy {
     #callbacks: Set<QueryCallback>;
     #keepaliveTimer: number;
     #unsubscribe?: () => void;
-    #latestResult: AllInstancesResult;
+    #latestResult: AllInstancesResult|null;
     #disposed: boolean = false;
     #initialized: Promise<boolean>;
     #initTimeoutId?: NodeJS.Timeout;
@@ -77,6 +77,7 @@ export class QuerySubscriptionProxy {
         this.#query = query;
         this.#client = client;
         this.#callbacks = new Set();
+        this.#latestResult = null;
     }
 
     async subscribe() {
@@ -100,6 +101,15 @@ export class QuerySubscriptionProxy {
                         this.#initTimeoutId = undefined;
                     }
                     resolve(true);
+
+                    // if the result is one of those repeated initialization results
+                    // and we got a result before, we don't notify the callbacks
+                    // so they don't get confused (we could have gotten another 
+                    // more recent result in between)
+                    if(result.isInit && this.#latestResult) {
+                        return
+                    }
+
                     this.#latestResult = result;
                     this.#notifyCallbacks(result);
                 }

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -2089,7 +2089,6 @@ impl PerspectiveInstance {
         // Send initial result after 3 delays
         let result_string = format!("#init#{}", result_string);
         for delay in [100, 500, 1000, 10000] {
-            log::info!("Sending subscription initialization update");
             self.send_subscription_update(
                 subscription_id.clone(),
                 result_string.clone(),

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -2085,13 +2085,17 @@ impl PerspectiveInstance {
             .await
             .insert(subscription_id.clone(), subscribed_query);
 
-        // Send initial result after a short delay
-        self.send_subscription_update(
-            subscription_id.clone(),
-            result_string.clone(),
-            Some(Duration::from_millis(100)),
-        )
-        .await;
+        // Send initial result after 3 delays
+        for delay in [100, 500, 1000, 10000] {
+            log::info!("Sending subscription initialization update");
+            self.send_subscription_update(
+                subscription_id.clone(),
+                result_string.clone(),
+                Some(Duration::from_millis(delay)),
+            )
+            .await;
+        }
+        
 
         Ok((subscription_id, result_string))
     }

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -2095,7 +2095,6 @@ impl PerspectiveInstance {
             )
             .await;
         }
-        
 
         Ok((subscription_id, result_string))
     }

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -2058,10 +2058,11 @@ impl PerspectiveInstance {
         if let Some(existing_id) = existing_subscription {
             let queries = self.subscribed_queries.lock().await;
             if let Some(query) = queries.get(&existing_id) {
+                let result_string = format!("#init#{}", query.last_result);
                 for delay in [100, 500, 1000] {
                     self.send_subscription_update(
                         existing_id.clone(),
-                        query.last_result.clone(),
+                        result_string.clone(),
                         Some(Duration::from_millis(delay)),
                     )
                     .await;
@@ -2086,6 +2087,7 @@ impl PerspectiveInstance {
             .insert(subscription_id.clone(), subscribed_query);
 
         // Send initial result after 3 delays
+        let result_string = format!("#init#{}", result_string);
         for delay in [100, 500, 1000, 10000] {
             log::info!("Sending subscription initialization update");
             self.send_subscription_update(

--- a/tests/js/tests/perspective.ts
+++ b/tests/js/tests/perspective.ts
@@ -861,9 +861,6 @@ export default function perspectiveTests(testContext: TestContext) {
                 expect(initialResult.length).to.equal(1)
                 expect(initialResult[0].X).to.equal('note-ipfs://Qm123')
 
-                // Wait for initialization results to be sent
-                await sleep(2000)
-
                 // Set up callback for updates
                 const updates: any[] = []
                 const unsubscribe = subscription.onResult((result: any) => {

--- a/tests/js/tests/perspective.ts
+++ b/tests/js/tests/perspective.ts
@@ -861,6 +861,9 @@ export default function perspectiveTests(testContext: TestContext) {
                 expect(initialResult.length).to.equal(1)
                 expect(initialResult[0].X).to.equal('note-ipfs://Qm123')
 
+                // Wait for initialization results to be sent
+                await sleep(2000)
+
                 // Set up callback for updates
                 const updates: any[] = []
                 const unsubscribe = subscription.onResult((result: any) => {


### PR DESCRIPTION
Harden setup of query subscriptions with delayed init handshakes in all cases and resubscribing after timeout.

Properly mark init handshake results as such and ignore in client to not get confused with early new results overlapping with delayed init result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of query subscriptions by implementing delayed initialization handshakes and automatic resubscription after timeouts.
  - Enhanced subscription setup to send multiple initialization updates at increasing intervals, reducing the chance of missed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->