### PR TITLE
fix(test-runner): update ad4m-test for v0.10.1+ compatibility

### DIFF
--- a/test-runner/package.json
+++ b/test-runner/package.json
@@ -36,7 +36,6 @@
     "express": "4.18.2",
     "find-process": "^1.4.7",
     "fs-extra": "^10.0.1",
-    "get-port": "5.1.1",
     "glob": "^7.2.0",
     "graphql": "15.7.2",
     "graphql-ws": "5.12.0",

--- a/test-runner/package.json
+++ b/test-runner/package.json
@@ -3,6 +3,12 @@
   "description": "Testing library to test ad4m languages",
   "license": "MIT",
   "bin": "./build/cli.js",
+  "files": [
+    "build/",
+    "scripts/",
+    "bootstrapSeed.json",
+    "public/"
+  ],
   "scripts": {
     "build": "tsc",
     "build:util": "browserify build/client.js --standalone Bundle -p esmify > public/client.js",

--- a/test-runner/src/installSystemLanguages.ts
+++ b/test-runner/src/installSystemLanguages.ts
@@ -1,7 +1,7 @@
 import { LanguageMetaInput } from "@coasys/ad4m"
 import path from "path";
 import fs from 'fs-extra';
-import { ChildProcessWithoutNullStreams, execSync, spawn } from "child_process";
+import { ChildProcessWithoutNullStreams, execFileSync, spawn } from "child_process";
 import { ad4mDataDirectory, deleteAllAd4mData, findAndKillProcess, getAd4mHostBinary, logger } from "./utils";
 import kill from 'tree-kill'
 import { buildAd4mClient } from "./client";
@@ -49,7 +49,7 @@ export async function installSystemLanguages(relativePath = '') {
 
     const seedFile = path.join(__dirname, '../bootstrapSeed.json')
 
-    execSync(`${binaryPath} init --data-path ${relativePath} --network-bootstrap-seed ${seedFile}`, { encoding: 'utf-8' });
+    execFileSync(binaryPath, ['init', '--data-path', relativePath, '--network-bootstrap-seed', seedFile], { encoding: 'utf-8' });
 
     logger.info('ad4m-test initialized')
 
@@ -78,8 +78,8 @@ export async function installSystemLanguages(relativePath = '') {
       logFile.write(data)
     });
     child.stderr.on('data', async (data) => {
-      logFile.write(data)
       // Re-emit stderr on stdout so detection logic below catches Rust log output
+      // (stdout handler already writes to logFile, so no duplicate write needed here)
       child.stdout.emit('data', data)
     })
 

--- a/test-runner/src/installSystemLanguages.ts
+++ b/test-runner/src/installSystemLanguages.ts
@@ -49,7 +49,7 @@ export async function installSystemLanguages(relativePath = '') {
 
     const seedFile = path.join(__dirname, '../bootstrapSeed.json')
 
-    execSync(`${binaryPath} init --dataPath ${relativePath} --networkBootstrapSeed ${seedFile} --overrideConfig`, { encoding: 'utf-8' });
+    execSync(`${binaryPath} init --data-path ${relativePath} --network-bootstrap-seed ${seedFile}`, { encoding: 'utf-8' });
 
     logger.info('ad4m-test initialized')
 
@@ -66,9 +66,9 @@ export async function installSystemLanguages(relativePath = '') {
     fs.writeFileSync(path.join(__dirname, '../bootstrapSeed.json'), JSON.stringify(seed));
 
     if (defaultLangPath) {
-      child = spawn(`${binaryPath}`, ['serve', '--reqCredential', global.ad4mToken ,'--dataPath', relativePath, '--port', '4000', '--languageLanguageOnly', 'true'])
+      child = spawn(`${binaryPath}`, ['run', '--admin-credential', global.ad4mToken, '--app-data-path', relativePath, '--gql-port', '4000', '--language-language-only', 'true'])
     } else {
-      child = spawn(`${binaryPath}`, ['serve', '--reqCredential', global.ad4mToken, '--dataPath', relativePath, '--port', '4000', '--languageLanguageOnly', 'true'])
+      child = spawn(`${binaryPath}`, ['run', '--admin-credential', global.ad4mToken, '--app-data-path', relativePath, '--gql-port', '4000', '--language-language-only', 'true'])
     }
 
 
@@ -79,10 +79,12 @@ export async function installSystemLanguages(relativePath = '') {
     });
     child.stderr.on('data', async (data) => {
       logFile.write(data)
+      // Re-emit stderr on stdout so detection logic below catches Rust log output
+      child.stdout.emit('data', data)
     })
 
     child.stdout.on('data', async (data) => {
-      if (data.toString().includes('GraphQL server started, Unlock the agent to start holohchain')) {
+      if (data.toString().includes('GraphQL server started, Unlock the agent to start holohchain') || data.toString().includes('listening on http://127.0.0.1')) {
         const client = await buildAd4mClient(4000);
         
         await client.agent.generate('123456789')

--- a/test-runner/src/installSystemLanguages.ts
+++ b/test-runner/src/installSystemLanguages.ts
@@ -55,8 +55,6 @@ export async function installSystemLanguages(relativePath = '') {
 
     let child: ChildProcessWithoutNullStreams;
 
-    const defaultLangPath = path.join(__dirname, './languages');
-
     const languageLanguageBundlePath = path.join(__dirname, 'languages', "languages", "build", "bundle.js");
         
     seed['languageLanguageBundle'] = fs.readFileSync(languageLanguageBundlePath).toString();
@@ -65,11 +63,13 @@ export async function installSystemLanguages(relativePath = '') {
 
     fs.writeFileSync(path.join(__dirname, '../bootstrapSeed.json'), JSON.stringify(seed));
 
-    if (defaultLangPath) {
-      child = spawn(`${binaryPath}`, ['run', '--admin-credential', global.ad4mToken, '--app-data-path', relativePath, '--gql-port', '4000', '--language-language-only', 'true'])
-    } else {
-      child = spawn(`${binaryPath}`, ['run', '--admin-credential', global.ad4mToken, '--app-data-path', relativePath, '--gql-port', '4000', '--language-language-only', 'true'])
-    }
+    child = spawn(`${binaryPath}`, [
+      'run',
+      '--admin-credential', global.ad4mToken,
+      '--app-data-path', relativePath,
+      '--gql-port', '4000',
+      '--language-language-only', 'true',
+    ])
 
 
     const logFile = fs.createWriteStream(path.join(process.cwd(), 'ad4m-test.log'))

--- a/test-runner/src/utils.ts
+++ b/test-runner/src/utils.ts
@@ -85,6 +85,13 @@ export async function getAd4mHostBinary(relativePath: string) {
     let data: any;
     try {
       const response = await fetch("https://api.github.com/repos/coasys/ad4m/releases/latest");
+      if (!response.ok) {
+        const status = response.status;
+        const message = status === 403 ? 'GitHub API rate limited' : `GitHub API returned ${status}`;
+        logger.error(message);
+        reject(new Error(message));
+        return;
+      }
       data = await response.json();
     } catch (err) {
       logger.error(`Failed to fetch release info from GitHub: ${err}`);
@@ -92,7 +99,7 @@ export async function getAd4mHostBinary(relativePath: string) {
       return;
     }
 
-    const version = (data && data['name']) ? data['name'].replace('v', '') : 'unknown';
+    const version = (data && data['name']) ? data['name'].replace(/^v/, '') : 'unknown';
     global.ad4mHostVersion = version;
 
     let dest = path.join(binaryPath, `ad4m`);


### PR DESCRIPTION
## Summary

Fixes `@coasys/ad4m-test` (test-runner) for compatibility with the AD4M executor v0.10.1+. Verified working in CI on [HexaField/nextgraph-adam-language](https://github.com/HexaField/nextgraph-adam-language) — a real AD4M Language with both unit and e2e tests green.

## Changes

### CLI Flag Renames (v0.10.1 uses kebab-case)

| Old (camelCase) | New (kebab-case) |
|---|---|
| `--dataPath` | `--data-path` / `--app-data-path` |
| `--reqCredential` | `--admin-credential` |
| `--port` | `--gql-port` |
| `--networkBootstrapSeed` | `--network-bootstrap-seed` |
| `--languageLanguageOnly` | `--language-language-only` |
| `serve` | `run` |
| `--ipfsPort` | _(removed — IPFS removed from executor)_ |
| `--overrideConfig` | _(removed)_ |

### stderr → stdout Re-emit

The executor logs via Rust's `log` crate to **stderr**, but all server/init detection logic in `cli.ts` and `installSystemLanguages.ts` only checked `stdout`. Added `child.stdout.emit('data', data)` in the stderr handler so detection works for both old and new executor versions.

### Alternative Server Detection

v0.10.1 emits `"listening on http://127.0.0.1:PORT"` instead of `"GraphQL server started, Unlock the agent to start holohchain"`. Added fallback detection for both patterns.

### GitHub API Safety (`utils.ts`)

- **Check binary existence before API call** — avoids unnecessary API calls and rate-limit errors
- **Wrap fetch in try/catch** — previously crashed with `Cannot read properties of undefined (reading 'replace')` when rate-limited
- **Safe version extraction** — `data?.name` with fallback to `'unknown'`
- **Safe asset lookup** — `data.assets?.find(...)` with explicit error when platform binary not found
- **Updated org** — `perspect3vism/ad4m` → `coasys/ad4m`
- **Fixed Linux asset pattern** — `"-linux-"` → `"-linux"` (actual filename: `ad4m-cli-executor-linux-0.10.1-x64`)

### Package Publishing Fix

Added `files` field to `package.json` so `build/`, `scripts/`, `bootstrapSeed.json`, and `public/` are included in the npm tarball. Previously only shipped TypeScript source — consumers got no compiled output.

### Storage Path Guards

- Guard `storagePath` operations with truthiness checks (empty string in fresh `bootstrapSeed.json` caused crashes)
- Use `{ recursive: true }` in `mkdirSync` for robustness
- Simplified copy-and-suffix logic

### Cleanup

- Removed `get-port` dependency (only used for `--ipfsPort` which is removed)
- Removed dead if/else branches with identical bodies
- Removed unused `defaultLangPath` variable in `installSystemLanguages.ts`
- `defaultLangPath` now properly controls `--language-language-only` flag in `cli.ts`

## Testing

CI verified on [HexaField/nextgraph-adam-language](https://github.com/HexaField/nextgraph-adam-language/actions):
- ✅ 35/35 unit tests (vitest, Node 22)
- ✅ Single-agent e2e test (real AD4M executor v0.10.1 on ubuntu-latest)
- Language published, wallet created, session started, expression created + retrieved + verified

## Note on System Language Bundles

The language bundles downloaded by `get-builtin-test-langs.js` are CJS format, but the executor's Deno runtime requires ESM. This is a broader issue not addressed here — consumers need to convert bundles at build time or use `--language-language-only true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during initialization and language installation
  * Enhanced binary download process with better OS-specific asset detection and error messaging
  * More reliable server startup status detection

* **Chores**
  * Refactored internal execution mechanisms
  * Streamlined dependency requirements for leaner installation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->