### PR TITLE
Send more inits for query subscriptions (10s - 25s)

### DIFF
--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -2059,7 +2059,7 @@ impl PerspectiveInstance {
             let queries = self.subscribed_queries.lock().await;
             if let Some(query) = queries.get(&existing_id) {
                 let result_string = format!("#init#{}", query.last_result);
-                for delay in [100, 500, 1000] {
+                for delay in [100, 500, 1000, 10000, 15000, 20000, 25000] {
                     self.send_subscription_update(
                         existing_id.clone(),
                         result_string.clone(),
@@ -2088,7 +2088,7 @@ impl PerspectiveInstance {
 
         // Send initial result after 3 delays
         let result_string = format!("#init#{}", result_string);
-        for delay in [100, 500, 1000, 10000] {
+        for delay in [100, 500, 1000, 10000, 15000, 20000, 25000] {
             self.send_subscription_update(
                 subscription_id.clone(),
                 result_string.clone(),


### PR DESCRIPTION
We are still seeing cases where query subscriptions fail to initialise and timeout. This can only happen if for some reason they missed the first initailistion response. Since we now have a way to distinguish init responses from regular ones, there is no problem with just sending more inits after longer wait periods, in order to fetch-up any query client that for any reason (maybe during loading the app was not yet there...) didn't get previous ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Extended the timing intervals for sending initial subscription updates to subscribers, resulting in updates being spaced out over a longer period. No visible changes to user interface or interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->