### PR TITLE
Use batch mode inside Ad4mModel.save()

### DIFF
--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -698,6 +698,13 @@ export class Ad4mModel {
     // We use createSubject's initialValues to set properties (but not collections)
     // We then later use innerUpdate to set collections
 
+    let batchCreatedHere = false;
+    if(!batchId) {
+      batchId = await this.perspective.createBatch()
+      batchCreatedHere = true;
+    }
+    
+
     // First filter out the properties that are not collections (arrays)
     const initialValues = {};
     for (const [key, value] of Object.entries(this)) {
@@ -724,13 +731,13 @@ export class Ad4mModel {
     // Set collections
     await this.innerUpdate(false, batchId)
 
-    // If we're in batch mode, we don't need to do anything else 
-    // since the instance won't exist until batch commit
-    if (batchId) {
-      return;
+    // If we got a batchId passed in, we let the caller decide when to commit.
+    // But then we can call getData() since the instance won't exist in the perspective
+    // until the bacht is committedl
+    if (batchCreatedHere) {
+      await this.perspective.commitBatch(batchId)
+      await this.getData();
     }
-
-    await this.getData();
   }
 
   private cleanCopy() {


### PR DESCRIPTION
Creating instances of Subject Classes / Ad4mModels will always at least result in two commits or more, since the constructor must at least write one link, plus the default `source` link.

P-Diff-Sync has a fast-track method for updating the other agents via p2p remote call (instead of DHT sync) if there is only one commit difference.

So currently we never use this fast-track method.

The newly introduced batch mode can reduce an arbitrary number of link changes into one commit to the link language. Ad4mModel.save() already had an optional parameter with which the calling context could provide a batch ID, but had to initiate and commit the batch. 

Now, if no batch ID is provided, save() will create a new batch and commit it at the end, resulting in only one commit to the link language.

This PR sits on top of https://github.com/coasys/ad4m/pull/607 since it needs the deadlock fixes in there. Otherwise, extensive use of the batch mode would run into deadlocks almost certainly as seen in the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data consistency when saving by ensuring data is refreshed only after batch operations are committed.
  - Enhanced reliability when handling batch saves, distinguishing between internal and external batch management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->