### PR TITLE
Avoid delays in Ad4mModel.save() and batch.commit()

### DIFF
--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -3219,7 +3219,6 @@ impl PerspectiveInstance {
             //log::info!("🔄 BATCH COMMIT: Starting prolog facts update - {} add, {} rem",
             //    combined_diff.additions.len(), combined_diff.removals.len());
 
-
             // Update prolog facts once for all changes and wait for completion
             self.spawn_prolog_facts_update(combined_diff.clone(), None);
             self.update_surreal_cache(&combined_diff).await;

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -3198,13 +3198,10 @@ impl PerspectiveInstance {
             //log::info!("🔄 BATCH COMMIT: Starting prolog facts update - {} add, {} rem",
             //    combined_diff.additions.len(), combined_diff.removals.len());
 
-            // Create oneshot channel for prolog facts update completion
-            let (completion_sender, completion_receiver) = tokio::sync::oneshot::channel();
 
             // Update prolog facts once for all changes and wait for completion
-            self.spawn_prolog_facts_update(combined_diff.clone(), Some(completion_sender));
+            self.spawn_prolog_facts_update(combined_diff.clone(), None);
             self.update_surreal_cache(&combined_diff).await;
-            let _ = completion_receiver.await;
 
             //log::info!("🔄 BATCH COMMIT: Prolog facts update completed in {:?}", prolog_start.elapsed());
         }

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -1229,10 +1229,14 @@ describe("Prolog + Literals", () => {
                     task1.dueDate = start;
                     await task1.save();
 
-                    // Small delay to ensure different timestamps - 5ms is enough
-                    await sleep(5);
+                    // Small delay to ensure different timestamps
+                    await sleep(10);
 
-                    const mid = new Date().getTime();
+                    let mid = new Date().getTime();
+                    // Ensure mid > start even if system clock resolution is low
+                    if (mid <= start) {
+                        mid = start + 1;
+                    }
 
                     const task2 = new TaskDue(perspective!);
                     task2.title = "Medium priority task";
@@ -1246,10 +1250,14 @@ describe("Prolog + Literals", () => {
                     task3.dueDate = mid + 2;
                     await task3.save();
 
-                    // Small delay to ensure different timestamps - 5ms is enough
-                    await sleep(5);
+                    // Small delay to ensure different timestamps
+                    await sleep(10);
 
-                    const end = new Date().getTime();
+                    let end = new Date().getTime();
+                    // Ensure end > mid even if system clock resolution is low
+                    if (end <= mid) {
+                        end = mid + 1;
+                    }
 
                     // Check all tasks are there
                     const allTasks = await TaskDue.findAll(perspective!);

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -180,13 +180,11 @@ describe("Prolog + Literals", () => {
 
                 //@ts-ignore
                 await subject.addComments(c1)
-                await sleep(100)
                 //@ts-ignore
                 expect(await subject.comments).to.deep.equal([c1])
 
                 //@ts-ignore
                 await subject.addComments(c2)
-                await sleep(100)
                 //@ts-ignore
                 expect(await subject.comments).to.deep.equal([c1, c2])
             })
@@ -396,7 +394,6 @@ describe("Prolog + Literals", () => {
                 expect(todo2).to.have.property("comments")
                 // @ts-ignore
                 await todo.setState("todo://review")
-                await sleep(1000)
                 expect(await todo.state).to.equal("todo://review")
                 expect(await todo.comments).to.be.empty
 
@@ -1232,7 +1229,8 @@ describe("Prolog + Literals", () => {
                     task1.dueDate = start;
                     await task1.save();
 
-                    await sleep(2000);
+                    // Small delay to ensure different timestamps - 5ms is enough
+                    await sleep(5);
 
                     const mid = new Date().getTime();
 
@@ -1248,7 +1246,8 @@ describe("Prolog + Literals", () => {
                     task3.dueDate = mid + 2;
                     await task3.save();
 
-                    await sleep(2000);
+                    // Small delay to ensure different timestamps - 5ms is enough
+                    await sleep(5);
 
                     const end = new Date().getTime();
 
@@ -1828,8 +1827,11 @@ describe("Prolog + Literals", () => {
                     notification1.read = false;
                     await notification1.save();
 
-                    // Wait for subscription to fire
-                    await sleep(1000);
+                    // Wait for subscription to fire with smart polling
+                    for (let i = 0; i < 20; i++) {
+                        if (updateCount >= 1) break;
+                        await sleep(50);
+                    }
                     expect(updateCount).to.equal(1);
                     expect(notifications.length).to.equal(1);
 
@@ -1840,7 +1842,10 @@ describe("Prolog + Literals", () => {
                     notification2.read = false;
                     await notification2.save();
 
-                    await sleep(1000);
+                    for (let i = 0; i < 20; i++) {
+                        if (updateCount >= 2) break;
+                        await sleep(50);
+                    }
                     expect(updateCount).to.equal(2);
                     expect(notifications.length).to.equal(2);
 
@@ -1851,7 +1856,7 @@ describe("Prolog + Literals", () => {
                     notification3.read = false;
                     await notification3.save();
 
-                    await sleep(1000);
+                    await sleep(200); // Give it time but don't wait the full second
                     // With SurrealDB we get 3 updates because we do comparison filtering in the client
                     // and not the query. So the raw query result actually is different, even though
                     // the ultimate result is the same.
@@ -1861,7 +1866,10 @@ describe("Prolog + Literals", () => {
                     // Mark notification1 as read - should trigger subscription to remove it
                     notification1.read = true;
                     await notification1.update();
-                    await sleep(1000);
+                    for (let i = 0; i < 20; i++) {
+                        if (notifications.length === 1) break;
+                        await sleep(50);
+                    }
                     expect(notifications.length).to.equal(1);
 
                     // Dispose the subscription to prevent cross-test interference


### PR DESCRIPTION
`commit_batch()` was still waiting for Prolog to be updated at the end which isn't needed anymore with SurrealDB.

But the main delay was due to the `link_language` mutex being locked in the `nh_sync_loop` but also being accessed through `has_link_language()` in every write. Now these processes are decoupled through an `RwLock`. Writing is not waiting  for the sync loop and much faster now.

Prolog-and-Literal integration tests are much faster now due to this. Some more `sleep` improvements to make this test suite even faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal concurrency handling to reduce contention and improve runtime responsiveness and stability.
* **Tests**
  * Accelerated and stabilized test suite by replacing long fixed waits with smarter polling and shorter delays, improving reliability and execution speed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->