### PR TITLE
Set HC bootstrap server to our own relay

### DIFF
--- a/rust-executor/src/ai_service/mod.rs
+++ b/rust-executor/src/ai_service/mod.rs
@@ -340,19 +340,19 @@ impl AIService {
     // -------------------------------------
 
     fn new_candle_device() -> Device {
-        let non_accelerated_message = "Could not get accelerated Candle device. Defaulting to CPU.";
         if cfg!(feature = "cuda") {
             log::info!("Using CUDA device");
+            let non_accelerated_message =
+                "Could not get accelerated CUDA device. Defaulting to CPU.";
             Device::new_cuda(0).unwrap_or_else(|e| {
                 println!("{} {:?}", non_accelerated_message, e);
-                error!(
-                    "Couldn't get accellerated CUDA device:{} {:?}",
-                    non_accelerated_message, e
-                );
+                error!("{} {:?}", non_accelerated_message, e);
                 Device::Cpu
             })
         } else if cfg!(feature = "metal") {
             Device::new_metal(0).unwrap_or_else(|e| {
+                let non_accelerated_message =
+                    "Could not get accelerated Metal device. Defaulting to CPU.";
                 println!("{} {:?}", non_accelerated_message, e);
                 error!("{} {:?}", non_accelerated_message, e);
                 Device::Cpu

--- a/rust-executor/src/ai_service/mod.rs
+++ b/rust-executor/src/ai_service/mod.rs
@@ -342,9 +342,13 @@ impl AIService {
     fn new_candle_device() -> Device {
         let non_accelerated_message = "Could not get accelerated Candle device. Defaulting to CPU.";
         if cfg!(feature = "cuda") {
+            log::info!("Using CUDA device");
             Device::new_cuda(0).unwrap_or_else(|e| {
                 println!("{} {:?}", non_accelerated_message, e);
-                error!("{} {:?}", non_accelerated_message, e);
+                error!(
+                    "Couldn't get accellerated CUDA device:{} {:?}",
+                    non_accelerated_message, e
+                );
                 Device::Cpu
             })
         } else if cfg!(feature = "metal") {
@@ -354,6 +358,7 @@ impl AIService {
                 Device::Cpu
             })
         } else {
+            log::warn!("Using CPU candle device");
             Device::Cpu
         }
     }

--- a/rust-executor/src/config.rs
+++ b/rust-executor/src/config.rs
@@ -67,10 +67,10 @@ impl Ad4mConfig {
             self.connect_holochain = Some(false);
         }
         if self.hc_proxy_url.is_none() {
-            self.hc_proxy_url = Some("ws://relay.ad4m.dev:4433".to_string());
+            self.hc_proxy_url = Some("wss://relay.ad4m.dev:4433".to_string());
         }
         if self.hc_bootstrap_url.is_none() {
-            self.hc_bootstrap_url = Some("http://relay.ad4m.dev:4433".to_string());
+            self.hc_bootstrap_url = Some("https://relay.ad4m.dev:4433".to_string());
         }
         if self.hc_use_bootstrap.is_none() {
             self.hc_use_bootstrap = Some(true);

--- a/rust-executor/src/config.rs
+++ b/rust-executor/src/config.rs
@@ -67,10 +67,10 @@ impl Ad4mConfig {
             self.connect_holochain = Some(false);
         }
         if self.hc_proxy_url.is_none() {
-            self.hc_proxy_url = Some("wss://dev-test-bootstrap2.holochain.org".to_string());
+            self.hc_proxy_url = Some("ws://relay.ad4m.dev:4433".to_string());
         }
         if self.hc_bootstrap_url.is_none() {
-            self.hc_bootstrap_url = Some("https://dev-test-bootstrap2.holochain.org".to_string());
+            self.hc_bootstrap_url = Some("http://relay.ad4m.dev:4433".to_string());
         }
         if self.hc_use_bootstrap.is_none() {
             self.hc_use_bootstrap = Some(true);

--- a/rust-executor/src/config.rs
+++ b/rust-executor/src/config.rs
@@ -67,10 +67,10 @@ impl Ad4mConfig {
             self.connect_holochain = Some(false);
         }
         if self.hc_proxy_url.is_none() {
-            self.hc_proxy_url = Some("wss://relay.ad4m.dev:4433".to_string());
+            self.hc_proxy_url = Some("ws://relay.ad4m.dev:4433".to_string());
         }
         if self.hc_bootstrap_url.is_none() {
-            self.hc_bootstrap_url = Some("https://relay.ad4m.dev:4433".to_string());
+            self.hc_bootstrap_url = Some("http://relay.ad4m.dev:4433".to_string());
         }
         if self.hc_use_bootstrap.is_none() {
             self.hc_use_bootstrap = Some(true);

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -361,21 +361,21 @@ impl HolochainService {
             if local_config.use_bootstrap {
                 network_config.bootstrap_url = Url2::parse(local_config.bootstrap_url.as_str());
             } else {
-                network_config.bootstrap_url = Url2::parse("https://relay.ad4m.dev:4433");
+                network_config.bootstrap_url = Url2::parse("http://relay.ad4m.dev:4433");
             }
 
             if local_config.use_proxy {
                 network_config.signal_url = Url2::parse(local_config.proxy_url.as_str());
             } else {
-                network_config.signal_url = Url2::parse("wss://relay.ad4m.dev:4433");
+                network_config.signal_url = Url2::parse("ws://relay.ad4m.dev:4433");
             }
 
             //if local_config.use_local_proxy {
-            // network_config.advanced = Some(serde_json::json!({
-            //     "tx5Transport": {
-            //         "signalAllowPlainText": true,
-            //     }
-            // }));
+            network_config.advanced = Some(serde_json::json!({
+                "tx5Transport": {
+                    "signalAllowPlainText": true,
+                }
+            }));
             //}
 
             network_config.webrtc_config = Some(serde_json::json!({

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -361,21 +361,21 @@ impl HolochainService {
             if local_config.use_bootstrap {
                 network_config.bootstrap_url = Url2::parse(local_config.bootstrap_url.as_str());
             } else {
-                network_config.bootstrap_url = Url2::parse("http://relay.ad4m.dev:4433");
+                network_config.bootstrap_url = Url2::parse("https://relay.ad4m.dev:4433");
             }
 
             if local_config.use_proxy {
                 network_config.signal_url = Url2::parse(local_config.proxy_url.as_str());
             } else {
-                network_config.signal_url = Url2::parse("ws://relay.ad4m.dev:4433");
+                network_config.signal_url = Url2::parse("wss://relay.ad4m.dev:4433");
             }
 
             //if local_config.use_local_proxy {
-            network_config.advanced = Some(serde_json::json!({
-                "tx5Transport": {
-                    "signalAllowPlainText": true,
-                }
-            }));
+            // network_config.advanced = Some(serde_json::json!({
+            //     "tx5Transport": {
+            //         "signalAllowPlainText": true,
+            //     }
+            // }));
             //}
 
             network_config.webrtc_config = Some(serde_json::json!({

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -361,23 +361,22 @@ impl HolochainService {
             if local_config.use_bootstrap {
                 network_config.bootstrap_url = Url2::parse(local_config.bootstrap_url.as_str());
             } else {
-                network_config.bootstrap_url =
-                    Url2::parse("https://dev-test-bootstrap2.holochain.org");
+                network_config.bootstrap_url = Url2::parse("http://relay.ad4m.dev:4433");
             }
 
             if local_config.use_proxy {
                 network_config.signal_url = Url2::parse(local_config.proxy_url.as_str());
             } else {
-                network_config.signal_url = Url2::parse("wss://dev-test-bootstrap2.holochain.org");
+                network_config.signal_url = Url2::parse("ws://relay.ad4m.dev:4433");
             }
 
-            if local_config.use_local_proxy {
-                network_config.advanced = Some(serde_json::json!({
-                    "tx5Transport": {
-                        "signalAllowPlainText": true,
-                    }
-                }));
-            }
+            //if local_config.use_local_proxy {
+            network_config.advanced = Some(serde_json::json!({
+                "tx5Transport": {
+                    "signalAllowPlainText": true,
+                }
+            }));
+            //}
 
             network_config.webrtc_config = Some(serde_json::json!({
                 "iceServers": [


### PR DESCRIPTION
Running our own Holochain bootstrap server.

New log outputs so we know if an accelerated CUDA device was used for AI model inference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved runtime logging for device selection and error messages, clarifying the use of CUDA, Metal, or CPU devices.

- **Chores**
  - Updated default network configuration URLs for proxy and bootstrap services to new relay endpoints, affecting default connection settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->