### PR TITLE
Deduplicate links

### DIFF
--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -87,6 +87,20 @@ impl Ad4mDb {
              )",
             [],
         )?;
+        // Ensure we don't have duplicate link expressions and enforce uniqueness going forward
+        conn.execute(
+            "DELETE FROM link
+             WHERE id NOT IN (
+               SELECT MIN(id) FROM link
+               GROUP BY perspective, source, predicate, target, author, timestamp
+             )",
+            [],
+        )?;
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS link_unique_idx
+             ON link (perspective, source, predicate, target, author, timestamp)",
+            [],
+        )?;
 
         conn.execute(
             "CREATE TABLE IF NOT EXISTS expression (
@@ -733,7 +747,7 @@ impl Ad4mDb {
         status: &LinkStatus,
     ) -> Ad4mDbResult<()> {
         self.conn.execute(
-            "INSERT INTO link (perspective, source, predicate, target, author, timestamp, signature, key, status)
+            "INSERT OR IGNORE INTO link (perspective, source, predicate, target, author, timestamp, signature, key, status)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             params![
                 perspective_uuid,
@@ -758,7 +772,7 @@ impl Ad4mDb {
     ) -> Ad4mDbResult<()> {
         for link in links.iter() {
             self.conn.execute(
-                "INSERT INTO link (perspective, source, predicate, target, author, timestamp, signature, key, status)
+                "INSERT OR IGNORE INTO link (perspective, source, predicate, target, author, timestamp, signature, key, status)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
                 params![
                     perspective_uuid,
@@ -1640,7 +1654,7 @@ impl Ad4mDb {
                     log::debug!("Importing {} links", links.len());
                     for (link, signature, key) in links {
                         match self.conn.execute(
-                            "INSERT INTO link (perspective, source, predicate, target, author, timestamp, signature, key, status) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                            "INSERT OR IGNORE INTO link (perspective, source, predicate, target, author, timestamp, signature, key, status) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
                             params![
                                 link.perspective,
                                 link.source,

--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -891,7 +891,7 @@ impl Ad4mDb {
         perspective_uuid: &str,
     ) -> Ad4mDbResult<Vec<(LinkExpression, LinkStatus)>> {
         let mut stmt = self.conn.prepare(
-            "SELECT perspective, source, predicate, target, author, timestamp, signature, key, status FROM link WHERE perspective = ?1",
+            "SELECT perspective, source, predicate, target, author, timestamp, signature, key, status FROM link WHERE perspective = ?1 ORDER BY timestamp, source, predicate, target, author",
         )?;
         let link_iter = stmt.query_map(params![perspective_uuid], |row| {
             let status: LinkStatus =
@@ -928,7 +928,7 @@ impl Ad4mDb {
         source: &str,
     ) -> Ad4mDbResult<Vec<(LinkExpression, LinkStatus)>> {
         let mut stmt = self.conn.prepare(
-            "SELECT perspective, source, predicate, target, author, timestamp, signature, key, status FROM link WHERE perspective = ?1 AND source = ?2",
+            "SELECT perspective, source, predicate, target, author, timestamp, signature, key, status FROM link WHERE perspective = ?1 AND source = ?2 ORDER BY timestamp, predicate, target, author",
         )?;
         let link_iter = stmt.query_map(params![perspective_uuid, source], |row| {
             let status: LinkStatus =
@@ -965,7 +965,7 @@ impl Ad4mDb {
         target: &str,
     ) -> Ad4mDbResult<Vec<(LinkExpression, LinkStatus)>> {
         let mut stmt = self.conn.prepare(
-            "SELECT perspective, source, predicate, target, author, timestamp, signature, key, status FROM link WHERE perspective = ?1 AND target = ?2",
+            "SELECT perspective, source, predicate, target, author, timestamp, signature, key, status FROM link WHERE perspective = ?1 AND target = ?2 ORDER BY timestamp, source, predicate, author",
         )?;
         let link_iter = stmt.query_map(params![perspective_uuid, target], |row| {
             let status: LinkStatus =

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -2181,7 +2181,7 @@ describe("Prolog + Literals", () => {
 
                     // Verify models are updated
                     const recipesAfterUpdate = await BatchRecipe.findAll(perspective!);
-                    expect(recipesAfterUpdate[0].ingredients).to.deep.equal(["pasta", "sauce", "cheese", "garlic"]);
+                    expect(recipesAfterUpdate[0].ingredients).to.deep.equal(["cheese", "garlic", "pasta", "sauce"]);
 
                     const notesAfterUpdate = await BatchNote.findAll(perspective!);
                     expect(notesAfterUpdate[0].content).to.equal("Updated: Use fresh ingredients and add garlic");

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -2196,7 +2196,11 @@ describe("Prolog + Literals", () => {
 
                     // Verify models are updated
                     const recipesAfterUpdate = await BatchRecipe.findAll(perspective!);
-                    expect(recipesAfterUpdate[0].ingredients).to.deep.equal(["cheese", "garlic", "pasta", "sauce"]);
+                    expect(recipesAfterUpdate[0].ingredients.length).to.equal(4);
+                    expect(recipesAfterUpdate[0].ingredients.includes("pasta")).to.be.true;
+                    expect(recipesAfterUpdate[0].ingredients.includes("sauce")).to.be.true;
+                    expect(recipesAfterUpdate[0].ingredients.includes("cheese")).to.be.true;
+                    expect(recipesAfterUpdate[0].ingredients.includes("garlic")).to.be.true;
 
                     const notesAfterUpdate = await BatchNote.findAll(perspective!);
                     expect(notesAfterUpdate[0].content).to.equal("Updated: Use fresh ingredients and add garlic");

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -2196,7 +2196,7 @@ describe("Prolog + Literals", () => {
 
                     // Verify models are updated
                     const recipesAfterUpdate = await BatchRecipe.findAll(perspective!);
-                    expect(recipesAfterUpdate[0].ingredients).to.deep.equal(["pasta", "sauce", "cheese", "garlic"]);
+                    expect(recipesAfterUpdate[0].ingredients).to.deep.equal(["cheese", "garlic", "pasta", "sauce"]);
 
                     const notesAfterUpdate = await BatchNote.findAll(perspective!);
                     expect(notesAfterUpdate[0].content).to.equal("Updated: Use fresh ingredients and add garlic");

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -2181,7 +2181,7 @@ describe("Prolog + Literals", () => {
 
                     // Verify models are updated
                     const recipesAfterUpdate = await BatchRecipe.findAll(perspective!);
-                    expect(recipesAfterUpdate[0].ingredients).to.deep.equal(["cheese", "garlic", "pasta", "sauce"]);
+                    expect(recipesAfterUpdate[0].ingredients).to.deep.equal(["pasta", "sauce", "cheese", "garlic"]);
 
                     const notesAfterUpdate = await BatchNote.findAll(perspective!);
                     expect(notesAfterUpdate[0].content).to.equal("Updated: Use fresh ingredients and add garlic");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Deduplicates existing links and enforces uniqueness to prevent future duplicates.
  - Makes link insertions and imports idempotent to avoid duplicate errors.
  - Ensures deterministic ordering when listing or fetching links for consistent results.

- Refactor
  - Deduplicates additions and removals in perspective diffs to avoid redundant updates.

- Tests
  - Updated expectations and sorting to reflect deterministic link ordering.
  - Made a recipe test order-insensitive by checking contents rather than exact array order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->