### PR TITLE
Add SMTP Configuration Toggle

### DIFF
--- a/rust-executor/src/config.rs
+++ b/rust-executor/src/config.rs
@@ -31,6 +31,7 @@ pub struct TlsConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SmtpConfig {
+    pub enabled: bool,
     pub host: String,
     pub port: u16,
     pub username: String,

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -619,12 +619,14 @@ impl Mutation {
         let smtp_config_opt = crate::config::SMTP_CONFIG
             .lock()
             .ok()
-            .and_then(|cfg| cfg.clone());
+            .and_then(|cfg| cfg.clone())
+            .filter(|config| config.enabled);
 
         if test_mode || smtp_config_opt.is_some() {
             // In test mode, use dummy config since send_verification_email will capture codes instead
             let smtp_config = if test_mode && smtp_config_opt.is_none() {
                 crate::config::SmtpConfig {
+                    enabled: true,
                     host: "test.localhost".to_string(),
                     port: 587,
                     username: "test".to_string(),
@@ -912,11 +914,13 @@ impl Mutation {
         let smtp_config_opt = crate::config::SMTP_CONFIG
             .lock()
             .ok()
-            .and_then(|cfg| cfg.clone());
+            .and_then(|cfg| cfg.clone())
+            .filter(|config| config.enabled);
 
         let smtp_config = if test_mode && smtp_config_opt.is_none() {
             // In test mode without SMTP config, use dummy config
             crate::config::SmtpConfig {
+                enabled: true,
                 host: "test.localhost".to_string(),
                 port: 587,
                 username: "test".to_string(),
@@ -1108,9 +1112,10 @@ impl Mutation {
             .lock()
             .ok()
             .and_then(|cfg| cfg.clone())
+            .filter(|config| config.enabled)
             .ok_or_else(|| {
                 FieldError::new(
-                    "SMTP is not configured. Please configure email settings in the launcher.",
+                    "SMTP is not configured or is disabled. Please enable email settings in the launcher.",
                     graphql_value!(null),
                 )
             })?;

--- a/ui/src-tauri/src/commands/app.rs
+++ b/ui/src-tauri/src/commands/app.rs
@@ -316,15 +316,17 @@ pub fn get_smtp_config() -> Option<SmtpConfigDto> {
 
 #[tauri::command]
 pub fn set_smtp_config(config: SmtpConfigDto) -> Result<(), String> {
-    // Validate SMTP config
-    if config.host.is_empty() {
-        return Err("SMTP host cannot be empty".to_string());
-    }
-    if config.username.is_empty() {
-        return Err("SMTP username cannot be empty".to_string());
-    }
-    if config.from_address.is_empty() {
-        return Err("SMTP from address cannot be empty".to_string());
+    // Validate SMTP config only if enabled
+    if config.enabled {
+        if config.host.is_empty() {
+            return Err("SMTP host cannot be empty".to_string());
+        }
+        if config.username.is_empty() {
+            return Err("SMTP username cannot be empty".to_string());
+        }
+        if config.from_address.is_empty() {
+            return Err("SMTP from address cannot be empty".to_string());
+        }
     }
 
     // Convert DTO to SmtpConfig (password will be encrypted on save)

--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -297,6 +297,7 @@ pub fn run() {
 
                     let smtp = multi_user_config.smtp_config.as_ref().map(|config| {
                         rust_executor::config::SmtpConfig {
+                            enabled: config.enabled,
                             host: config.host.clone(),
                             port: config.port,
                             username: config.username.clone(),

--- a/ui/src/components/Settings.tsx
+++ b/ui/src/components/Settings.tsx
@@ -114,6 +114,7 @@ const Profile = (props: Props) => {
 
   // SMTP Configuration state
   const [smtpConfig, setSmtpConfig] = useState<{
+    enabled: boolean;
     host: string;
     port: number;
     username: string;
@@ -163,6 +164,7 @@ const Profile = (props: Props) => {
       try {
         const config = await invoke<typeof smtpConfig>("get_smtp_config");
         setSmtpConfig(config || {
+          enabled: true,
           host: "",
           port: 587,
           username: "",
@@ -664,7 +666,23 @@ const Profile = (props: Props) => {
 
           {smtpConfig && (
             <>
-              {/* SMTP Host */}
+              {/* SMTP Enable/Disable Toggle */}
+              <j-box px="500" my="500">
+                <j-toggle
+                  checked={smtpConfig.enabled}
+                  onChange={(e) => {
+                    const newConfig = { ...smtpConfig, enabled: (e.target as HTMLInputElement).checked };
+                    setSmtpConfig(newConfig);
+                    handleSmtpConfigChange(newConfig);
+                  }}
+                >
+                  Enable Email/SMTP
+                </j-toggle>
+              </j-box>
+
+              {smtpConfig.enabled && (
+                <>
+                  {/* SMTP Host */}
               <j-box px="500" my="500">
                 <j-box mb="200">
                   <j-text size="500" weight="500">SMTP Host</j-text>
@@ -847,6 +865,8 @@ const Profile = (props: Props) => {
                   </j-text>
                 </j-box>
               </j-box>
+                </>
+              )}
             </>
           )}
         </>


### PR DESCRIPTION
Adds an `enabled` toggle to SMTP configuration, allowing users to temporarily disable email sending without losing their configuration settings.

  ### Changes

  **Backend:**
  - Added `enabled: bool` field to `SmtpConfig` in both `app_state.rs` and `config.rs`
  - Updated email sending logic to check `enabled` flag before sending emails
  - Modified validation to skip field checks when SMTP is disabled
  - Backward compatible: existing configs default to `enabled: true`

  **Frontend:**
  - Added toggle control in Settings UI that auto-saves on change
  - Configuration fields hidden when SMTP is disabled
  - Settings are preserved when toggling off/on

  ### Use Case

  Enables testing multi-user mode with password-only authentication without having to delete and re-enter SMTP configuration each time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SMTP enable/disable toggle in email settings for convenient control of email functionality.
  * SMTP configuration fields now conditionally display and only appear when enabled.
  * Configuration validation and error messaging updated to reflect enabled/disabled states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->