### PR TITLE
Feature/fix usage of ad4m model without subclass

### DIFF
--- a/connect/package.json
+++ b/connect/package.json
@@ -61,7 +61,6 @@
     "@undecaf/barcode-detector-polyfill": "^0.9.15",
     "@undecaf/zbar-wasm": "^0.9.12",
     "auto-bind": "^5.0.1",
-    "electron": "^20.0.3",
     "esbuild-plugin-copy": "^2.1.1",
     "esbuild-plugin-replace": "^1.4.0",
     "lit": "^2.3.1"

--- a/core/package.json
+++ b/core/package.json
@@ -39,7 +39,6 @@
     "express": "4.18.2",
     "graphql": "15.7.2",
     "reflect-metadata": "^0.1.13",
-    "type-graphql": "1.1.1",
     "pako": "*",
     "base64-js": "*"
   },
@@ -53,6 +52,7 @@
     "graphql-ws": "5.12.0",
     "honkit": "^4.0.0",
     "jest": "^26.6.0",
+    "type-graphql": "1.1.1",
     "patch-package": "^8.0.0",
     "rollup": "^2.56.3",
     "ts-jest": "^26.5.6",

--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -281,6 +281,14 @@ export class Ad4mModel {
   private static classNamesByClass = new WeakMap<typeof Ad4mModel, { [perspectiveId: string]: string }>();
 
   static async getClassName(perspective: PerspectiveProxy) {
+      // Check if this is the Ad4mModel class itself or a subclass
+      const isBaseClass = this === Ad4mModel;
+  
+      // For the base Ad4mModel class, we can't use the cache
+      if (isBaseClass) {
+        return await perspective.stringOrTemplateObjectToSubjectClassName(this);
+      }
+
     // Get or create the cache for this class
     let classCache = this.classNamesByClass.get(this);
     if (!classCache) {
@@ -725,8 +733,19 @@ export class Ad4mModel {
     await this.getData();
   }
 
+  private cleanCopy() {
+    const cleanCopy = {};
+    const props = Object.entries(this);
+    for (const [key, value] of props) {
+      if (value !== undefined && value !== null) {
+        cleanCopy[key] = value;
+      }
+    }
+    return cleanCopy;
+  }
+
   private async innerUpdate(setProperties: boolean = true, batchId?: string) {
-    this.#subjectClassName = await this.#perspective.stringOrTemplateObjectToSubjectClassName(this);
+    this.#subjectClassName = await this.#perspective.stringOrTemplateObjectToSubjectClassName(this.cleanCopy());
 
     const entries = Object.entries(this);
     for (const [key, value] of entries) {
@@ -795,7 +814,7 @@ export class Ad4mModel {
    * ```
    */
   async get() {
-    this.#subjectClassName = await this.#perspective.stringOrTemplateObjectToSubjectClassName(this);
+    this.#subjectClassName = await this.#perspective.stringOrTemplateObjectToSubjectClassName(this.cleanCopy());
 
     return await this.getData();
   }

--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -737,7 +737,7 @@ export class Ad4mModel {
     const cleanCopy = {};
     const props = Object.entries(this);
     for (const [key, value] of props) {
-      if (value !== undefined && value !== null) {
+      if (value !== undefined && value !== null && key !== "author" && key !== "timestamp") {
         cleanCopy[key] = value;
       }
     }


### PR DESCRIPTION
The Kanban view in Flux uses generic subject classes referred to not by JS class, but by subject class name. We are dealing with generic Ad4mModel instances in that case. There were a few pitfalls with this, like our class name cache in Ad4mModel. Also the setXX function names in Ad4mModel interfered with our subject class detection logic. We now pass in a clean object copy without the Ad4mModel prototype.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed the "electron" dependency from the application.
  - Updated "type-graphql" to be a development-only dependency.

- **Bug Fixes**
  - Improved handling of class name determination to ensure only defined and non-null properties are considered, enhancing reliability in certain operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->