### PR TITLE
Set get strategy to local for all HC DNAs to avoid timeouts

### DIFF
--- a/bootstrap-languages/agent-language/hc-dna/zomes/agent_store/src/utils.rs
+++ b/bootstrap-languages/agent-language/hc-dna/zomes/agent_store/src/utils.rs
@@ -15,7 +15,7 @@ pub(crate) fn get_latest_link(base: EntryHash, tag: Option<LinkTag>) -> ExternRe
         query = query.tag_prefix(t);
     }
 
-    let profile_info = get_links(query, GetStrategy::Network)?;
+    let profile_info = get_links(query, GetStrategy::Local)?;
 
     // Find the latest
     let latest_info =

--- a/bootstrap-languages/direct-message-language/hc-dna/zomes/direct-message/src/lib.rs
+++ b/bootstrap-languages/direct-message-language/hc-dna/zomes/direct-message/src/lib.rs
@@ -215,7 +215,7 @@ pub fn fetch_inbox(_: ()) -> ExternResult<()> {
         )?
         .tag_prefix(LinkTag::new("message"));
 
-        for link in get_links(query, GetStrategy::Network)? {
+        for link in get_links(query, GetStrategy::Local)? {
             //debug!("fetch_inbox link");
             if let Some(message_entry) = get(
                 link.target

--- a/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/link_adapter/snapshots.rs
+++ b/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/link_adapter/snapshots.rs
@@ -46,7 +46,7 @@ pub fn generate_snapshot(
                 LinkTypes::Snapshot
             )?
             .tag_prefix(LinkTag::new("snapshot"));
-            let mut snapshot_links = get_links(query, GetStrategy::Network)?;
+            let mut snapshot_links = get_links(query, GetStrategy::Local)?;
             let after = get_now()?.time();
             debug!("===PerspectiveDiffSync.generate_snapshot() - Profiling: Took {} to get the snapshot links", (after - now).num_milliseconds());
             if snapshot_links.len() == 0 {

--- a/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/link_adapter/workspace.rs
+++ b/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/link_adapter/workspace.rs
@@ -668,7 +668,7 @@ impl Workspace {
             LinkTypes::Snapshot
         )?
         .tag_prefix(LinkTag::new("snapshot"));
-        let mut snapshot_links = get_links(query, GetStrategy::Network)?;
+        let mut snapshot_links = get_links(query, GetStrategy::Local)?;
 
         if snapshot_links.len() > 0 {
             let snapshot = get(

--- a/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/retriever/holochain.rs
+++ b/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/retriever/holochain.rs
@@ -172,7 +172,7 @@ pub fn get_active_agents() -> SocialContextResult<Vec<AgentPubKey>> {
         LinkTypes::Index
     )?
     .tag_prefix(LinkTag::new("active_agent"));
-    let recent_agents = get_links(query, GetStrategy::Network)?;
+    let recent_agents = get_links(query, GetStrategy::Local)?;
 
     let recent_agents = recent_agents
         .into_iter()

--- a/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/telepresence/status.rs
+++ b/bootstrap-languages/p-diff-sync/hc-dna/zomes/perspective_diff_sync/src/telepresence/status.rs
@@ -66,7 +66,7 @@ pub fn create_did_pub_key_link(did: String) -> SocialContextResult<()> {
     let agent_key = agent_info()?.agent_initial_pubkey;
     debug!("PerspectiveDiffSync.create_did_pub_key_link() agent_key: {:?}", agent_key);
     let query = LinkQuery::try_new(agent_key.clone(), LinkTypes::DidLink)?;
-    let did_links = get_links(query, GetStrategy::Network)?;
+    let did_links = get_links(query, GetStrategy::Local)?;
     debug!("PerspectiveDiffSync.create_did_pub_key_link() did_links: {:?}", did_links);
     if did_links.len() == 0 {
 
@@ -95,7 +95,7 @@ pub fn get_my_did() -> SocialContextResult<Option<String>> {
         agent_info()?.agent_initial_pubkey,
         LinkTypes::DidLink
     )?;
-    let mut did_links = get_links(query, GetStrategy::Network)?;
+    let mut did_links = get_links(query, GetStrategy::Local)?;
     if did_links.len() > 0 {
         let did = get(
             did_links
@@ -126,7 +126,7 @@ pub fn get_dids_agent_key(did: String) -> SocialContextResult<Option<AgentPubKey
         did_entry_hash,
         LinkTypes::DidLink
     )?;
-    let did_links = get_links(query, GetStrategy::Network)?;
+    let did_links = get_links(query, GetStrategy::Local)?;
     debug!("PerspectiveDiffSync.get_dids_agent_key() did_links: {:?}", did_links);
     if did_links.len() > 0 {
         let entry: EntryHash = did_links[0].target.clone().try_into().unwrap();
@@ -141,7 +141,7 @@ pub fn get_agents_did_key(agent: AgentPubKey) -> SocialContextResult<Option<Stri
         agent,
         LinkTypes::DidLink
     )?;
-    let mut did_links = get_links(query, GetStrategy::Network)?;
+    let mut did_links = get_links(query, GetStrategy::Local)?;
     if did_links.len() > 0 {
         let did = get(
             did_links


### PR DESCRIPTION
This was the old default in 0.5 and is the better choice when there is no sharding yet anyways. Otherwise would need to handle get timeouts (because node/neighbourhood that holds the data isn't online) in our zome code.