### PR TITLE
p-diff-sync: Add validation to ensure parent commits exist before accepting PerspectiveDiffEntryReference

### DIFF
--- a/bootstrap-languages/p-diff-sync/hc-dna/Cargo.lock
+++ b/bootstrap-languages/p-diff-sync/hc-dna/Cargo.lock
@@ -422,8 +422,8 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hdi"
-version = "0.6.2"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.2-coasys#3bd25fa4183f9ace9b26580bf8c68a08de95bd44"
+version = "0.6.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "getrandom",
  "hdk_derive",
@@ -440,8 +440,8 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.5.2"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.2-coasys#3bd25fa4183f9ace9b26580bf8c68a08de95bd44"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "getrandom",
  "hdi",
@@ -459,8 +459,8 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.5.2"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.2-coasys#3bd25fa4183f9ace9b26580bf8c68a08de95bd44"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "darling",
  "heck",
@@ -480,8 +480,8 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holo_hash"
-version = "0.5.2"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.2-coasys#3bd25fa4183f9ace9b26580bf8c68a08de95bd44"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -497,8 +497,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.5.2"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.2-coasys#3bd25fa4183f9ace9b26580bf8c68a08de95bd44"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "holo_hash",
  "holochain_secure_primitive",
@@ -513,8 +513,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.5.2"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.2-coasys#3bd25fa4183f9ace9b26580bf8c68a08de95bd44"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "getrandom",
  "holochain_secure_primitive",
@@ -523,8 +523,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_secure_primitive"
-version = "0.5.2"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.2-coasys#3bd25fa4183f9ace9b26580bf8c68a08de95bd44"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "paste",
  "serde",
@@ -534,7 +534,8 @@ dependencies = [
 [[package]]
 name = "holochain_serialized_bytes"
 version = "0.0.56"
-source = "git+https://github.com/holochain/holochain-serialization#2bad99994d89fb8e22699fd9e4f753f615d5ea74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad33bcab89bdceca5498f1b2fd5c4d1c07d35749deba965c2911494001845ac8"
 dependencies = [
  "holochain_serialized_bytes_derive",
  "rmp-serde",
@@ -548,7 +549,8 @@ dependencies = [
 [[package]]
 name = "holochain_serialized_bytes_derive"
 version = "0.0.56"
-source = "git+https://github.com/holochain/holochain-serialization#2bad99994d89fb8e22699fd9e4f753f615d5ea74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01865625f72d8b6a05487440dfce3c03b0fc83ae03bba7ed6bfbc2f6f8143d14"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -556,8 +558,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_timestamp"
-version = "0.5.2"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.2-coasys#3bd25fa4183f9ace9b26580bf8c68a08de95bd44"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "chrono",
  "serde",
@@ -565,8 +567,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.5.2"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.2-coasys#3bd25fa4183f9ace9b26580bf8c68a08de95bd44"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "cfg-if",
  "colored",
@@ -577,8 +579,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_common"
-version = "0.0.99"
-source = "git+https://github.com/coasys/holochain-wasmer.git?branch=0.0.99-coasys#2cf0208e2f78d4e487f9a1cbe1a657ff9668af1d"
+version = "0.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2246138152bef3637f773399fb7118527715f3d03bea85c442d299a518f2bfd1"
 dependencies = [
  "holochain_serialized_bytes",
  "serde",
@@ -588,8 +591,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_guest"
-version = "0.0.99"
-source = "git+https://github.com/coasys/holochain-wasmer.git?branch=0.0.99-coasys#2cf0208e2f78d4e487f9a1cbe1a657ff9668af1d"
+version = "0.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b408ee73bd97b4daeae9a420fe3c321063d0aeaeee08bbbb3f7d9ae25d6f87a4"
 dependencies = [
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
@@ -600,8 +604,8 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.5.2"
-source = "git+https://github.com/coasys/holochain.git?branch=0.5.2-coasys#3bd25fa4183f9ace9b26580bf8c68a08de95bd44"
+version = "0.5.6"
+source = "git+https://github.com/coasys/holochain.git?branch=0.5.6-coasys#864d8ebc8683fde3ca20835015beb810f143c05a"
 dependencies = [
  "derive_more",
  "holo_hash",

--- a/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/Cargo.toml
+++ b/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/Cargo.toml
@@ -22,9 +22,9 @@ itertools = "0.10.3"
 perspective_diff_sync_integrity = { path = "../perspective_diff_sync_integrity" }
 sha2 = "0.10.5"
 
-hdi = { version = "0.6.2", git = "https://github.com/coasys/holochain.git", branch = "0.5.2-coasys" }
-hdk = { version = "0.5.2", git = "https://github.com/coasys/holochain.git", branch = "0.5.2-coasys" }
-holochain_serialized_bytes = { version = "=0.0.56", git = "https://github.com/holochain/holochain-serialization"}
+hdi = { version = "0.6.6", git = "https://github.com/coasys/holochain.git", branch = "0.5.6-coasys" }
+hdk = { version = "0.5.6", git = "https://github.com/coasys/holochain.git", branch = "0.5.6-coasys" }
+holochain_serialized_bytes = "=0.0.56"
 
 [features]
 test = []

--- a/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync_integrity/Cargo.toml
+++ b/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync_integrity/Cargo.toml
@@ -13,7 +13,7 @@ derive_more = "0"
 serde = "1"
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 
-hdi = { version = "0.6.2", git = "https://github.com/coasys/holochain.git", branch = "0.5.2-coasys" }
-hdk = { version = "0.5.2", git = "https://github.com/coasys/holochain.git", branch = "0.5.2-coasys" }
-holochain_serialized_bytes = { version = "=0.0.56", git = "https://github.com/holochain/holochain-serialization"}
-holo_hash =  { version = "0.5.2", git = "https://github.com/coasys/holochain.git", branch = "0.5.2-coasys" }
+hdi = { version = "0.6.6", git = "https://github.com/coasys/holochain.git", branch = "0.5.6-coasys" }
+hdk = { version = "0.5.6", git = "https://github.com/coasys/holochain.git", branch = "0.5.6-coasys" }
+holochain_serialized_bytes = "=0.0.56"
+holo_hash =  { version = "0.5.6", git = "https://github.com/coasys/holochain.git", branch = "0.5.6-coasys" }

--- a/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync_integrity/src/lib.rs
+++ b/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync_integrity/src/lib.rs
@@ -240,10 +240,9 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
             // Only care about our PerspectiveDiffEntryReference entries
             let maybe_entry = record
                 .entry()
-                .to_app_option::<PerspectiveDiffEntryReference>()
-                .map_err(|e| wasm_error!(e))?;
+                .to_app_option::<PerspectiveDiffEntryReference>();
 
-            if let Some(pdiff_ref) = maybe_entry {
+            if let Ok(Some(pdiff_ref)) = maybe_entry {
                 if let Some(parents) = pdiff_ref.parents {
                     for parent_action_hash in parents {
                         // Ensure each declared parent exists and is valid in the source chain/DHT

--- a/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync_integrity/src/lib.rs
+++ b/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync_integrity/src/lib.rs
@@ -244,13 +244,15 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
 
             if let Ok(Some(pdiff_ref)) = maybe_entry {
                 if let Some(parents) = pdiff_ref.parents {
+                    let mut missing: Vec<AnyDhtHash> = Vec::new();
                     for parent_action_hash in parents {
                         // Ensure each declared parent exists and is valid in the source chain/DHT
-                        if must_get_valid_record(parent_action_hash).is_err() {
-                            return Ok(ValidateCallbackResult::Invalid(
-                                "Parent action not found or invalid".into(),
-                            ));
+                        if must_get_valid_record(parent_action_hash.clone()).is_err() {
+                            missing.push(parent_action_hash.into());
                         }
+                    }
+                    if !missing.is_empty() {
+                        return Ok(ValidateCallbackResult::UnresolvedDependencies(UnresolvedDependencies::Hashes(missing)));
                     }
                 }
             }

--- a/cli/mainnet_seed.json
+++ b/cli/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdgeRG79Nq4Bud9XZUyNnALA62NuqGHbEornp6qpFh9SR9"
+    "QmzSYwdaPHA3WJKSzVAi3REGhMhos9E3RNtE2Xw1PA5FUvvpvuB"
   ],
   "directMessageLanguage": "QmzSYwdob1TwkrGs5SzpS6UF2NpNBBzd3XSy2HpmaDnRPivNcE9",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/cli/mainnet_seed.json
+++ b/cli/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdePGBz4TB2fB2Zwh5YQnX9WJBwXctajWfM9UuREdFJ2LH"
+    "QmzSYwdgeRG79Nq4Bud9XZUyNnALA62NuqGHbEornp6qpFh9SR9"
   ],
   "directMessageLanguage": "QmzSYwdob1TwkrGs5SzpS6UF2NpNBBzd3XSy2HpmaDnRPivNcE9",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/cli/mainnet_seed.json
+++ b/cli/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdiuaBqw812TNcudpKwvU5U3HM9tdxWqjhkp26XEc228xe"
+    "QmzSYwdePGBz4TB2fB2Zwh5YQnX9WJBwXctajWfM9UuREdFJ2LH"
   ],
   "directMessageLanguage": "QmzSYwdob1TwkrGs5SzpS6UF2NpNBBzd3XSy2HpmaDnRPivNcE9",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/rust-executor/src/mainnet_seed.json
+++ b/rust-executor/src/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdgeRG79Nq4Bud9XZUyNnALA62NuqGHbEornp6qpFh9SR9"
+    "QmzSYwdaPHA3WJKSzVAi3REGhMhos9E3RNtE2Xw1PA5FUvvpvuB"
   ],
   "directMessageLanguage": "QmzSYwdob1TwkrGs5SzpS6UF2NpNBBzd3XSy2HpmaDnRPivNcE9",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/rust-executor/src/mainnet_seed.json
+++ b/rust-executor/src/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdePGBz4TB2fB2Zwh5YQnX9WJBwXctajWfM9UuREdFJ2LH"
+    "QmzSYwdgeRG79Nq4Bud9XZUyNnALA62NuqGHbEornp6qpFh9SR9"
   ],
   "directMessageLanguage": "QmzSYwdob1TwkrGs5SzpS6UF2NpNBBzd3XSy2HpmaDnRPivNcE9",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",

--- a/rust-executor/src/mainnet_seed.json
+++ b/rust-executor/src/mainnet_seed.json
@@ -4,7 +4,7 @@
     "did:key:z6MkvPpWxwXAnLtMcoc9sX7GEoJ96oNnQ3VcQJRLspNJfpE7"
   ],
   "knownLinkLanguages": [
-    "QmzSYwdiuaBqw812TNcudpKwvU5U3HM9tdxWqjhkp26XEc228xe"
+    "QmzSYwdePGBz4TB2fB2Zwh5YQnX9WJBwXctajWfM9UuREdFJ2LH"
   ],
   "directMessageLanguage": "QmzSYwdob1TwkrGs5SzpS6UF2NpNBBzd3XSy2HpmaDnRPivNcE9",
   "agentLanguage": "QmzSYwdZDdgxiyE8crozqbxoBP52h6ocMdDq2S2mg4ScjzVLWKQ",


### PR DESCRIPTION
Adds an integrity zome `validate` callback that enforces parent existence for `PerspectiveDiffEntryReference` entries in the p-diff-sync bootstrap language.

- **What**: Validate that all declared parent action hashes resolve to valid records.
- **Where**: `bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync_integrity/src/lib.rs`
- **How**: Use `must_get_valid_record()` during `Op::StoreRecord` to verify each parent.

### Problem
Without validation, the DHT can accept a diff that references parents which are not yet present. If an agent shares later commits in the linearized history and goes offline before earlier commits are published, peers may end up in a state where subsequent syncs never converge: newer data references missing ancestors that never arrive, causing resolution to stall.

### Solution
- Adds an integrity `validate` callback that:
  - Extracts `PerspectiveDiffEntryReference` from the `StoreRecord` op.
  - For each declared parent action hash, calls `must_get_valid_record()` to assert presence and validity.
  - Rejects the entry if any parent is missing/invalid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added runtime validation to block storing perspective-diff entries when referenced parent records are missing.

- Chores
  - Upgraded Holochain-related dependencies for compatibility and stability.
  - Switched a serialization dependency from a git source to a pinned registry version for more reliable builds.
  - Updated knownLinkLanguages hash in mainnet seed configurations (CLI and executor).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->