### PR TITLE
Migrate Notification System from Prolog to SurrealDB

### DIFF
--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -2993,7 +2993,7 @@ mod tests {
             app_name: "Test App".to_string(),
             app_url: "http://test.app".to_string(),
             app_icon_path: "/test/icon.png".to_string(),
-            trigger: "test-trigger".to_string(),
+            trigger: "SELECT * FROM link WHERE predicate = 'test://trigger'".to_string(),
             perspective_ids: vec![perspective1.uuid.clone()],
             webhook_url: "http://test.webhook".to_string(),
             webhook_auth: "test-auth".to_string(),
@@ -3337,7 +3337,7 @@ mod tests {
             app_name: "Test App Name".to_string(),
             app_url: "Test App URL".to_string(),
             app_icon_path: "Test App Icon Path".to_string(),
-            trigger: "Test Trigger".to_string(),
+            trigger: "SELECT * FROM link WHERE predicate = 'test://trigger'".to_string(),
             perspective_ids: vec!["Test Perspective ID".to_string()],
             webhook_url: "Test Webhook URL".to_string(),
             webhook_auth: "Test Webhook Auth".to_string(),
@@ -3360,7 +3360,7 @@ mod tests {
             test_notification.app_icon_path,
             "Test App Icon Path".to_string()
         );
-        assert_eq!(test_notification.trigger, "Test Trigger");
+        assert_eq!(test_notification.trigger, "SELECT * FROM link WHERE predicate = 'test://trigger'");
         assert_eq!(
             test_notification.perspective_ids,
             vec!["Test Perspective ID".to_string()]
@@ -3376,7 +3376,7 @@ mod tests {
             app_name: "Test App Name".to_string(),
             app_url: "Test App URL".to_string(),
             app_icon_path: "Test App Icon Path".to_string(),
-            trigger: "Test Trigger".to_string(),
+            trigger: "SELECT * FROM link WHERE predicate = 'test://updated'".to_string(),
             perspective_ids: vec!["Test Perspective ID".to_string()],
             webhook_url: "Test Webhook URL".to_string(),
             webhook_auth: "Test Webhook Auth".to_string(),

--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -3370,7 +3370,10 @@ mod tests {
             test_notification.app_icon_path,
             "Test App Icon Path".to_string()
         );
-        assert_eq!(test_notification.trigger, "SELECT * FROM link WHERE predicate = 'test://trigger'");
+        assert_eq!(
+            test_notification.trigger,
+            "SELECT * FROM link WHERE predicate = 'test://trigger'"
+        );
         assert_eq!(
             test_notification.perspective_ids,
             vec!["Test Perspective ID".to_string()]

--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -479,8 +479,8 @@ impl Ad4mDb {
 
         // Check for mutating operations
         let mutating_operations = [
-            "INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "REMOVE",
-            "DEFINE", "ALTER", "RELATE", "BEGIN", "COMMIT", "CANCEL",
+            "INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "REMOVE", "DEFINE", "ALTER", "RELATE",
+            "BEGIN", "COMMIT", "CANCEL",
         ];
 
         for operation in &mutating_operations {
@@ -572,9 +572,10 @@ impl Ad4mDb {
     ) -> Result<String, rusqlite::Error> {
         // Validate the trigger query before storing
         if let Err(e) = Self::validate_notification_query(&notification.trigger) {
-            return Err(rusqlite::Error::InvalidParameterName(
-                format!("Invalid notification query: {}", e)
-            ));
+            return Err(rusqlite::Error::InvalidParameterName(format!(
+                "Invalid notification query: {}",
+                e
+            )));
         }
 
         let id = uuid::Uuid::new_v4().to_string();
@@ -657,9 +658,10 @@ impl Ad4mDb {
     ) -> Result<bool, rusqlite::Error> {
         // Validate the trigger query before updating
         if let Err(e) = Self::validate_notification_query(&updated_notification.trigger) {
-            return Err(rusqlite::Error::InvalidParameterName(
-                format!("Invalid notification query: {}", e)
-            ));
+            return Err(rusqlite::Error::InvalidParameterName(format!(
+                "Invalid notification query: {}",
+                e
+            )));
         }
 
         let result = self.conn.execute(

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -2318,9 +2318,15 @@ impl PerspectiveInstance {
             .replace("$perspectiveId", &format!("'{}'", perspective_id));
 
         log::debug!("🔔 Notification query original: {}", query);
-        log::debug!("🔔 Notification query with context (agentDid='{}', perspectiveId='{}'): {}", agent_did, perspective_id, query_with_context);
+        log::debug!(
+            "🔔 Notification query with context (agentDid='{}', perspectiveId='{}'): {}",
+            agent_did,
+            perspective_id,
+            query_with_context
+        );
 
-        let results = self.surreal_service
+        let results = self
+            .surreal_service
             .query_links(&perspective_id, &query_with_context)
             .await
             .map_err(|e| {
@@ -2329,7 +2335,11 @@ impl PerspectiveInstance {
                     perspective_id,
                     e
                 );
-                anyhow!("Notification query failed for perspective {}: {}", perspective_id, e)
+                anyhow!(
+                    "Notification query failed for perspective {}: {}",
+                    perspective_id,
+                    e
+                )
             })?;
 
         log::debug!("🔔 Notification query results: {:?}", results);
@@ -2599,7 +2609,9 @@ impl PerspectiveInstance {
         Ok(result_map)
     }
 
-    async fn notification_trigger_snapshot(&self) -> BTreeMap<Notification, Vec<serde_json::Value>> {
+    async fn notification_trigger_snapshot(
+        &self,
+    ) -> BTreeMap<Notification, Vec<serde_json::Value>> {
         self.calc_notification_trigger_matches()
             .await
             .unwrap_or_else(|e| {
@@ -2621,9 +2633,9 @@ impl PerspectiveInstance {
                         after_matches
                             .iter()
                             .filter(|after_match| {
-                                !before_matches.iter().any(|before_match| {
-                                    before_match == *after_match
-                                })
+                                !before_matches
+                                    .iter()
+                                    .any(|before_match| before_match == *after_match)
                             })
                             .cloned()
                             .collect()
@@ -2648,8 +2660,8 @@ impl PerspectiveInstance {
         for (notification, matches) in match_map {
             if !matches.is_empty() {
                 // Convert matches to JSON string
-                let trigger_match = serde_json::to_string(&matches)
-                    .unwrap_or_else(|_| "[]".to_string());
+                let trigger_match =
+                    serde_json::to_string(&matches).unwrap_or_else(|_| "[]".to_string());
 
                 let payload = TriggeredNotification {
                     notification: notification.clone(),

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -15,7 +15,7 @@ use crate::languages::language::Language;
 use crate::languages::LanguageController;
 use crate::perspectives::utils::{prolog_get_first_binding, prolog_value_to_json_string};
 use crate::prolog_service::get_prolog_service;
-use crate::prolog_service::types::{QueryMatch, QueryResolution};
+use crate::prolog_service::types::QueryResolution;
 use crate::prolog_service::PrologService;
 use crate::prolog_service::{
     engine_pool::FILTERING_THRESHOLD, DEFAULT_POOL_SIZE, DEFAULT_POOL_SIZE_WITH_FILTERING,

--- a/rust-executor/src/surreal_service/mod.rs
+++ b/rust-executor/src/surreal_service/mod.rs
@@ -321,6 +321,76 @@ impl SurrealDBService {
                     return url;
                 };
             };
+
+            DEFINE FUNCTION IF NOT EXISTS fn::strip_html($html: option<string>) {
+                RETURN function($html) {
+                    const [html] = arguments;
+
+                    if (!html || typeof html !== 'string') {
+                        return html;
+                    }
+
+                    // Remove HTML tags using regex
+                    return html.replace(/<[^>]*>/g, '');
+                };
+            };
+
+            DEFINE FUNCTION IF NOT EXISTS fn::json_path($obj: option<record>, $path: option<string>) {
+                RETURN function($obj, $path) {
+                    const [obj, path] = arguments;
+
+                    if (!obj || !path || typeof path !== 'string') {
+                        return null;
+                    }
+
+                    // Split path by dots and traverse object
+                    const parts = path.split('.');
+                    let current = obj;
+
+                    for (const part of parts) {
+                        if (current && typeof current === 'object' && part in current) {
+                            current = current[part];
+                        } else {
+                            return null;
+                        }
+                    }
+
+                    return current;
+                };
+            };
+
+            DEFINE FUNCTION IF NOT EXISTS fn::contains($str: option<string>, $substring: option<string>) {
+                RETURN function($str, $substring) {
+                    const [str, substring] = arguments;
+                    //console.log('🔍 fn::contains input - str:', str, 'substring:', substring);
+
+                    if (!str || !substring || typeof str !== 'string' || typeof substring !== 'string') {
+                        //console.log('🔍 fn::contains: invalid types, returning false');
+                        return false;
+                    }
+
+                    const result = str.includes(substring);
+                    //console.log('🔍 fn::contains result:', result);
+                    return result;
+                };
+            };
+
+            DEFINE FUNCTION IF NOT EXISTS fn::regex_match($str: option<string>, $pattern: option<string>) {
+                RETURN function($str, $pattern) {
+                    const [str, pattern] = arguments;
+
+                    if (!str || !pattern || typeof str !== 'string' || typeof pattern !== 'string') {
+                        return false;
+                    }
+
+                    try {
+                        const regex = new RegExp(pattern);
+                        return regex.test(str);
+                    } catch (e) {
+                        return false;
+                    }
+                };
+            };
             ",
         )
         .await?;

--- a/tests/js/tests/runtime.ts
+++ b/tests/js/tests/runtime.ts
@@ -157,7 +157,7 @@ export default function runtimeTests(testContext: TestContext) {
                 appName: "Test App Name",
                 appUrl: "Test App URL",
                 appIconPath: "Test App Icon Path",
-                trigger: "Test Trigger",
+                trigger: "SELECT * FROM link WHERE predicate = 'test://never-matches'",
                 perspectiveIds: ["Test Perspective ID"],
                 webhookUrl: "Test Webhook URL",
                 webhookAuth: "Test Webhook Auth"
@@ -174,14 +174,16 @@ export default function runtimeTests(testContext: TestContext) {
                 if (exception.type === ExceptionType.InstallNotificationRequest) {
                     const requestedNotification = JSON.parse(exception.addon);
 
-                    expect(requestedNotification.description).to.equal(notification.description);
-                    expect(requestedNotification.appName).to.equal(notification.appName);
-                    expect(requestedNotification.appUrl).to.equal(notification.appUrl);
-                    expect(requestedNotification.appIconPath).to.equal(notification.appIconPath);
-                    expect(requestedNotification.trigger).to.equal(notification.trigger);
-                    expect(requestedNotification.perspectiveIds).to.eql(notification.perspectiveIds);
-                    expect(requestedNotification.webhookUrl).to.equal(notification.webhookUrl);
-                    expect(requestedNotification.webhookAuth).to.equal(notification.webhookAuth);
+                    // Only check assertions for THIS test's notification
+                    if (requestedNotification.description === notification.description) {
+                        expect(requestedNotification.appName).to.equal(notification.appName);
+                        expect(requestedNotification.appUrl).to.equal(notification.appUrl);
+                        expect(requestedNotification.appIconPath).to.equal(notification.appIconPath);
+                        expect(requestedNotification.trigger).to.equal(notification.trigger);
+                        expect(requestedNotification.perspectiveIds).to.eql(notification.perspectiveIds);
+                        expect(requestedNotification.webhookUrl).to.equal(notification.webhookUrl);
+                        expect(requestedNotification.webhookAuth).to.equal(notification.webhookAuth);
+                    }
                     // Automatically resolve without needing to manually manage a Promise
                     return null;
                 }
@@ -215,7 +217,7 @@ export default function runtimeTests(testContext: TestContext) {
                 appName: "Test App Name",
                 appUrl: "Test App URL",
                 appIconPath: "Test App Icon Path",
-                trigger: "Test Trigger",
+                trigger: "SELECT * FROM link WHERE predicate = 'test://updated'",
                 perspectiveIds: ["Test Perspective ID"],
                 webhookUrl: "Test Webhook URL",
                 webhookAuth: "Test Webhook Auth"
@@ -235,8 +237,7 @@ export default function runtimeTests(testContext: TestContext) {
             expect(removed).to.be.true
         })
 
-        // TODO: make notifications work without prolog
-        it.skip("can trigger notifications", async () => {
+        it("can trigger notifications", async () => {
             const ad4mClient = testContext.ad4mClient!
 
             let triggerPredicate = "ad4m://notification"
@@ -249,7 +250,7 @@ export default function runtimeTests(testContext: TestContext) {
                 appName: "ADAM tests",
                 appUrl: "Test App URL",
                 appIconPath: "Test App Icon Path",
-                trigger: `triple(Source, "${triggerPredicate}", Target)`,
+                trigger: `SELECT source, target, predicate FROM link WHERE predicate = '${triggerPredicate}'`,
                 perspectiveIds: [notificationPerspective.uuid],
                 webhookUrl: "Test Webhook URL",
                 webhookAuth: "Test Webhook Auth"
@@ -285,9 +286,9 @@ export default function runtimeTests(testContext: TestContext) {
             expect(triggerMatch.length).to.equal(1)
             let match = triggerMatch[0]
             //@ts-ignore
-            expect(match.Source).to.equal("test://source")
+            expect(match.source).to.equal("test://source")
             //@ts-ignore
-            expect(match.Target).to.equal("test://target1")
+            expect(match.target).to.equal("test://target1")
 
             // Ensuring we don't get old data on a new trigger
             await notificationPerspective.add(new Link({source: "test://source", predicate: triggerPredicate, target: "test://target2"}))
@@ -298,9 +299,64 @@ export default function runtimeTests(testContext: TestContext) {
             expect(triggerMatch.length).to.equal(1)
             match = triggerMatch[0]
             //@ts-ignore
-            expect(match.Source).to.equal("test://source")
+            expect(match.source).to.equal("test://source")
             //@ts-ignore
-            expect(match.Target).to.equal("test://target2")
+            expect(match.target).to.equal("test://target2")
+        })
+
+        it("can detect mentions in notifications (Flux example)", async () => {
+            const ad4mClient = testContext.ad4mClient!
+            const agentStatus = await ad4mClient.agent.status()
+            const agentDid = agentStatus.did
+
+            let notificationPerspective = await ad4mClient.perspective.add("flux mention test")
+
+            const notification: NotificationInput = {
+                description: "You were mentioned in a message",
+                appName: "Flux Mentions",
+                appUrl: "https://flux.app",
+                appIconPath: "/flux-icon.png",
+                // Use context variable $agentDid, fn::parse_literal and fn::contains functions
+                trigger: `SELECT source, fn::parse_literal(target) as target, predicate FROM link WHERE predicate = 'rdf://content' AND fn::contains(fn::parse_literal(target), $agentDid)`,
+                perspectiveIds: [notificationPerspective.uuid],
+                webhookUrl: "https://test.webhook",
+                webhookAuth: "test-auth"
+            }
+
+            const notificationId = await ad4mClient.runtime.requestInstallNotification(notification);
+            await sleep(1000)
+            const granted = await ad4mClient.runtime.grantNotification(notificationId)
+            expect(granted).to.be.true
+
+            const mockFunction = sinon.stub();
+            await ad4mClient.runtime.addNotificationTriggeredCallback(mockFunction)
+
+            // Add a message that doesn't mention the agent
+            await notificationPerspective.add(new Link({
+                source: "message://1",
+                predicate: "rdf://content",
+                target: "literal://string:Hello%20world"
+            }))
+            await sleep(2000)
+            expect(mockFunction.called).to.be.false
+
+            // Add a message that mentions the agent
+            await notificationPerspective.add(new Link({
+                source: "message://2",
+                predicate: "rdf://content",
+                target: `literal://string:Hello%20${encodeURIComponent(agentDid!)}%2C%20how%20are%20you%3F`
+            }))
+            await sleep(7000)
+            expect(mockFunction.called).to.be.true
+
+            let triggeredNotification = mockFunction.getCall(0).args[0] as TriggeredNotification
+            expect(triggeredNotification.notification.description).to.equal(notification.description)
+            let triggerMatch = JSON.parse(triggeredNotification.triggerMatch)
+            expect(triggerMatch.length).to.equal(1)
+            //@ts-ignore
+            expect(triggerMatch[0].source).to.equal("message://2")
+            //@ts-ignore
+            expect(triggerMatch[0].target).to.include(agentDid)
         })
 
         it("can export and import database", async () => {


### PR DESCRIPTION
This PR migrates the notification trigger system from Prolog queries to SurrealQL queries, enabling notifications to work in SdnaOnly mode (which saves RAM by not loading Prolog facts).

## Why This Change?

Previously, notifications relied on Prolog queries that analyzed facts loaded into memory. When ad4m switched to SdnaOnly mode to reduce memory usage, the notification system broke because Prolog facts weren't available. This PR replaces Prolog with SurrealQL queries that run directly against the SurrealDB instances where perspective data is stored.

## Key Changes

### 1. Added Custom SurrealDB Functions

Added four custom functions to enable complex notification queries:

- **`fn::parse_literal($url)`** - Parses literal URLs (e.g., `literal://string:Hello%20World` → `"Hello World"`)
- **`fn::json_path($obj, $path)`** - Navigate JSON objects by dot-separated path (e.g., `fn::json_path(data, 'user.name')`)
- **`fn::contains($str, $substring)`** - String contains check
- **`fn::strip_html($html)`** - Remove HTML tags using regex
- **`fn::regex_match($str, $pattern)`** - Regex pattern matching

**Location:** `/rust-executor/src/surreal_service/mod.rs:282-402`

### 2. Context Variable Injection

Notification queries can now use two context variables that are automatically injected:

- **`$agentDid`** - The agent's DID (e.g., `did:key:z6Mks...`)
- **`$perspectiveId`** - The perspective UUID being queried

These are injected via string replacement before query execution.

**Location:** `/rust-executor/src/perspectives/perspective_instance.rs:2301-2338`

### 3. Query Validation

Added validation at notification creation/update time to ensure queries are safe:

- Must start with SELECT/RETURN/LET/WITH
- Cannot contain mutating operations (INSERT, UPDATE, DELETE, etc.)
- Must have balanced parentheses
- Length limit of 10,000 characters

**Location:** `/rust-executor/src/db.rs:456-542`

### 4. Changed Internal Types

- Notification matches now return `Vec<serde_json::Value>` instead of `Vec<QueryMatch>`
- Removed Prolog-specific types from notification code
- Updated all notification matching methods to work with JSON

**Location:** `/rust-executor/src/perspectives/perspective_instance.rs:2524-2633`

## Migration Guide: Flux Notification Example

### Before (Prolog):

```prolog
agent_did(Did),
subject_class("Message", C),
instance(C, Base),
property_getter(C, Base, "body", Body),
literal_from_url(Body, JsonString, _),
json_property(JsonString, "data", MessageContent),
string_includes(MessageContent, MentionString),
remove_html_tags(MessageContent, Description)
```

### After (SurrealQL):

```sql
SELECT
    in.uri as message_id,
    fn::parse_literal(out.uri) as body_literal,
    fn::json_path(fn::parse_literal(out.uri), 'data') as message_content,
    fn::strip_html(
        fn::json_path(fn::parse_literal(out.uri), 'data')
    ) as description,
    $agentDid as mentioned_agent
FROM link
WHERE predicate = 'msg://body'
    AND fn::contains(
        fn::json_path(fn::parse_literal(out.uri), 'data'),
        'data-type="mention" href="' + $agentDid + '"'
    )
```

### Key Differences:

1. **Standard SQL syntax** - Use `SELECT ... FROM link WHERE ...` instead of Prolog predicates
2. **Explicit field selection** - Name each field you want in the result using `as alias`
3. **Function calls** - Use `fn::function_name()` for custom functions
4. **Context variables** - Use `$agentDid` and `$perspectiveId` directly in queries
5. **Link graph traversal** - Use `in.uri` for link source, `out.uri` for link target

## Extracting Multiple Data Points

You can select multiple computed fields in one query:

```sql
SELECT
    source as message_id,
    fn::parse_literal(target) as message_content,
    fn::strip_html(fn::parse_literal(target)) as plain_text,
    $agentDid as mentioned_agent,
    $perspectiveId as perspective_id
FROM link
WHERE predicate = 'rdf://content'
    AND fn::contains(fn::parse_literal(target), $agentDid)
```

Each match object will contain all these fields:

```json
{
  "message_id": "message://2",
  "message_content": "<p>Hey <strong>did:key:z6Mks...</strong>, how are you?</p>",
  "plain_text": "Hey did:key:z6Mks..., how are you?",
  "mentioned_agent": "did:key:z6Mks...",
  "perspective_id": "3b7104cb-cec0-4d05-a968-c566936dd289"
}
```

## Breaking Changes

- **Notification trigger format:** Apps using notifications must update their trigger queries from Prolog to SurrealQL
- **Match result structure:** The `triggerMatch` field now contains JSON objects with explicitly selected fields instead of Prolog variable bindings

## Known Limitations

Multi-user support will be addressed in a follow-up PR to ensure notifications work correctly with managed users and per-user agent DIDs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications can use SELECT-style query triggers and now return JSON-formatted trigger results.
  * SurrealDB helper functions added: HTML stripping, JSON path extraction, substring and regex checks.

* **Bug Fixes / Refactor**
  * Validation added for notification triggers on create/update to reject unsafe or malformed queries.
  * Internal notification matches normalized to JSON with consistent lower-case fields.

* **Tests**
  * Notification tests updated, re-enabled, and extended to cover new trigger formats, string-literal handling, and richer match extraction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->