### PR TITLE
Re-attempt surreal link additions up to 5 times if they hit read-write conflicts

### DIFF
--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -1712,7 +1712,7 @@ impl PerspectiveInstance {
 
         // Removals first
         for removal in &diff.removals {
-            retry_surreal_op(
+            Self::retry_surreal_op(
                 || self.surreal_service.remove_link(&uuid, removal),
                 &uuid,
                 removal,
@@ -1722,7 +1722,7 @@ impl PerspectiveInstance {
         }
         // Additions after
         for addition in &diff.additions {
-            retry_surreal_op(
+            Self::retry_surreal_op(
                 || self.surreal_service.add_link(&uuid, addition),
                 &uuid,
                 addition,

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -1690,9 +1690,13 @@ impl PerspectiveInstance {
                     Ok(_) => break,
                     Err(e) => {
                         let msg = format!("{}", e);
-                        if msg.contains("Failed to commit transaction due to a read or write conflict") && attempts < max_attempts {
+                        if msg.contains(
+                            "Failed to commit transaction due to a read or write conflict",
+                        ) && attempts < max_attempts
+                        {
                             attempts += 1;
-                            tokio::time::sleep(std::time::Duration::from_millis(100 * attempts)).await;
+                            tokio::time::sleep(std::time::Duration::from_millis(100 * attempts))
+                                .await;
                             continue;
                         } else {
                             log::warn!(


### PR DESCRIPTION
# Retry SurrealDB Link Addition on Read/Write Conflicts
### Summary
This PR improves the reliability of link additions to SurrealDB within the `PerspectiveInstance` by implementing a retry mechanism for transient read/write conflicts. When a `Failed to commit transaction due to a read or write conflict` error is encountered, the system will now retry the addition up to 5 times with exponential backoff.

### Motivation
SurrealDB transactions can occasionally fail due to concurrent read/write conflicts, especially under high load or rapid updates. Previously, such failures would result in lost link additions and warning logs. This change ensures that temporary conflicts do not cause data loss, improving robustness and consistency.

### Changes
- Added a retry loop to `update_surreal_cache` for link additions.
- On conflict error, retries up to 5 times, increasing the delay between attempts.
- Logs a warning only if all retries fail.
### Impact
- Reduces risk of missing links due to transient SurrealDB transaction conflicts.
- Improves data consistency for perspectives under concurrent operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of link updates by adding automatic retries with backoff for transient database conflicts. Removals are now attempted before additions, and both paths share the same retry behavior, reducing failed operations and improving overall stability and resilience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->