### PR TITLE
Bump Holochain to 0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6193,8 +6193,8 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixt"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -7531,8 +7531,8 @@ dependencies = [
 
 [[package]]
 name = "hc_deepkey_sdk"
-version = "0.8.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.8.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "hc_deepkey_types",
  "hdk",
@@ -7543,8 +7543,8 @@ dependencies = [
 
 [[package]]
 name = "hc_deepkey_types"
-version = "0.9.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.9.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "hdi",
  "holo_hash",
@@ -7596,8 +7596,8 @@ dependencies = [
 
 [[package]]
 name = "hdi"
-version = "0.6.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.6.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "getrandom 0.2.15",
  "hdk_derive",
@@ -7614,8 +7614,8 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "getrandom 0.2.15",
  "hdi",
@@ -7633,8 +7633,8 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "darling 0.14.4",
  "heck 0.5.0",
@@ -7966,8 +7966,8 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "base64 0.22.1",
  "blake2b_simd",
@@ -7976,7 +7976,7 @@ dependencies = [
  "fixt",
  "futures",
  "holochain_serialized_bytes",
- "holochain_util 0.5.5",
+ "holochain_util 0.5.6",
  "holochain_wasmer_common",
  "kitsune2_api",
  "must_future",
@@ -7992,8 +7992,8 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -8030,9 +8030,9 @@ dependencies = [
  "holochain_state",
  "holochain_test_wasm_common",
  "holochain_timestamp",
- "holochain_trace 0.5.5",
+ "holochain_trace 0.5.6",
  "holochain_types",
- "holochain_util 0.5.5",
+ "holochain_util 0.5.6",
  "holochain_wasm_test_utils",
  "holochain_wasmer_host",
  "holochain_websocket",
@@ -8093,8 +8093,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "async-trait",
  "fixt",
@@ -8106,9 +8106,9 @@ dependencies = [
  "holochain_serialized_bytes",
  "holochain_sqlite",
  "holochain_state",
- "holochain_trace 0.5.5",
+ "holochain_trace 0.5.6",
  "holochain_types",
- "holochain_util 0.5.5",
+ "holochain_util 0.5.6",
  "holochain_zome_types",
  "kitsune2_api",
  "mockall",
@@ -8121,8 +8121,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_chc"
-version = "0.2.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.2.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "async-trait",
  "derive_more 0.99.18",
@@ -8147,15 +8147,15 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_bundle"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "anyhow",
  "clap 4.5.38",
  "futures",
  "holochain_serialized_bytes",
  "holochain_types",
- "holochain_util 0.5.5",
+ "holochain_util 0.5.6",
  "holochain_wasmer_host",
  "mr_bundle",
  "serde_yaml",
@@ -8183,8 +8183,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "cfg-if 1.0.0",
  "derive_more 0.99.18",
@@ -8193,7 +8193,7 @@ dependencies = [
  "holochain_serialized_bytes",
  "holochain_state_types",
  "holochain_types",
- "holochain_util 0.5.5",
+ "holochain_util 0.5.6",
  "holochain_zome_types",
  "indexmap 2.9.0",
  "kitsune2_api",
@@ -8210,14 +8210,14 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_config"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "ansi_term",
  "anyhow",
  "holochain_conductor_api",
  "holochain_types",
- "holochain_util 0.5.5",
+ "holochain_util 0.5.6",
  "nanoid",
  "serde",
  "serde_yaml",
@@ -8227,8 +8227,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_services"
-version = "0.4.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.4.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8238,7 +8238,7 @@ dependencies = [
  "holochain_keystore",
  "holochain_serialized_bytes",
  "holochain_types",
- "holochain_util 0.5.5",
+ "holochain_util 0.5.6",
  "mockall",
  "must_future",
  "nanoid",
@@ -8257,15 +8257,15 @@ checksum = "be0aa773b74c40ef5e4e02f414d8cbfc4e92520a93511055a3fbccc12d2dd045"
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "derive_builder",
  "holo_hash",
  "holochain_secure_primitive",
  "holochain_serialized_bytes",
  "holochain_timestamp",
- "holochain_util 0.5.5",
+ "holochain_util 0.5.6",
  "proptest",
  "proptest-derive",
  "serde",
@@ -8277,8 +8277,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "base64 0.22.1",
  "derive_more 0.99.18",
@@ -8286,7 +8286,7 @@ dependencies = [
  "holo_hash",
  "holochain_secure_primitive",
  "holochain_serialized_bytes",
- "holochain_util 0.5.5",
+ "holochain_util 0.5.6",
  "holochain_zome_types",
  "lair_keystore",
  "must_future",
@@ -8306,8 +8306,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_metrics"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "influxive",
  "opentelemetry_api",
@@ -8316,8 +8316,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "getrandom 0.2.15",
  "holochain_secure_primitive",
@@ -8326,8 +8326,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_p2p"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "async-trait",
  "blake2b_simd",
@@ -8343,7 +8343,7 @@ dependencies = [
  "holochain_sqlite",
  "holochain_state",
  "holochain_timestamp",
- "holochain_trace 0.5.5",
+ "holochain_trace 0.5.6",
  "holochain_types",
  "holochain_zome_types",
  "kitsune2",
@@ -8366,8 +8366,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_secure_primitive"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "paste",
  "serde",
@@ -8404,8 +8404,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8420,7 +8420,7 @@ dependencies = [
  "holochain_nonce",
  "holochain_serialized_bytes",
  "holochain_timestamp",
- "holochain_util 0.5.5",
+ "holochain_util 0.5.6",
  "holochain_zome_types",
  "kitsune2_api",
  "nanoid",
@@ -8447,8 +8447,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "async-recursion",
  "base64 0.22.1",
@@ -8482,8 +8482,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_state_types"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "holo_hash",
  "holochain_integrity_types",
@@ -8492,8 +8492,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "hdk",
  "holochain_serialized_bytes",
@@ -8502,8 +8502,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_timestamp"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -8530,8 +8530,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_trace"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "chrono",
  "derive_more 0.99.18",
@@ -8547,8 +8547,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8570,8 +8570,8 @@ dependencies = [
  "holochain_serialized_bytes",
  "holochain_sqlite",
  "holochain_timestamp",
- "holochain_trace 0.5.5",
- "holochain_util 0.5.5",
+ "holochain_trace 0.5.6",
+ "holochain_util 0.5.6",
  "holochain_zome_types",
  "indexmap 2.9.0",
  "isotest",
@@ -8619,8 +8619,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -8636,11 +8636,11 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_test_utils"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "holochain_types",
- "holochain_util 0.5.5",
+ "holochain_util 0.5.6",
  "strum 0.18.0",
  "strum_macros 0.18.0",
  "toml 0.8.19",
@@ -8693,8 +8693,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "async-trait",
  "futures",
@@ -8710,8 +8710,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "contrafact",
  "derive_builder",
@@ -9453,9 +9453,9 @@ dependencies = [
 
 [[package]]
 name = "influxive"
-version = "0.0.4-alpha.1"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3680518e6abe9c1d1f7d9983dcf2c4d4b3b0bcc1b34c2c02f375e9f7d467a68"
+checksum = "b6d0b6985380cf881e6b3228a6f80cddcda367def4db1789905917625a217998"
 dependencies = [
  "influxive-child-svc",
  "influxive-otel",
@@ -9464,9 +9464,9 @@ dependencies = [
 
 [[package]]
 name = "influxive-child-svc"
-version = "0.0.4-alpha.1"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73581cf719096a1d127ecd0c166eac4479fd64cc25e9950700ef2d3904e95cfd"
+checksum = "1cbd657d59c9e4ad6c37f80ac253bed584cbfe64a17802ef99724c24daa490b3"
 dependencies = [
  "hex-literal",
  "influxive-core",
@@ -9479,15 +9479,15 @@ dependencies = [
 
 [[package]]
 name = "influxive-core"
-version = "0.0.4-alpha.1"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516f0d73d7c5c0268aafc343ff95f9536dd49c29057ee2d752acd3808e7df8ce"
+checksum = "c055d67219b8b73dcb777fb46acb7b812ad83b9007af9b2713b21d663c21aeaa"
 
 [[package]]
 name = "influxive-downloader"
-version = "0.0.4-alpha.1"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8dd10c3e1416f5d99c447fa238f452f4c6353a48cff6b3be7afa17850e4bb7e"
+checksum = "db841bcd61baa5670e37b992bc3e1ad3de720f38ecc1ba68bc5e8cdaa7423817"
 dependencies = [
  "base64 0.22.1",
  "digest 0.10.7",
@@ -9507,9 +9507,9 @@ dependencies = [
 
 [[package]]
 name = "influxive-otel"
-version = "0.0.4-alpha.1"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d8e663336807ed8864618db6cb4d3c05309535323d7be429224ba7f952a282"
+checksum = "93bddd13d48687fabfcb920638f7113c4b35acddcec7eeacd54b6201c9c724c8"
 dependencies = [
  "influxive-core",
  "opentelemetry_api",
@@ -9527,9 +9527,9 @@ dependencies = [
 
 [[package]]
 name = "influxive-writer"
-version = "0.0.4-alpha.1"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ac6efbbfafec11613fc1264214a1add55c02063716f2d448080eac9097e62b"
+checksum = "1120f1a6467ee14139cca30bc0222b3593331d58a2c1b066cc29b7aae2d2daed"
 dependencies = [
  "influxdb",
  "influxive-core",
@@ -11642,13 +11642,13 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mr_bundle"
-version = "0.5.5"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.5-coasys#578c6651726d327aba9fd446248e0b8046265bdc"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "derive_more 0.99.18",
  "flate2",
  "futures",
- "holochain_util 0.5.5",
+ "holochain_util 0.5.6",
  "proptest",
  "proptest-derive",
  "reqwest 0.12.9",

--- a/rust-executor/Cargo.toml
+++ b/rust-executor/Cargo.toml
@@ -95,9 +95,9 @@ webbrowser = "0.8.12"
 holochain_cli_run_local_services = { version = "0.5.0-dev.12" }
 kitsune_p2p_types = { version = "0.5.0-dev.9" }
 kitsune2_api = "0.1.15"
-holochain = { version = "0.5.5", features = ["test_utils", "default", "backend-go-pion"], git = "https://github.com/coasys/holochain.git", branch = "0.5.5-coasys" }
-holochain_cli_bundle = { version = "0.5.5", git = "https://github.com/coasys/holochain.git", branch = "0.5.5-coasys" }
-holochain_types = { version = "0.5.5", git = "https://github.com/coasys/holochain.git", branch = "0.5.5-coasys" }
+holochain = { version = "0.5.6", features = ["test_utils", "default", "backend-go-pion"], git = "https://github.com/coasys/holochain.git", branch = "0.5.6-coasys" }
+holochain_cli_bundle = { version = "0.5.6", git = "https://github.com/coasys/holochain.git", branch = "0.5.6-coasys" }
+holochain_types = { version = "0.5.6", git = "https://github.com/coasys/holochain.git", branch = "0.5.6-coasys" }
 lair_keystore_api = { version = "0.6.1", git = "https://github.com/coasys/lair.git", branch = "0.6.1-coasys" }
 sodoken = "=0.1.0"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated Holochain-related dependencies to version 0.5.6, aligning with the latest compatible branch.
  - Incorporates upstream fixes and minor improvements for improved stability and compatibility.
  - No functional changes or user-visible behavior adjustments expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->