### PR TITLE
ci: Optimize binary builds with Docker (Linux) and caching (macOS)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,43 +40,117 @@ jobs:
           draft: true
           prerelease: false
 
-  build-launcher-binary:
-    strategy:
-      fail-fast: false
-      matrix:
-        #platform: [GH-hosted-ubuntu, macos-latest, windows-latest]
-        platform: [GH-hosted-ubuntu, macos-latest]
-        node-version: [18.x]
+  # ============================================================================
+  # Linux Binary Build - Uses Docker container (all deps pre-installed)
+  # ============================================================================
+  build-launcher-binary-linux:
+    runs-on: ubuntu-latest
+    container:
+      image: coasys/ad4m-ci-linux:latest@sha256:3d6e8b6357224d689345eebd5f9da49ee5fd494b3fd976273d0cf5528f6903ab
 
     needs:
       - create-release
 
-    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Fetch source code
+      uses: actions/checkout@v3
+
+    - name: Extract version
+      id: extract_version
+      uses: Saionaro/extract-package-version@v1.1.1
+      with:
+        path: ui
+
+    - name: pnpm Install
+      run: pnpm install
+
+    - name: Install core dependencies
+      run: cd ./core && pnpm install
+
+    - name: Build AD4M-CLI
+      run: pnpm build-libs
+
+    - name: Build Launcher binary
+      run: pnpm run package-ad4m
+
+    - name: Upload Release Deb Asset
+      id: upload-release-deb-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create-release.outputs.upload_url }}
+        asset_path: target/release/bundle/deb/ADAM Launcher_${{ steps.extract_version.outputs.version }}_amd64.deb
+        asset_name: ADAM Launcher_${{ steps.extract_version.outputs.version }}_amd64.deb
+        asset_content_type: application/octet-stream
+
+    - name: Upload Release AppImage Asset
+      id: upload-release-appimage-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create-release.outputs.upload_url }}
+        asset_path: target/release/bundle/appimage/ADAM Launcher_${{ steps.extract_version.outputs.version }}_amd64.AppImage
+        asset_name: ADAM Launcher_${{ steps.extract_version.outputs.version }}_amd64.AppImage
+        asset_content_type: application/octet-stream
+
+    - name: Upload Release AD4M CLI client Linux Binary
+      id: upload-release-linux-ad4m-cli-binary
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create-release.outputs.upload_url }}
+        asset_path: target/release/ad4m
+        asset_name: ad4m-cli-client-linux-${{ steps.extract_version.outputs.version }}-x64
+        asset_content_type: application/octet-stream
+
+    - name: Upload Release AD4M CLI executor Linux Binary
+      id: upload-release-linux-ad4m-cli-executor-binary
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create-release.outputs.upload_url }}
+        asset_path: target/release/ad4m-executor
+        asset_name: ad4m-cli-executor-linux-${{ steps.extract_version.outputs.version }}-x64
+        asset_content_type: application/octet-stream
+
+  # ============================================================================
+  # macOS Binary Build - Uses aggressive caching (Docker not available)
+  # ============================================================================
+  build-launcher-binary-macos:
+    runs-on: macos-latest
+
+    needs:
+      - create-release
 
     steps:
     - name: Fetch source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install Rust stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        override: true
         toolchain: 1.86.0
-    - run: rustup target add wasm32-unknown-unknown
+        targets: wasm32-unknown-unknown,x86_64-apple-darwin,aarch64-apple-darwin
 
-    - name: Install Rust targets for macOS
-      if: matrix.platform == 'macos-latest'
-      run: |
-        rustup target add x86_64-apple-darwin
-        rustup target add aarch64-apple-darwin
+    # Aggressive Rust caching - this is the biggest time saver for macOS
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: |
+          rust-executor
+          ui/src-tauri
+        cache-targets: true
+        cache-all-crates: true
 
     - name: Install GO
       uses: actions/setup-go@v4
       with:
         go-version: '1.24.6'
-    
-    - name: Install/update node-gyp
-      run: npm install -g node-gyp
+        cache: true
 
     - name: Install Deno
       uses: denoland/setup-deno@v1
@@ -90,23 +164,29 @@ jobs:
 
     - uses: pnpm/action-setup@v4
 
+    - name: Use Node.js 18.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.x
+        cache: 'pnpm'
 
-    - name: install dependencies (ubuntu only)
-      if: matrix.platform == 'GH-hosted-ubuntu'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf protobuf-compiler cmake fuse libfuse2 mesa-utils mesa-vulkan-drivers libsoup-3.0-dev javascriptcoregtk-4.1-dev webkit2gtk-4.1-dev librust-alsa-sys-dev
+    # Cache Homebrew packages
+    - name: Cache Homebrew
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/Library/Caches/Homebrew
+          /usr/local/Cellar
+          /opt/homebrew/Cellar
+        key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/publish.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-brew-
 
-    - name: install dependencies (macos only)
-      if: matrix.platform == 'macos-latest'
+    - name: Install dependencies (macOS)
       run: brew install protobuf cmake
 
-    - name: install dependencies (windows only)
-      if: matrix.platform == 'windows-latest'
-      run: choco install strawberryperl protoc cmake curl cygwin gnuwin32-m4 msys2 make mingw
-
-    - name: get version
-      run: echo "PACKAGE_VERSION=$(node -p "require('./ui/package.json').version")" >> $GITHUB_ENV
+    - name: Install/update node-gyp
+      run: npm install -g node-gyp
 
     - name: Extract version
       id: extract_version
@@ -114,280 +194,64 @@ jobs:
       with:
         path: ui
 
-    - name: Change package UI version
-      id: changed_version
-      if: matrix.platform == 'windows-latest'
-      run: cd ui && pnpm change-ui-version
-
-    - name: Extract changed version
-      id: changed_extract_version
-      uses: Saionaro/extract-package-version@v1.1.1
-      with:
-        path: ui
-
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-
     - name: pnpm Install
-      run: pnpm install --no-cache
+      run: pnpm install
 
     - name: Install core dependencies
-      run: cd ./core && pnpm install --no-cache
-
-    #- name: Decrypt and install certificates
-    #  if: matrix.platform == 'macos-latest'
-    #  env:
-    #    APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-    #    APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-    #  run: |
-    #    echo $APPLE_CERTIFICATE | base64 --decode > certificate.p12
-    #    security create-keychain -p "actions" build.keychain
-    #    security import certificate.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
-    #    security list-keychain -d user -s build.keychain
-    #    security unlock-keychain -p "actions" build.keychain
-    #    mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-    #    security set-key-partition-list -S apple-tool
+      run: cd ./core && pnpm install
 
     - name: Build AD4M-CLI
       run: pnpm build-libs
 
-    - name: Build AD4M-CLI & build Launcher binary (macos/linux-latest)
-      #if: matrix.platform != 'windows-latest'
-      #env:
-        #TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-        #TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-        #APPLE_ID: ${{ secrets.APPLE_ID }}
-        #APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-        #APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-        #APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        #APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        #APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+    - name: Build Launcher binary
       run: pnpm run package-ad4m
 
-    #- name:  Build AD4M-CLI & build Launcher binary (windows-latest)
-    #  if: matrix.platform == 'windows-latest'
-    #  env:
-    #    TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-    #    TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-    #  run: pnpm run package-ad4m
-
-    - name: Upload Release Deb Asset
-      id: upload-release-deb-asset
-      if: matrix.platform == 'GH-hosted-ubuntu'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: /home/runner/work/ad4m/ad4m/target/release/bundle/deb/ADAM Launcher_${{ steps.extract_version.outputs.version }}_amd64.deb
-        asset_name: ADAM/ Launcher_${{ steps.extract_version.outputs.version }}_amd64.deb
-        asset_content_type: application/octet-stream
-
-    - name: Upload Release AppImage Asset
-      id: upload-release-appimage-asset
-      if: matrix.platform == 'GH-hosted-ubuntu'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: /home/runner/work/ad4m/ad4m/target/release/bundle/appimage/ADAM Launcher_${{ steps.extract_version.outputs.version }}_amd64.AppImage
-        asset_name: ADAM\ Launcher_${{ steps.extract_version.outputs.version }}_amd64.AppImage
-        asset_content_type: application/octet-stream
-
-    #- name: Upload Release AppImage Update Asset
-    #  id: upload-release-appimage-asset-update
-    #  if: matrix.platform == 'GH-hosted-ubuntu'
-    #  uses: actions/upload-release-asset@v1
-    #  env:
-    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #  with:
-    #    upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-    #    asset_path: /home/runner/work/ad4m/ad4m/target/release/bundle/appimage/adam-launcher_${{ steps.extract_version.outputs.version }}_amd64.AppImage.tar.gz
-    #    asset_name: adam-launcher_${{ steps.extract_version.outputs.version }}_amd64.deb.tar.gz
-    #    asset_content_type: application/octet-stream
-
-    #- name: Upload Release AppImage update sig Asset
-    #  id: upload-release-appimage-asset-update-sig
-    #  if: matrix.platform == 'GH-hosted-ubuntu'
-    #  uses: actions/upload-release-asset@v1
-    #  env:
-    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #  with:
-    #    upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-    #    asset_path: /home/runner/work/ad4m/ad4m/target/release/bundle/appimage/adam-launcher_${{ steps.extract_version.outputs.version }}_amd64.AppImage.tar.gz.sig
-    #    asset_name: adam-launcher_${{ steps.extract_version.outputs.version }}_amd64.deb.tar.gz.sig
-    #    asset_content_type: application/octet-stream
-
-    - name: Upload Release AD4M CLI client Linux Binary
-      id: upload-release-linux-ad4m-cli-binary
-      if: matrix.platform == 'GH-hosted-ubuntu'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: /home/runner/work/ad4m/ad4m/target/release/ad4m
-        asset_name: ad4m-cli-client-linux-${{ steps.extract_version.outputs.version }}-x64
-        asset_content_type: application/octet-stream
-
-    - name: Upload Release AD4M CLI executor Linux Binary
-      id: upload-release-linux-ad4m-cli-executor-binary
-      if: matrix.platform == 'GH-hosted-ubuntu'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: /home/runner/work/ad4m/ad4m/target/release/ad4m-executor
-        asset_name: ad4m-cli-executor-linux-${{ steps.extract_version.outputs.version }}-x64
-        asset_content_type: application/octet-stream
-
-    - name: Upload Release Macos Asset
+    - name: Upload Release macOS DMG Asset
       id: upload-release-macos-asset
-      if: matrix.platform == 'macos-latest'
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path:  "/Users/runner/work/ad4m/ad4m/target/release/bundle/dmg/ADAM Launcher_${{ steps.extract_version.outputs.version }}_aarch64.dmg"
-        asset_name: ADAM\ Launcher_${{ steps.extract_version.outputs.version }}_aarch64.dmg
+        upload_url: ${{ needs.create-release.outputs.upload_url }}
+        asset_path: "/Users/runner/work/ad4m/ad4m/target/release/bundle/dmg/ADAM Launcher_${{ steps.extract_version.outputs.version }}_aarch64.dmg"
+        asset_name: ADAM Launcher_${{ steps.extract_version.outputs.version }}_aarch64.dmg
         asset_content_type: application/octet-stream
-
-    #- name: Upload Release Macos update Asset
-    #  id: upload-release-macos-asset-update
-    #  if: matrix.platform == 'macos-latest'
-    #  uses: actions/upload-release-asset@v1
-    #  env:
-    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #  with:
-    #    upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-    #    asset_path:  "/Users/runner/work/ad4m/ad4m/target/release/universal-apple-darwin/bundle/macos/ADAM Launcher.app.tar.gz"
-    #    asset_name: ADAM\ Launcher_${{ steps.extract_version.outputs.version }}_aarch64.app.tar.gz
-    #    asset_content_type: application/octet-stream
-
-    #- name: Upload Release Macos update sig Asset
-    #  id: upload-release-macos-asset-update-sig
-    #  if: matrix.platform == 'macos-latest'
-    #  uses: actions/upload-release-asset@v1
-    #  env:
-    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #  with:
-    #    upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-    #    asset_path:  "/Users/runner/work/ad4m/ad4m/target/release/universal-apple-darwin/bundle/macos/ADAM Launcher.app.tar.gz.sig"
-    #    asset_name: ADAM\ Launcher_${{ steps.extract_version.outputs.version }}_aarch64.app.tar.gz.sig
-    #    asset_content_type: application/octet-stream
 
     - name: Upload Release AD4M CLI client macOS Binary
       id: upload-release-macos-ad4m-cli-binary
-      if: matrix.platform == 'macos-latest'
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+        upload_url: ${{ needs.create-release.outputs.upload_url }}
         asset_path: /Users/runner/work/ad4m/ad4m/target/release/ad4m
         asset_name: ad4m-cli-client-macos-${{ steps.extract_version.outputs.version }}-aarch64
         asset_content_type: application/octet-stream
 
     - name: Upload Release AD4M CLI executor macOS Binary
       id: upload-release-macos-ad4m-cli-executor-binary
-      if: matrix.platform == 'macos-latest'
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+        upload_url: ${{ needs.create-release.outputs.upload_url }}
         asset_path: /Users/runner/work/ad4m/ad4m/target/release/ad4m-executor
         asset_name: ad4m-cli-executor-macos-${{ steps.extract_version.outputs.version }}-aarch64
         asset_content_type: application/octet-stream
 
-    - name: Upload Release MSI Asset
-      id: upload-release-msi-asset
-      if: matrix.platform == 'windows-latest'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: 'D:\a\ad4m\ad4m\target\release\bundle\msi\ADAM Launcher_${{ steps.changed_extract_version.outputs.version }}_x64_en-US.msi'
-        asset_name: ADAM\ Launcher_${{ steps.changed_extract_version.outputs.version }}_x64_en-US.msi
-        asset_content_type: application/octet-stream
+  # NOTE: Windows builds are currently disabled. When re-enabling, consider:
+  # - Using a self-hosted Windows runner with pre-installed deps, OR
+  # - Adding aggressive caching similar to macOS job
 
-    #- name: Upload Release MSI update Asset
-    #  id: upload-release-msi-asset-update
-    #  if: matrix.platform == 'windows-latest'
-    #  uses: actions/upload-release-asset@v1
-    #  env:
-    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #  with:
-    #    upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-    #    asset_path: 'D:\a\ad4m\ad4m\target\release\bundle\msi\ADAM Launcher_${{ steps.changed_extract_version.outputs.version }}_x64_en-US.msi.zip'
-    #    asset_name: ADAM\ Launcher_${{ steps.changed_extract_version.outputs.version }}_x64_en-US.msi.zip
-    #    asset_content_type: application/octet-stream
-
-    #- name: Upload Release MSI update sig Asset
-    #  id: upload-release-msi-asset-update-sig
-    #  if: matrix.platform == 'windows-latest'
-    #  uses: actions/upload-release-asset@v1
-    #  env:
-    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #  with:
-    #    upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-    #    asset_path: 'D:\a\ad4m\ad4m\target\release\bundle\msi\ADAM Launcher_${{ steps.changed_extract_version.outputs.version }}_x64_en-US.msi.zip.sig'
-    #    asset_name: ADAM\ Launcher_${{ steps.changed_extract_version.outputs.version }}_x64_en-US.msi.zip.sig
-    #    asset_content_type: application/octet-stream
-
-    # - name: Upload Release AD4M CLI Windows Binary
-    #   id: upload-release-windows-ad4m-cli-binary
-    #   if: matrix.platform == 'windows-latest'
-    #   uses: actions/upload-release-asset@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-    #     asset_path: D:\a\ad4m\ad4m\target\release\ad4m-x64.exe
-    #     asset_name: ad4m-windows-${{ steps.extract_version.outputs.version }}-x64.exe
-    #     asset_content_type: application/octet-stream
-
-    - name: Upload Release AD4M CLI client Windows Binary
-      id: upload-release-windows-ad4m-cli-client-binary
-      if: matrix.platform == 'windows-latest'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: D:\a\ad4m\ad4m\target\release\ad4m-x64.exe
-        asset_name: ad4m-cli-client-windows-${{ steps.extract_version.outputs.version }}-x64.exe
-        asset_content_type: application/octet-stream
-
-    - name: Upload Release AD4M CLI executor Windows Binary
-      id: upload-release-windows-ad4m-cli-executor-binary
-      if: matrix.platform == 'windows-latest'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: D:\a\ad4m\ad4m\target\release\ad4m-executor-x64.exe
-        asset_name: ad4m-cli-executor-windows-${{ steps.extract_version.outputs.version }}-x64.exe
-        asset_content_type: application/octet-stream
-
+  # ============================================================================
+  # NPM Publish - Uses Docker container (all deps pre-installed)
+  # ============================================================================
   npm-publish:
-    runs-on: GH-hosted-ubuntu
+    runs-on: ubuntu-latest
+    container:
+      image: coasys/ad4m-ci-linux:latest@sha256:3d6e8b6357224d689345eebd5f9da49ee5fd494b3fd976273d0cf5528f6903ab
     steps:
       - uses: actions/checkout@v3
-      # Setup .npmrc file to publish to npm
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 18.x
-
-      - uses: pnpm/action-setup@v4
 
       - name: Extract version
         id: extract_version
@@ -398,32 +262,17 @@ jobs:
       - name: Check if string contains prerelease
         run: |
           STRING="${{ steps.extract_version.outputs.version }}"
-          if [[ $STRING == *"prerelease"* ]]; then
+          if [[ $STRING == *-* ]]; then
             echo "CONTAINS_PRERELEASE=true" >> $GITHUB_ENV
           else
             echo "CONTAINS_PRERELEASE=false" >> $GITHUB_ENV
           fi
-
-      - name: Install GO
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.24.6'
-
-      - name: Install Linux Deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf protobuf-compiler cmake fuse libfuse2 mesa-vulkan-drivers 
 
       - name: Install deps
         run: pnpm install
 
       - name: Install core dependencies
         run: cd ./core && pnpm install
-
-      - name: Install Deno
-        uses: denoland/setup-deno@v1
-        with:
-          deno-version: v2.x
 
       - name: Build modules
         run: pnpm run build-npm-packages


### PR DESCRIPTION
## Summary
Optimizes the binary build workflow for faster CI runs.

## Linux Builds
- **Uses Docker container** (`coasys/ad4m-ci-linux`) - all dependencies pre-installed
- Eliminates ~15 setup steps per job (Rust, Go, Deno, Python, apt-get, pnpm, etc.)
- Same optimization now applied to npm-publish

## macOS Builds
Docker containers are **not supported** on GitHub Actions macOS runners, so instead:
- **Rust caching** via `Swatinem/rust-cache` (the best Rust caching action)
- **pnpm caching** via `actions/setup-node`
- **Homebrew caching** for protobuf/cmake bottles
- **Go module caching** via `actions/setup-go`

## Other Changes
- Split matrix job into separate platform-specific jobs (cleaner, easier to debug)
- Fixed prerelease detection (`*-*` pattern catches `0.11.2-dev.4`)
- Removed Windows builds (were already disabled)
- Updated deprecated actions (checkout@v2 → v3, setup-node@v1 → v3)

## Expected Improvement
- **Linux**: ~5-10 min faster (no tool installation)
- **macOS**: ~3-5 min faster on cache hits (Rust target cache is the big win)

## Windows Discussion
When ready to re-enable Windows, options include:
1. Self-hosted Windows runner with pre-installed tools
2. Aggressive caching similar to macOS approach
3. Windows Docker containers (experimental in Actions)