### PR TITLE
ci: Use Docker container for npm-publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -400,10 +400,10 @@ jobs:
           fi
 
       - name: Install deps
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install
 
       - name: Install core dependencies
-        run: cd ./core && pnpm install --no-frozen-lockfile
+        run: cd ./core && pnpm install
 
       - name: Build modules
         run: pnpm run build-npm-packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -393,7 +393,7 @@ jobs:
       - name: Check if string contains prerelease
         run: |
           STRING="${{ steps.extract_version.outputs.version }}"
-          if [[ $STRING == *"prerelease"* ]]; then
+          if [[ $STRING == *-* ]]; then
             echo "CONTAINS_PRERELEASE=true" >> $GITHUB_ENV
           else
             echo "CONTAINS_PRERELEASE=false" >> $GITHUB_ENV

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -378,16 +378,11 @@ jobs:
         asset_content_type: application/octet-stream
 
   npm-publish:
-    runs-on: GH-hosted-ubuntu
+    runs-on: ubuntu-latest
+    container:
+      image: coasys/ad4m-ci-linux:latest@sha256:3d6e8b6357224d689345eebd5f9da49ee5fd494b3fd976273d0cf5528f6903ab
     steps:
       - uses: actions/checkout@v3
-      # Setup .npmrc file to publish to npm
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 18.x
-
-      - uses: pnpm/action-setup@v4
 
       - name: Extract version
         id: extract_version
@@ -404,26 +399,11 @@ jobs:
             echo "CONTAINS_PRERELEASE=false" >> $GITHUB_ENV
           fi
 
-      - name: Install GO
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.24.6'
-
-      - name: Install Linux Deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf protobuf-compiler cmake fuse libfuse2 mesa-vulkan-drivers 
-
       - name: Install deps
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
 
       - name: Install core dependencies
-        run: cd ./core && pnpm install
-
-      - name: Install Deno
-        uses: denoland/setup-deno@v1
-        with:
-          deno-version: v2.x
+        run: cd ./core && pnpm install --no-frozen-lockfile
 
       - name: Build modules
         run: pnpm run build-npm-packages

--- a/.github/workflows/publish_staging.yml
+++ b/.github/workflows/publish_staging.yml
@@ -400,10 +400,10 @@ jobs:
           fi
 
       - name: Install deps
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install
 
       - name: Install core dependencies
-        run: cd ./core && pnpm install --no-frozen-lockfile
+        run: cd ./core && pnpm install
 
       - name: Build modules
         run: pnpm run build-npm-packages

--- a/.github/workflows/publish_staging.yml
+++ b/.github/workflows/publish_staging.yml
@@ -393,7 +393,7 @@ jobs:
       - name: Check if string contains prerelease
         run: |
           STRING="${{ steps.extract_version.outputs.version }}"
-          if [[ $STRING == *"prerelease"* ]]; then
+          if [[ $STRING == *-* ]]; then
             echo "CONTAINS_PRERELEASE=true" >> $GITHUB_ENV
           else
             echo "CONTAINS_PRERELEASE=false" >> $GITHUB_ENV

--- a/.github/workflows/publish_staging.yml
+++ b/.github/workflows/publish_staging.yml
@@ -378,16 +378,11 @@ jobs:
         asset_content_type: application/octet-stream
 
   npm-publish:
-    runs-on: GH-hosted-ubuntu
+    runs-on: ubuntu-latest
+    container:
+      image: coasys/ad4m-ci-linux:latest@sha256:3d6e8b6357224d689345eebd5f9da49ee5fd494b3fd976273d0cf5528f6903ab
     steps:
       - uses: actions/checkout@v3
-      # Setup .npmrc file to publish to npm
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 18.x
-
-      - uses: pnpm/action-setup@v4
 
       - name: Extract version
         id: extract_version
@@ -404,26 +399,11 @@ jobs:
             echo "CONTAINS_PRERELEASE=false" >> $GITHUB_ENV
           fi
 
-      - name: Install GO
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.22'
-
-      - name: Install Linux Deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf protobuf-compiler cmake fuse libfuse2 mesa-utils mesa-vulkan-drivers 
-
       - name: Install deps
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
 
       - name: Install core dependencies
-        run: cd ./core && pnpm install
-
-      - name: Install Deno
-        uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.32.4
+        run: cd ./core && pnpm install --no-frozen-lockfile
 
       - name: Build modules
         run: pnpm run build-npm-packages

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.ad4m.dev

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-docs.ad4m.dev


### PR DESCRIPTION
## Summary

Use the same Docker image that CircleCI uses for the npm-publish job in GitHub Actions.

## Problem

The npm-publish job was failing with:

```
node-pre-gyp ERR! stack Error: 404 status code downloading tarball 
https://github.com/mattrglobal/node-bbs-signatures/releases/download/0.11.0/node-v108-linux-x64.tar.gz
```

The `@mattrglobal/node-bbs-signatures` package doesn't have pre-built binaries for Node 18 (v108 ABI).

## Solution

Use the `coasys/ad4m-ci-linux` Docker image (same as CircleCI) which has all dependencies pre-installed and configured.

## Changes

- `publish.yml`: npm-publish job now uses Docker container
- `publish_staging.yml`: npm-publish job now uses Docker container

## Notes

This uses the same pinned image SHA that CircleCI uses for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved publishing to a containerized pipeline for more reliable, consistent releases.
  * Simplified workflow and build setup by removing redundant tool-install steps.
  * Improved prerelease detection logic for accurate tagging.
  * Publish process now handles multiple artifacts and platform-specific release assets and ensures packages are published with public access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->