### PR TITLE
fix: reject links with invalid or empty source/target/predicate URIs

### DIFF
--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -870,6 +870,7 @@ impl PerspectiveInstance {
         batch_id: Option<String>,
         context: &AgentContext,
     ) -> Result<DecoratedLinkExpression, AnyError> {
+        link.validate()?;
         let link_expr: LinkExpression = create_signed_expression(link, context)?.into();
         self.add_link_expression(link_expr, status, batch_id).await
     }
@@ -1034,6 +1035,7 @@ impl PerspectiveInstance {
         status: LinkStatus,
         batch_id: Option<String>,
     ) -> Result<DecoratedLinkExpression, AnyError> {
+        link_expression.data.validate()?;
         if let Some(batch_id) = batch_id {
             let mut batches = self.batch_store.write().await;
             let diff = batches
@@ -1079,6 +1081,9 @@ impl PerspectiveInstance {
         batch_id: Option<String>,
         context: &AgentContext,
     ) -> Result<Vec<DecoratedLinkExpression>, AnyError> {
+        for link in &links {
+            link.validate()?;
+        }
         let link_expressions: Result<Vec<_>, _> = links
             .into_iter()
             .map(|l| create_signed_expression(l, context).map(LinkExpression::from))
@@ -1131,10 +1136,12 @@ impl PerspectiveInstance {
         status: LinkStatus,
         context: &AgentContext,
     ) -> Result<DecoratedPerspectiveDiff, AnyError> {
-        let additions = mutations
-            .additions
+        let addition_links: Vec<Link> = mutations.additions.into_iter().map(Link::from).collect();
+        for link in &addition_links {
+            link.validate()?;
+        }
+        let additions = addition_links
             .into_iter()
-            .map(Link::from)
             .map(|l| create_signed_expression(l, context))
             .map(|r| r.map(LinkExpression::from))
             .collect::<Result<Vec<LinkExpression>, AnyError>>()?;

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -3372,7 +3372,30 @@ impl PerspectiveInstance {
             }
         } else {
             Ok(match value {
-                serde_json::Value::String(s) => s.clone(),
+                serde_json::Value::String(s) => {
+                    // If the value is already a valid URI (has a scheme), use it directly.
+                    // Otherwise wrap it in a literal:// URI so link targets are always valid URIs.
+                    static URI_SCHEME_RE: std::sync::OnceLock<regex::Regex> =
+                        std::sync::OnceLock::new();
+                    let re = URI_SCHEME_RE
+                        .get_or_init(|| regex::Regex::new(r"^[a-zA-Z][a-zA-Z0-9+\-.]*:").unwrap());
+                    if re.is_match(s) {
+                        s.clone()
+                    } else {
+                        Literal::from_string(s.clone())
+                            .to_url()
+                            .expect("Literal::from_string could not be turned into URL")
+                    }
+                }
+                serde_json::Value::Number(n) => {
+                    if let Some(f) = n.as_f64() {
+                        Literal::from_number(f)
+                            .to_url()
+                            .expect("Literal::from_number could not be turned into URL")
+                    } else {
+                        value.to_string()
+                    }
+                }
                 _ => value.to_string(),
             })
         }
@@ -4775,7 +4798,7 @@ mod tests {
         // two links in the batch
         let link1 = create_link();
         let mut link2 = link1.clone();
-        link2.target = "target2".to_string();
+        link2.target = "test://target2".to_string();
 
         let batch_id = perspective.create_batch().await;
 
@@ -5075,7 +5098,7 @@ mod tests {
         let sdna_link = Link {
             source: "test://source".to_string(),
             target: "ad4m://sdna".to_string(),
-            predicate: Some("has_sdna".to_string()),
+            predicate: Some("ad4m://has_sdna".to_string()),
         };
         perspective
             .add_link(
@@ -5332,7 +5355,7 @@ property_setter(c, "rating", '[{action: "setSingleTarget", source: "this", predi
             .add_link(
                 Link {
                     source: "literal://user1".to_string(),
-                    target: "Alice".to_string(),
+                    target: "literal://Alice".to_string(),
                     predicate: Some("user://name".to_string()),
                 },
                 LinkStatus::Shared,
@@ -5346,7 +5369,7 @@ property_setter(c, "rating", '[{action: "setSingleTarget", source: "this", predi
             .add_link(
                 Link {
                     source: "literal://incomplete_recipe".to_string(),
-                    target: "Half Recipe".to_string(),
+                    target: "literal://HalfRecipe".to_string(),
                     predicate: Some("recipe://name".to_string()),
                     // Missing rating - should NOT be found as a Recipe instance
                 },
@@ -5504,11 +5527,18 @@ GROUP BY source
             .get("targets")
             .and_then(|v| v.as_array())
             .unwrap();
-        let has_pasta = r1_targets
+        let has_pasta = r1_targets.iter().any(|v| {
+            v.as_str()
+                .map(|s| s.contains("Pasta") || s.contains("Carbonara"))
+                .unwrap_or(false)
+        });
+        let has_rating_5 = r1_targets
             .iter()
-            .any(|v| v.as_str() == Some("Pasta Carbonara"));
-        let has_rating_5 = r1_targets.iter().any(|v| v.as_str() == Some("5"));
-        assert!(has_pasta, "Recipe1 should have name 'Pasta Carbonara'");
+            .any(|v| v.as_str().map(|s| s.contains('5')).unwrap_or(false));
+        assert!(
+            has_pasta,
+            "Recipe1 should have name containing 'Pasta Carbonara'"
+        );
         assert!(has_rating_5, "Recipe1 should have rating '5'");
 
         // Verify recipe2 has correct properties
@@ -5517,11 +5547,18 @@ GROUP BY source
             .get("targets")
             .and_then(|v| v.as_array())
             .unwrap();
-        let has_pizza = r2_targets
+        let has_pizza = r2_targets.iter().any(|v| {
+            v.as_str()
+                .map(|s| s.contains("Pizza") || s.contains("Margherita"))
+                .unwrap_or(false)
+        });
+        let has_rating_4 = r2_targets
             .iter()
-            .any(|v| v.as_str() == Some("Pizza Margherita"));
-        let has_rating_4 = r2_targets.iter().any(|v| v.as_str() == Some("4"));
-        assert!(has_pizza, "Recipe2 should have name 'Pizza Margherita'");
+            .any(|v| v.as_str().map(|s| s.contains('4')).unwrap_or(false));
+        assert!(
+            has_pizza,
+            "Recipe2 should have name containing 'Pizza Margherita'"
+        );
         assert!(has_rating_4, "Recipe2 should have rating '4'");
 
         println!("\n=== ✓ SUCCESS ===");
@@ -5881,7 +5918,7 @@ GROUP BY source
                 Link {
                     source: "user://alice".to_string(),
                     target: "user://bob".to_string(),
-                    predicate: Some("follows".to_string()),
+                    predicate: Some("ad4m://follows".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -5895,7 +5932,7 @@ GROUP BY source
                 Link {
                     source: "user://alice".to_string(),
                     target: "post://123".to_string(),
-                    predicate: Some("likes".to_string()),
+                    predicate: Some("ad4m://likes".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -5908,14 +5945,14 @@ GROUP BY source
 
         // Test: Filter links by predicate
         let follows = perspective
-            .surreal_query("SELECT * FROM link WHERE predicate = 'follows'".to_string())
+            .surreal_query("SELECT * FROM link WHERE predicate = 'ad4m://follows'".to_string())
             .await
             .unwrap();
 
         assert_eq!(follows.len(), 1, "Should find 1 follow link");
         assert_eq!(
             follows[0].get("predicate").and_then(|v| v.as_str()),
-            Some("follows")
+            Some("ad4m://follows")
         );
     }
 
@@ -5930,7 +5967,7 @@ GROUP BY source
                     Link {
                         source: format!("user://{}", uuid::Uuid::new_v4()),
                         target: "user://alice".to_string(),
-                        predicate: Some("follows".to_string()),
+                        predicate: Some("ad4m://follows".to_string()),
                     },
                     LinkStatus::Shared,
                     None,
@@ -5946,7 +5983,7 @@ GROUP BY source
                     Link {
                         source: format!("user://{}", uuid::Uuid::new_v4()),
                         target: "post://123".to_string(),
-                        predicate: Some("likes".to_string()),
+                        predicate: Some("ad4m://likes".to_string()),
                     },
                     LinkStatus::Shared,
                     None,
@@ -5970,7 +6007,7 @@ GROUP BY source
 
         let follows_stat = stats
             .iter()
-            .find(|s| s.get("predicate").and_then(|v| v.as_str()) == Some("follows"))
+            .find(|s| s.get("predicate").and_then(|v| v.as_str()) == Some("ad4m://follows"))
             .expect("Should find follows stat");
         // Extract count - might be nested in different ways
         let follows_count = follows_stat
@@ -5985,7 +6022,7 @@ GROUP BY source
 
         let likes_stat = stats
             .iter()
-            .find(|s| s.get("predicate").and_then(|v| v.as_str()) == Some("likes"))
+            .find(|s| s.get("predicate").and_then(|v| v.as_str()) == Some("ad4m://likes"))
             .expect("Should find likes stat");
         let likes_count = likes_stat
             .get("total")
@@ -6011,7 +6048,7 @@ GROUP BY source
                 Link {
                     source: "user://alice".to_string(),
                     target: "post://1".to_string(),
-                    predicate: Some("posted".to_string()),
+                    predicate: Some("ad4m://posted".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6025,7 +6062,7 @@ GROUP BY source
                 Link {
                     source: "user://bob".to_string(),
                     target: "post://2".to_string(),
-                    predicate: Some("posted".to_string()),
+                    predicate: Some("ad4m://posted".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6086,7 +6123,7 @@ GROUP BY source
                 Link {
                     source: "user://alice".to_string(),
                     target: "user://bob".to_string(),
-                    predicate: Some("follows".to_string()),
+                    predicate: Some("ad4m://follows".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6100,7 +6137,7 @@ GROUP BY source
                 Link {
                     source: "user://alice".to_string(),
                     target: "user://charlie".to_string(),
-                    predicate: Some("follows".to_string()),
+                    predicate: Some("ad4m://follows".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6113,7 +6150,7 @@ GROUP BY source
 
         let alice_follows = perspective
             .surreal_query(
-                "SELECT target FROM link WHERE in.uri = 'user://alice' AND predicate = 'follows'"
+                "SELECT target FROM link WHERE in.uri = 'user://alice' AND predicate = 'ad4m://follows'"
                     .to_string(),
             )
             .await
@@ -6138,7 +6175,7 @@ GROUP BY source
                 Link {
                     source: "user://bob".to_string(),
                     target: "user://alice".to_string(),
-                    predicate: Some("follows".to_string()),
+                    predicate: Some("ad4m://follows".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6152,7 +6189,7 @@ GROUP BY source
                 Link {
                     source: "user://charlie".to_string(),
                     target: "user://alice".to_string(),
-                    predicate: Some("follows".to_string()),
+                    predicate: Some("ad4m://follows".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6165,7 +6202,7 @@ GROUP BY source
 
         let alice_followers = perspective
             .surreal_query(
-                "SELECT source FROM link WHERE out.uri = 'user://alice' AND predicate = 'follows'"
+                "SELECT source FROM link WHERE out.uri = 'user://alice' AND predicate = 'ad4m://follows'"
                     .to_string(),
             )
             .await
@@ -6190,7 +6227,7 @@ GROUP BY source
                 Link {
                     source: "user://alice".to_string(),
                     target: "user://bob".to_string(),
-                    predicate: Some("follows".to_string()),
+                    predicate: Some("ad4m://follows".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6205,7 +6242,7 @@ GROUP BY source
                 Link {
                     source: "user://charlie".to_string(),
                     target: "user://alice".to_string(),
-                    predicate: Some("follows".to_string()),
+                    predicate: Some("ad4m://follows".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6219,7 +6256,7 @@ GROUP BY source
         // Test: Find all users connected to Alice (either following or followed by)
         let alice_connections = perspective
             .surreal_query(
-                "SELECT source, target FROM link WHERE (in.uri = 'user://alice' OR out.uri = 'user://alice') AND predicate = 'follows'"
+                "SELECT source, target FROM link WHERE (in.uri = 'user://alice' OR out.uri = 'user://alice') AND predicate = 'ad4m://follows'"
                     .to_string(),
             )
             .await
@@ -6242,7 +6279,7 @@ GROUP BY source
                 Link {
                     source: "user://alice".to_string(),
                     target: "user://bob".to_string(),
-                    predicate: Some("follows".to_string()),
+                    predicate: Some("ad4m://follows".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6256,7 +6293,7 @@ GROUP BY source
                 Link {
                     source: "user://alice".to_string(),
                     target: "user://charlie".to_string(),
-                    predicate: Some("follows".to_string()),
+                    predicate: Some("ad4m://follows".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6271,7 +6308,7 @@ GROUP BY source
                 Link {
                     source: "user://bob".to_string(),
                     target: "user://dave".to_string(),
-                    predicate: Some("follows".to_string()),
+                    predicate: Some("ad4m://follows".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6286,7 +6323,7 @@ GROUP BY source
                 Link {
                     source: "user://charlie".to_string(),
                     target: "user://eve".to_string(),
-                    predicate: Some("follows".to_string()),
+                    predicate: Some("ad4m://follows".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6302,7 +6339,7 @@ GROUP BY source
         // Use GROUP BY instead or handle deduplication in application
         let friends_of_friends = perspective
             .surreal_query(
-                "SELECT out->link[WHERE predicate = 'follows'].out.uri AS friend_of_friend FROM link WHERE in.uri = 'user://alice' AND predicate = 'follows'"
+                "SELECT out->link[WHERE predicate = 'ad4m://follows'].out.uri AS friend_of_friend FROM link WHERE in.uri = 'user://alice' AND predicate = 'ad4m://follows'"
                     .to_string(),
             )
             .await
@@ -6324,7 +6361,7 @@ GROUP BY source
                 Link {
                     source: "user://alice".to_string(),
                     target: "user://bob".to_string(),
-                    predicate: Some("follows".to_string()),
+                    predicate: Some("ad4m://follows".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6339,7 +6376,7 @@ GROUP BY source
                 Link {
                     source: "user://bob".to_string(),
                     target: "profile://bob_profile".to_string(),
-                    predicate: Some("has_profile".to_string()),
+                    predicate: Some("ad4m://has_profile".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6353,7 +6390,7 @@ GROUP BY source
         // Test: Get user profiles 2 hops away
         let profiles = perspective
             .surreal_query(
-                "SELECT out.uri AS user, out->link[WHERE predicate = 'has_profile'][0].out.uri AS profile FROM link WHERE in.uri = 'user://alice' AND predicate = 'follows'"
+                "SELECT out.uri AS user, out->link[WHERE predicate = 'ad4m://has_profile'][0].out.uri AS profile FROM link WHERE in.uri = 'user://alice' AND predicate = 'ad4m://follows'"
                     .to_string(),
             )
             .await
@@ -6462,7 +6499,7 @@ GROUP BY source
                 Link {
                     source: "user://alice".to_string(),
                     target: "post://123".to_string(),
-                    predicate: Some("authored".to_string()),
+                    predicate: Some("ad4m://authored".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6477,7 +6514,7 @@ GROUP BY source
                 Link {
                     source: "post://123".to_string(),
                     target: "comment://c1".to_string(),
-                    predicate: Some("has_comment".to_string()),
+                    predicate: Some("ad4m://has_comment".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6491,7 +6528,7 @@ GROUP BY source
                 Link {
                     source: "post://123".to_string(),
                     target: "comment://c2".to_string(),
-                    predicate: Some("has_comment".to_string()),
+                    predicate: Some("ad4m://has_comment".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6505,7 +6542,7 @@ GROUP BY source
         // Test: Find all comments on Alice's posts (2-hop)
         let comments = perspective
             .surreal_query(
-                "SELECT out.uri AS post, out->link[WHERE predicate = 'has_comment'].out.uri AS comments FROM link WHERE in.uri = 'user://alice' AND predicate = 'authored'"
+                "SELECT out.uri AS post, out->link[WHERE predicate = 'ad4m://has_comment'].out.uri AS comments FROM link WHERE in.uri = 'user://alice' AND predicate = 'ad4m://authored'"
                     .to_string(),
             )
             .await
@@ -6675,7 +6712,7 @@ GROUP BY source
                         Link {
                             source: format!("user://user{}", j),
                             target: post_uri.clone(),
-                            predicate: Some("likes".to_string()),
+                            predicate: Some("ad4m://likes".to_string()),
                         },
                         LinkStatus::Shared,
                         None,
@@ -6692,7 +6729,7 @@ GROUP BY source
         // Note: SurrealDB doesn't support HAVING clause, filter in application code
         let all_posts = perspective
             .surreal_query(
-                "SELECT out.uri as post, count() as like_count FROM link WHERE predicate = 'likes' GROUP BY out.uri"
+                "SELECT out.uri as post, count() as like_count FROM link WHERE predicate = 'ad4m://likes' GROUP BY out.uri"
                     .to_string(),
             )
             .await
@@ -6749,7 +6786,7 @@ GROUP BY source
                 Link {
                     source: "user://alice".to_string(),
                     target: "user://bob".to_string(),
-                    predicate: Some("follows".to_string()),
+                    predicate: Some("ad4m://follows".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6763,7 +6800,7 @@ GROUP BY source
                 Link {
                     source: "user://alice".to_string(),
                     target: "post://123".to_string(),
-                    predicate: Some("likes".to_string()),
+                    predicate: Some("ad4m://likes".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6777,7 +6814,7 @@ GROUP BY source
                 Link {
                     source: "user://bob".to_string(),
                     target: "post://456".to_string(),
-                    predicate: Some("likes".to_string()),
+                    predicate: Some("ad4m://likes".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6800,8 +6837,8 @@ GROUP BY source
             .iter()
             .filter_map(|p| p.get("predicate").and_then(|v| v.as_str()))
             .collect();
-        assert!(pred_values.contains(&"follows"));
-        assert!(pred_values.contains(&"likes"));
+        assert!(pred_values.contains(&"ad4m://follows"));
+        assert!(pred_values.contains(&"ad4m://likes"));
     }
 
     #[tokio::test]
@@ -6852,7 +6889,7 @@ GROUP BY source
                 Link {
                     source: "user://alice".to_string(),
                     target: "user://bob".to_string(),
-                    predicate: Some("follows".to_string()),
+                    predicate: Some("ad4m://follows".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6866,7 +6903,7 @@ GROUP BY source
                 Link {
                     source: "user://bob".to_string(),
                     target: "user://alice".to_string(),
-                    predicate: Some("following".to_string()),
+                    predicate: Some("ad4m://following".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6880,7 +6917,7 @@ GROUP BY source
                 Link {
                     source: "user://alice".to_string(),
                     target: "post://123".to_string(),
-                    predicate: Some("likes".to_string()),
+                    predicate: Some("ad4m://likes".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6964,7 +7001,7 @@ GROUP BY source
                 Link {
                     source: "post://123".to_string(),
                     target: "literal://string:Hello%20World".to_string(),
-                    predicate: Some("has_title".to_string()),
+                    predicate: Some("ad4m://has_title".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -6978,7 +7015,7 @@ GROUP BY source
         // Test: Parse string literal
         let result = perspective
             .surreal_query(
-                "SELECT fn::parse_literal(out.uri) AS title FROM link WHERE in.uri = 'post://123' AND predicate = 'has_title'"
+                "SELECT fn::parse_literal(out.uri) AS title FROM link WHERE in.uri = 'post://123' AND predicate = 'ad4m://has_title'"
                     .to_string(),
             )
             .await
@@ -7002,7 +7039,7 @@ GROUP BY source
                 Link {
                     source: "post://456".to_string(),
                     target: "literal://number:42".to_string(),
-                    predicate: Some("has_count".to_string()),
+                    predicate: Some("ad4m://has_count".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -7016,7 +7053,7 @@ GROUP BY source
         // Test: Parse number literal
         let result = perspective
             .surreal_query(
-                "SELECT fn::parse_literal(out.uri) AS count FROM link WHERE in.uri = 'post://456' AND predicate = 'has_count'"
+                "SELECT fn::parse_literal(out.uri) AS count FROM link WHERE in.uri = 'post://456' AND predicate = 'ad4m://has_count'"
                     .to_string(),
             )
             .await
@@ -7054,7 +7091,7 @@ GROUP BY source
                 Link {
                     source: "user://789".to_string(),
                     target: format!("literal://json:{}", encoded_json),
-                    predicate: Some("has_profile".to_string()),
+                    predicate: Some("ad4m://has_profile".to_string()),
                 },
                 LinkStatus::Shared,
                 None,
@@ -7068,7 +7105,7 @@ GROUP BY source
         // Test: Parse JSON literal (should extract .data field)
         let result = perspective
             .surreal_query(
-                "SELECT fn::parse_literal(out.uri) AS profile FROM link WHERE in.uri = 'user://789' AND predicate = 'has_profile'"
+                "SELECT fn::parse_literal(out.uri) AS profile FROM link WHERE in.uri = 'user://789' AND predicate = 'ad4m://has_profile'"
                     .to_string(),
             )
             .await

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -3371,7 +3371,7 @@ impl PerspectiveInstance {
                 Ok(value.to_string())
             }
         } else {
-            Ok(match value {
+            let uri = match value {
                 serde_json::Value::String(s) => {
                     // If the value is already a valid URI (has a scheme), use it directly.
                     // Otherwise wrap it in a literal:// URI so link targets are always valid URIs.
@@ -3384,20 +3384,21 @@ impl PerspectiveInstance {
                     } else {
                         Literal::from_string(s.clone())
                             .to_url()
-                            .expect("Literal::from_string could not be turned into URL")
+                            .map_err(|e| anyhow!("Failed to encode string as literal URI: {}", e))?
                     }
                 }
                 serde_json::Value::Number(n) => {
                     if let Some(f) = n.as_f64() {
                         Literal::from_number(f)
                             .to_url()
-                            .expect("Literal::from_number could not be turned into URL")
+                            .map_err(|e| anyhow!("Failed to encode number as literal URI: {}", e))?
                     } else {
                         value.to_string()
                     }
                 }
                 _ => value.to_string(),
-            })
+            };
+            Ok(uri)
         }
     }
 

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -3378,7 +3378,7 @@ impl PerspectiveInstance {
                     static URI_SCHEME_RE: std::sync::OnceLock<regex::Regex> =
                         std::sync::OnceLock::new();
                     let re = URI_SCHEME_RE
-                        .get_or_init(|| regex::Regex::new(r"^[a-zA-Z][a-zA-Z0-9+\-.]*:").unwrap());
+                        .get_or_init(|| regex::Regex::new(r"^[a-zA-Z][a-zA-Z0-9+\-._]*:").unwrap());
                     if re.is_match(s) {
                         s.clone()
                     } else {

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -3393,7 +3393,9 @@ impl PerspectiveInstance {
                             .to_url()
                             .map_err(|e| anyhow!("Failed to encode number as literal URI: {}", e))?
                     } else {
-                        value.to_string()
+                        Literal::from_string(value.to_string())
+                            .to_url()
+                            .map_err(|e| anyhow!("Failed to encode number as literal URI: {}", e))?
                     }
                 }
                 _ => value.to_string(),

--- a/rust-executor/src/types.rs
+++ b/rust-executor/src/types.rs
@@ -111,12 +111,13 @@ impl Link {
     /// Validates that source and target are non-empty URIs (RFC 3986 scheme present),
     /// and that predicate, if present, is also a valid URI.
     ///
-    /// A valid URI must begin with a scheme: `[a-zA-Z][a-zA-Z0-9+\-.]*:`
-    /// Examples: `did:key:alice`, `expression://Qm...`, `neighbourhood://Qm...`
+    /// A valid URI must begin with a scheme: `[a-zA-Z][a-zA-Z0-9+\-._]*:`
+    /// (underscore is included as a pragmatic extension for schemes like `smart_literal://`)
+    /// Examples: `did:key:alice`, `expression://Qm...`, `smart_literal://content`
     pub fn validate(&self) -> Result<(), AnyError> {
         use std::sync::OnceLock;
         static URI_SCHEME_RE: OnceLock<Regex> = OnceLock::new();
-        let re = URI_SCHEME_RE.get_or_init(|| Regex::new(r"^[a-zA-Z][a-zA-Z0-9+\-.]*:").unwrap());
+        let re = URI_SCHEME_RE.get_or_init(|| Regex::new(r"^[a-zA-Z][a-zA-Z0-9+\-._]*:").unwrap());
 
         let check = |field: &str, value: &str| -> Result<(), AnyError> {
             if value.is_empty() {

--- a/rust-executor/src/types.rs
+++ b/rust-executor/src/types.rs
@@ -107,6 +107,41 @@ impl Link {
             target: self.target.clone(),
         }
     }
+
+    /// Validates that source and target are non-empty URIs (RFC 3986 scheme present),
+    /// and that predicate, if present, is also a valid URI.
+    ///
+    /// A valid URI must begin with a scheme: `[a-zA-Z][a-zA-Z0-9+\-.]*:`
+    /// Examples: `did:key:alice`, `expression://Qm...`, `neighbourhood://Qm...`
+    pub fn validate(&self) -> Result<(), AnyError> {
+        use std::sync::OnceLock;
+        static URI_SCHEME_RE: OnceLock<Regex> = OnceLock::new();
+        let re = URI_SCHEME_RE.get_or_init(|| Regex::new(r"^[a-zA-Z][a-zA-Z0-9+\-.]*:").unwrap());
+
+        let check = |field: &str, value: &str| -> Result<(), AnyError> {
+            if value.is_empty() {
+                return Err(anyhow!("Link {} must not be empty", field));
+            }
+            if !re.is_match(value) {
+                return Err(anyhow!(
+                    "Link {} is not a valid URI (must start with a scheme like 'did:', 'expression://', etc.): '{}'",
+                    field, value
+                ));
+            }
+            Ok(())
+        };
+
+        check("source", &self.source)?;
+        check("target", &self.target)?;
+
+        if let Some(predicate) = &self.predicate {
+            if !predicate.is_empty() {
+                check("predicate", predicate)?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(GraphQLObject, Debug, Deserialize, Serialize, Clone, PartialEq)]

--- a/tests/js/tests/agent.ts
+++ b/tests/js/tests/agent.ts
@@ -66,7 +66,7 @@ export default function agentTests(testContext: TestContext) {
                 let link = new LinkExpression();
                 link.author = "did:test";
                 link.timestamp = new Date().toISOString();
-                link.data = new Link({source: "src", target: "target", predicate: "pred"});
+                link.data = new Link({source: "ad4m://src", target: "test://target", predicate: "ad4m://pred"});
                 link.proof = new ExpressionProof("sig", "key")
                 const updatePerspective = await ad4mClient.agent.updatePublicPerspective(new Perspective([link]))
                 expect(currentAgent.perspective).not.to.be.undefined

--- a/tests/js/tests/integration.test.ts
+++ b/tests/js/tests/integration.test.ts
@@ -167,7 +167,7 @@ describe("Integration tests", function () {
           let link = new LinkExpression();
           link.author = "did:test";
           link.timestamp = new Date().toISOString();
-          link.data = new Link({source: "src", target: "target", predicate: "pred"});
+          link.data = new Link({source: "ad4m://src", target: "test://target", predicate: "ad4m://pred"});
           link.proof = new ExpressionProof("sig", "key")
 
           await testContext.bob.agent.updatePublicPerspective(new Perspective([link]))

--- a/tests/js/tests/multi-user-simple.test.ts
+++ b/tests/js/tests/multi-user-simple.test.ts
@@ -476,7 +476,7 @@ describe("Multi-User Simple integration tests", () => {
             const p1 = await client1.perspective.add("User 1 Test Perspective");
             // @ts-ignore - Suppress Apollo type mismatch
             const link1 = await client1.perspective.addLink(p1.uuid, {
-                source: "root",
+                source: "ad4m://root",
                 target: "test://target1",
                 predicate: "test://predicate"
             });
@@ -494,7 +494,7 @@ describe("Multi-User Simple integration tests", () => {
             const p2 = await client2.perspective.add("User 2 Test Perspective");
             // @ts-ignore - Suppress Apollo type mismatch
             const link2 = await client2.perspective.addLink(p2.uuid, {
-                source: "root",
+                source: "ad4m://root",
                 target: "test://target2",
                 predicate: "test://predicate"
             });

--- a/tests/js/tests/neighbourhood.ts
+++ b/tests/js/tests/neighbourhood.ts
@@ -195,19 +195,19 @@ export default function neighbourhoodTests(testContext: TestContext) {
 
                 // Alice creates some links
                 console.log("Alice creating links...")
-                await testContext.alice.perspective.addLink(aliceP1.uuid, {source: 'alice', target: 'test://alice/1'})
-                await testContext.alice.perspective.addLink(aliceP1.uuid, {source: 'alice', target: 'test://alice/2'})
-                await testContext.alice.perspective.addLink(aliceP1.uuid, {source: 'alice', target: 'test://alice/3'})
+                await testContext.alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://alice', target: 'test://alice/1'})
+                await testContext.alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://alice', target: 'test://alice/2'})
+                await testContext.alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://alice', target: 'test://alice/3'})
 
                 // Wait for sync with retry loop
-                bobLinks = await testContext.bob.perspective.queryLinks(bobP1.uuid, new LinkQuery({source: 'alice'}))
+                bobLinks = await testContext.bob.perspective.queryLinks(bobP1.uuid, new LinkQuery({source: 'ad4m://alice'}))
                 let bobTries = 1
                 const maxTriesBob = 20 // 20 tries with 2 second sleep = 40 seconds max
 
                 while(bobLinks.length < 3 && bobTries < maxTriesBob) {
                     console.log(`Bob retrying getting Alice's links... Got ${bobLinks.length}/3`);
                     await sleep(2000)
-                    bobLinks = await testContext.bob.perspective.queryLinks(bobP1.uuid, new LinkQuery({source: 'alice'}))
+                    bobLinks = await testContext.bob.perspective.queryLinks(bobP1.uuid, new LinkQuery({source: 'ad4m://alice'}))
                     bobTries++
                 }
 
@@ -219,19 +219,19 @@ export default function neighbourhoodTests(testContext: TestContext) {
 
                 // Bob creates some links
                 console.log("Bob creating links...")
-                await testContext.bob.perspective.addLink(bobP1.uuid, {source: 'bob', target: 'test://bob/1'})
-                await testContext.bob.perspective.addLink(bobP1.uuid, {source: 'bob', target: 'test://bob/2'}) 
-                await testContext.bob.perspective.addLink(bobP1.uuid, {source: 'bob', target: 'test://bob/3'})
+                await testContext.bob.perspective.addLink(bobP1.uuid, {source: 'ad4m://bob', target: 'test://bob/1'})
+                await testContext.bob.perspective.addLink(bobP1.uuid, {source: 'ad4m://bob', target: 'test://bob/2'})
+                await testContext.bob.perspective.addLink(bobP1.uuid, {source: 'ad4m://bob', target: 'test://bob/3'})
 
                 // Wait for sync with retry loop
-                let aliceLinks = await testContext.alice.perspective.queryLinks(aliceP1.uuid, new LinkQuery({source: 'bob'}))
+                let aliceLinks = await testContext.alice.perspective.queryLinks(aliceP1.uuid, new LinkQuery({source: 'ad4m://bob'}))
                 tries = 1
                 const maxTriesAlice = 20 // 2 minutes with 1 second sleep
 
                 while(aliceLinks.length < 3 && tries < maxTriesAlice) {
                     console.log(`Alice retrying getting links... Got ${aliceLinks.length}/3`);
                     await sleep(2000)
-                    aliceLinks = await testContext.alice.perspective.queryLinks(aliceP1.uuid, new LinkQuery({source: 'bob'}))
+                    aliceLinks = await testContext.alice.perspective.queryLinks(aliceP1.uuid, new LinkQuery({source: 'ad4m://bob'}))
                     tries++
                 }
 

--- a/tests/js/tests/neighbourhood.ts
+++ b/tests/js/tests/neighbourhood.ts
@@ -27,7 +27,7 @@ export default function neighbourhoodTests(testContext: TestContext) {
                 let link = new LinkExpression()
                 link.author = "did:test";
                 link.timestamp = new Date().toISOString();
-                link.data = new Link({source: "src", target: "target", predicate: "pred"});
+                link.data = new Link({source: "ad4m://src", target: "test://target", predicate: "ad4m://pred"});
                 link.proof = new ExpressionProof("sig", "key");
                 const publishPerspective = await ad4mClient.neighbourhood.publishFromPerspective(create.uuid, socialContext.address,
                     new Perspective(
@@ -93,17 +93,17 @@ export default function neighbourhoodTests(testContext: TestContext) {
 
                 await sleep(1000)
 
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
 
                 await sleep(1000)
 
-                let bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'root'}))
+                let bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                 let tries = 1
 
                 while(bobLinks.length < 1 && tries < 60) {
                     console.log("Bob retrying getting links...");
                     await sleep(1000)
-                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'root'}))
+                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                     tries++
                 }
 
@@ -127,17 +127,17 @@ export default function neighbourhoodTests(testContext: TestContext) {
 
                 await sleep(1000)
 
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'}, 'local')
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'}, 'local')
 
                 await sleep(1000)
 
-                let bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'root'}))
+                let bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                 let tries = 1
 
                 while(bobLinks.length < 1 && tries < 5) {
                     console.log("Bob retrying getting NOT received links...");
                     await sleep(1000)
-                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'root'}))
+                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                     tries++
                 }
 
@@ -162,7 +162,7 @@ export default function neighbourhoodTests(testContext: TestContext) {
                 //const linkPromises = []
                 for(let i = 0; i < 1500; i++) {
                     console.log("Alice adding link ", i)
-                    const link = await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: `test://test/${i}`})
+                    const link = await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: `test://test/${i}`})
                     console.log("Link expression:", link)
                 }
                 //await Promise.all(linkPromises)
@@ -170,14 +170,14 @@ export default function neighbourhoodTests(testContext: TestContext) {
                 console.log("wait 15s for initial sync")
                 await sleep(15000)
 
-                let bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'root'}))
+                let bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                 let tries = 1
                 const maxTries = 180 // 3 minutes with 1 second sleep (increased for fallback sync)
 
                 while(bobLinks.length < 1500 && tries < maxTries) {
                     console.log(`Bob retrying getting links... Got ${bobLinks.length}/1500`);
                     await sleep(1000)
-                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'root'}))
+                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                     tries++
                 }
 
@@ -275,7 +275,7 @@ export default function neighbourhoodTests(testContext: TestContext) {
 
             //     aliceP1.addSyncStateChangeListener(aliceSyncChangeHandler);
 
-            //     await testContext.alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
+            //     await testContext.alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
 
             //     let bobSyncChangeCalls = 0;
             //     let bobSyncChangeData = null;
@@ -295,12 +295,12 @@ export default function neighbourhoodTests(testContext: TestContext) {
 
             //     //These next assertions are flaky since they depend on holochain not syncing right away, which most of the time is the case
 
-            //     let bobLinks = await testContext.bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'root'}))
+            //     let bobLinks = await testContext.bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
             //     let tries = 1
 
             //     while(bobLinks.length < 1 && tries < 300) {
             //         await sleep(1000)
-            //         bobLinks = await testContext.bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'root'}))
+            //         bobLinks = await testContext.bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
             //         tries++
             //     }
 
@@ -368,7 +368,7 @@ export default function neighbourhoodTests(testContext: TestContext) {
                     let link = new LinkExpression()
                     link.author = "did:test";
                     link.timestamp = new Date().toISOString();
-                    link.data = new Link({source: "src", target: "target", predicate: "pred"});
+                    link.data = new Link({source: "ad4m://src", target: "test://target", predicate: "ad4m://pred"});
                     link.proof = new ExpressionProof("sig", "key");
                     link.proof.invalid = true;
                     link.proof.valid = false;

--- a/tests/js/tests/perspective.ts
+++ b/tests/js/tests/perspective.ts
@@ -136,13 +136,13 @@ export default function perspectiveTests(testContext: TestContext) {
                 expect(perspective.name).to.equal('test-duplicate-link-removal');
 
                 // create link
-                const link = { source: 'root', predicate: 'p', target: 'abc' };
+                const link = { source: 'ad4m://root', predicate: 'ad4m://p', target: 'test://abc' };
                 const addLink = await perspective.add(link);
-                expect(addLink.data.target).to.equal("abc");
+                expect(addLink.data.target).to.equal("test://abc");
 
                 // get link expression
                 const linkExpression = (await perspective.get(new LinkQuery(link)))[0];
-                expect(linkExpression.data.target).to.equal("abc");
+                expect(linkExpression.data.target).to.equal("test://abc");
 
                 // attempt to remove link twice (currently errors and prevents further execution of code)
                 await perspective.removeLinks([linkExpression, linkExpression])
@@ -291,12 +291,12 @@ export default function perspectiveTests(testContext: TestContext) {
                 const linkUpdated = sinon.fake()
                 await ad4mClient.perspective.addPerspectiveLinkUpdatedListener(p1.uuid, [linkUpdated])
 
-                const linkExpression = await ad4mClient.perspective.addLink(p1.uuid , {source: 'root', target: 'lang://123'})
+                const linkExpression = await ad4mClient.perspective.addLink(p1.uuid , {source: 'ad4m://root', target: 'lang://123'})
                 await sleep(1000)
                 expect(linkAdded.called).to.be.true;
                 expect(linkAdded.getCall(0).args[0]).to.eql(linkExpression)
 
-                const updatedLinkExpression = await ad4mClient.perspective.updateLink(p1.uuid , linkExpression, {source: 'root', target: 'lang://456'})
+                const updatedLinkExpression = await ad4mClient.perspective.updateLink(p1.uuid , linkExpression, {source: 'ad4m://root', target: 'lang://456'})
                 await sleep(1000)
                 expect(linkUpdated.called).to.be.true;
                 expect(linkUpdated.getCall(0).args[0].newLink).to.eql(updatedLinkExpression)
@@ -818,7 +818,7 @@ export default function perspectiveTests(testContext: TestContext) {
                 const link1 = new Link({
                     source: 'test://source',
                     predicate: 'test://predicate',
-                    target: 'target1'
+                    target: 'test://target1'
                 })
 
                 await proxy.setSingleTarget(link1)
@@ -826,12 +826,12 @@ export default function perspectiveTests(testContext: TestContext) {
                 expect(result1.source).to.equal(link1.source)
                 expect(result1.predicate).to.equal(link1.predicate)
                 expect(result1.target).to.equal(link1.target)
-                expect(await proxy.getSingleTarget(new LinkQuery(link1))).to.equal('target1')
+                expect(await proxy.getSingleTarget(new LinkQuery(link1))).to.equal('test://target1')
 
                 const link2 = new Link({
                     source: 'test://source',
                     predicate: 'test://predicate',
-                    target: 'target2'
+                    target: 'test://target2'
                 })
 
                 await proxy.setSingleTarget(link2)
@@ -840,7 +840,7 @@ export default function perspectiveTests(testContext: TestContext) {
                 expect(result2.source).to.equal(link2.source)
                 expect(result2.predicate).to.equal(link2.predicate)
                 expect(result2.target).to.equal(link2.target)
-                expect(await proxy.getSingleTarget(new LinkQuery(link1))).to.equal('target2')
+                expect(await proxy.getSingleTarget(new LinkQuery(link1))).to.equal('test://target2')
             })
 
             // SdnaOnly doesn't load links into prolog engine

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -907,14 +907,11 @@ describe("Prolog + Literals", () => {
                     const recipe = new Recipe(perspective!, root)
 
                     const longName = "This is a very long recipe name that goes on and on with many many characters to test that we can handle long property values without any issues whatsoever and keep going even longer to make absolutely sure we hit at least 300 characters in this test string that just keeps getting longer and longer until we are completely satisfied that it works properly with such lengthy content. But wait, there's more! We need to make this string even longer to properly test the system's ability to handle extremely long property values. Let's add some more meaningful content about recipes - ingredients like flour, sugar, eggs, milk, butter, vanilla extract, baking powder, salt, and detailed instructions for mixing them together in just the right way to create the perfect baked goods. We could go on about preheating the oven to the right temperature, greasing the pans properly, checking for doneness with a toothpick, and letting things cool completely before frosting. The possibilities are endless when it comes to recipe details and instructions that could make this string longer and longer. We want to be absolutely certain that our system can handle property values of any reasonable length without truncating or corrupting the data in any way. This is especially important for recipes where precise instructions and ingredient amounts can make the difference between success and failure in the kitchen. Testing with realistically long content helps ensure our system works reliably in real-world usage scenarios where users might enter detailed information that extends well beyond a few simple sentences."
-                    recipe.plain = longName
+                    // Use resolve (resolveLanguage: "literal") to store the long string value.
+                    // The plain property is for storing URI addresses; resolve encodes arbitrary strings.
                     recipe.resolve = longName
 
                     await recipe.save()
-
-                    let linksName = await perspective!.get(new LinkQuery({source: root, predicate: "recipe://plain"}))
-                    expect(linksName.length).to.equal(1)
-                    expect(linksName[0].data.target).to.equal(longName)
 
                     let linksResolve = await perspective!.get(new LinkQuery({source: root, predicate: "recipe://resolve"}))
                     expect(linksResolve.length).to.equal(1)
@@ -923,9 +920,6 @@ describe("Prolog + Literals", () => {
 
                     const recipe2 = new Recipe(perspective!, root)
                     await recipe2.get()
-
-                    expect(recipe2.plain.length).to.equal(longName.length)
-                    expect(recipe2.plain).to.equal(longName)
 
                     expect(recipe2.resolve.length).to.equal(longName.length)
                     expect(recipe2.resolve).to.equal(longName)
@@ -1006,13 +1000,13 @@ describe("Prolog + Literals", () => {
                 it("findAll() returns collections on instances", async () => {
                     let root1 = Literal.from("findAll test 1").toUrl()
                     let root2 = Literal.from("findAll test 2").toUrl()
-                    
+
                     const recipe1 = new Recipe(perspective!, root1)
-                    recipe1.comments = ["Recipe 1: Comment 1", "Recipe 1: Comment 2"];
+                    recipe1.comments = ["recipe://comment/r1/1", "recipe://comment/r1/2"];
                     await recipe1.save();
 
                     const recipe2 = new Recipe(perspective!, root2)
-                    recipe2.comments = ["Recipe 2: Comment 1", "Recipe 2: Comment 2"];
+                    recipe2.comments = ["recipe://comment/r2/1", "recipe://comment/r2/2"];
                     await recipe2.save();
 
                     // Test findAll
@@ -1020,12 +1014,12 @@ describe("Prolog + Literals", () => {
 
                     expect(recipes.length).to.equal(2);
                     expect(recipes[0].comments.length).to.equal(2);
-                    expect(recipes[0].comments).to.include("Recipe 1: Comment 1");
-                    expect(recipes[0].comments).to.include("Recipe 1: Comment 2");
+                    expect(recipes[0].comments).to.include("recipe://comment/r1/1");
+                    expect(recipes[0].comments).to.include("recipe://comment/r1/2");
 
                     expect(recipes[1].comments.length).to.equal(2);
-                    expect(recipes[1].comments).to.include("Recipe 2: Comment 1");
-                    expect(recipes[1].comments).to.include("Recipe 2: Comment 2");
+                    expect(recipes[1].comments).to.include("recipe://comment/r2/1");
+                    expect(recipes[1].comments).to.include("recipe://comment/r2/2");
                 })
 
                 it("findAll() returns author & timestamp on instances", async () => {
@@ -1110,8 +1104,8 @@ describe("Prolog + Literals", () => {
                 it("findAll() works with collections query", async () => {
                     let root = Literal.from("findAll test 1").toUrl()
                     const recipe = new Recipe(perspective!, root);
-                    recipe.comments = ["Recipe 1: Comment 1", "Recipe 1: Comment 2"];
-                    recipe.entries = ["Recipe 1: Entry 1", "Recipe 1: Entry 2"];
+                    recipe.comments = ["recipe://comment/1", "recipe://comment/2"];
+                    recipe.entries = ["recipe://entry/1", "recipe://entry/2"];
                     await recipe.save();
 
                     // Test recipes with all collections
@@ -1501,15 +1495,15 @@ describe("Prolog + Literals", () => {
                     const recipe1 = new Recipe(perspective!);
                     recipe1.name = "Recipe 1";
                     recipe1.booleanTest = true;
-                    recipe1.comments = ["Recipe 1: Comment 1", "Recipe 1: Comment 2"];
-                    recipe1.entries = ["Recipe 1: Entry 1", "Recipe 1: Entry 2"];
+                    recipe1.comments = ["recipe://comment/r1/1", "recipe://comment/r1/2"];
+                    recipe1.entries = ["recipe://entry/r1/1", "recipe://entry/r1/2"];
                     await recipe1.save();
 
                     const recipe2 = new Recipe(perspective!);
                     recipe2.name = "Recipe 2";
                     recipe2.booleanTest = false;
-                    recipe2.comments = ["Recipe 2: Comment 1", "Recipe 2: Comment 2"];
-                    recipe2.entries = ["Recipe 2: Entry 1", "Recipe 2: Entry 2"];
+                    recipe2.comments = ["recipe://comment/r2/1", "recipe://comment/r2/2"];
+                    recipe2.entries = ["recipe://entry/r2/1", "recipe://entry/r2/2"];
                     await recipe2.save();
 
                     // Check all recipes are there
@@ -2286,7 +2280,7 @@ describe("Prolog + Literals", () => {
                     // Create and save multiple models in batch
                     const recipe = new BatchRecipe(perspective!);
                     recipe.name = "Pasta";
-                    recipe.ingredients = ["pasta", "sauce", "cheese"];
+                    recipe.ingredients = ["recipe://ingredient/pasta", "recipe://ingredient/sauce", "recipe://ingredient/cheese"];
                     await recipe.save(batchId);
                     
 
@@ -2311,7 +2305,7 @@ describe("Prolog + Literals", () => {
                     const recipesAfterCommit = await BatchRecipe.findAll(perspective!);
                     expect(recipesAfterCommit.length).to.equal(1);
                     expect(recipesAfterCommit[0].name).to.equal("Pasta");
-                    expect(recipesAfterCommit[0].ingredients).to.have.members(["pasta", "sauce", "cheese"]);
+                    expect(recipesAfterCommit[0].ingredients).to.have.members(["recipe://ingredient/pasta", "recipe://ingredient/sauce", "recipe://ingredient/cheese"]);
 
                     const notesAfterCommit = await BatchNote.findAll(perspective!);
                     expect(notesAfterCommit.length).to.equal(1);
@@ -2320,7 +2314,7 @@ describe("Prolog + Literals", () => {
 
                     // Test updating models in batch
                     const updateBatchId = await perspective!.createBatch();
-                    recipe.ingredients.push("garlic");
+                    recipe.ingredients.push("recipe://ingredient/garlic");
                     await recipe.update(updateBatchId);
 
                     note.content = "Updated: Use fresh ingredients and add garlic";
@@ -2328,7 +2322,7 @@ describe("Prolog + Literals", () => {
 
                     // Verify models haven't changed before commit
                     const recipesBeforeUpdate = await BatchRecipe.findAll(perspective!);
-                    expect(recipesBeforeUpdate[0].ingredients).to.have.members(["pasta", "sauce", "cheese"]);
+                    expect(recipesBeforeUpdate[0].ingredients).to.have.members(["recipe://ingredient/pasta", "recipe://ingredient/sauce", "recipe://ingredient/cheese"]);
 
                     const notesBeforeUpdate = await BatchNote.findAll(perspective!);
                     expect(notesBeforeUpdate[0].content).to.equal("Make sure to use fresh ingredients");
@@ -2340,10 +2334,10 @@ describe("Prolog + Literals", () => {
                     // Verify models are updated
                     const recipesAfterUpdate = await BatchRecipe.findAll(perspective!);
                     expect(recipesAfterUpdate[0].ingredients.length).to.equal(4);
-                    expect(recipesAfterUpdate[0].ingredients.includes("pasta")).to.be.true;
-                    expect(recipesAfterUpdate[0].ingredients.includes("sauce")).to.be.true;
-                    expect(recipesAfterUpdate[0].ingredients.includes("cheese")).to.be.true;
-                    expect(recipesAfterUpdate[0].ingredients.includes("garlic")).to.be.true;
+                    expect(recipesAfterUpdate[0].ingredients.includes("recipe://ingredient/pasta")).to.be.true;
+                    expect(recipesAfterUpdate[0].ingredients.includes("recipe://ingredient/sauce")).to.be.true;
+                    expect(recipesAfterUpdate[0].ingredients.includes("recipe://ingredient/cheese")).to.be.true;
+                    expect(recipesAfterUpdate[0].ingredients.includes("recipe://ingredient/garlic")).to.be.true;
 
                     const notesAfterUpdate = await BatchNote.findAll(perspective!);
                     expect(notesAfterUpdate[0].content).to.equal("Updated: Use fresh ingredients and add garlic");
@@ -3793,9 +3787,9 @@ describe("Prolog + Literals", () => {
                 
                 // Test array/collection handling
                 // @ts-ignore - properties are added dynamically from JSON Schema
-                post1.tags = ["ad4m", "tutorial", "blockchain"]
+                post1.tags = ["tag://ad4m", "tag://tutorial", "tag://blockchain"]
                 // @ts-ignore - properties are added dynamically from JSON Schema
-                post1.categories = ["technology", "development"]
+                post1.categories = ["category://technology", "category://development"]
                 
                 // Test complex object handling (should be stored as JSON)
                 // @ts-ignore - properties are added dynamically from JSON Schema
@@ -3812,9 +3806,9 @@ describe("Prolog + Literals", () => {
                 // @ts-ignore - properties are added dynamically from JSON Schema
                 post2.title = "Advanced AD4M Patterns"
                 // @ts-ignore - properties are added dynamically from JSON Schema
-                post2.tags = ["ad4m", "advanced", "patterns"]
+                post2.tags = ["tag://ad4m", "tag://advanced", "tag://patterns"]
                 // @ts-ignore - properties are added dynamically from JSON Schema
-                post2.categories = ["technology"]
+                post2.categories = ["category://technology"]
                 // @ts-ignore - properties are added dynamically from JSON Schema
                 post2.metadata = {
                     created: "2025-09-22T11:00:00Z",
@@ -3835,7 +3829,7 @@ describe("Prolog + Literals", () => {
                 // @ts-ignore - properties are added dynamically from JSON Schema
                 expect(tutorialPost!.tags).to.be.an('array')
                 // @ts-ignore - properties are added dynamically from JSON Schema
-                expect(tutorialPost!.tags).to.include.members(["ad4m", "tutorial", "blockchain"])
+                expect(tutorialPost!.tags).to.include.members(["tag://ad4m", "tag://tutorial", "tag://blockchain"])
                 
                 // @ts-ignore - properties are added dynamically from JSON Schema
                 expect(tutorialPost!.metadata).to.be.an('object')
@@ -3904,7 +3898,7 @@ describe("Prolog + Literals", () => {
                 // @ts-ignore - properties are added dynamically from JSON Schema
                 person.email = "alice@example.com"
                 // @ts-ignore - properties are added dynamically from JSON Schema
-                person.skills = ["javascript", "typescript", "ad4m"]
+                person.skills = ["skill://javascript", "skill://typescript", "skill://ad4m"]
                 // @ts-ignore - properties are added dynamically from JSON Schema
                 person.profile = {
                     bio: "Software developer passionate about decentralized systems",
@@ -3922,7 +3916,7 @@ describe("Prolog + Literals", () => {
                 // @ts-ignore - properties are added dynamically from JSON Schema
                 expect(alice.profile.bio).to.equal("Software developer passionate about decentralized systems")
                 // @ts-ignore - properties are added dynamically from JSON Schema
-                expect(alice.skills).to.include.members(["javascript", "typescript", "ad4m"])
+                expect(alice.skills).to.include.members(["skill://javascript", "skill://typescript", "skill://ad4m"])
             })
         })
     })

--- a/tests/js/tests/triple-agent-test.ts
+++ b/tests/js/tests/triple-agent-test.ts
@@ -38,73 +38,73 @@ export default function tripleAgentTests(testContext: TestContext) {
 
                 await sleep(1000)
 
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
 
                 await sleep(1000)
 
-                let bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'root'}))
+                let bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                 let tries = 1
 
                 while(bobLinks.length < 10 && tries < 20) {
                     console.log("Bob retrying getting links...");
                     await sleep(1000)
-                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'root'}))
+                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                     tries++
                 }
                 
                 expect(bobLinks.length).to.be.equal(10)
 
-                await bob.perspective.addLink(bobP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await bob.perspective.addLink(bobP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await bob.perspective.addLink(bobP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await bob.perspective.addLink(bobP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await bob.perspective.addLink(bobP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
+                await bob.perspective.addLink(bobP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await bob.perspective.addLink(bobP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await bob.perspective.addLink(bobP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await bob.perspective.addLink(bobP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await bob.perspective.addLink(bobP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
 
-                let jimLinks = await jim.perspective.queryLinks(jimP1!.uuid, new LinkQuery({source: 'root'}))
+                let jimLinks = await jim.perspective.queryLinks(jimP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                 let jimRetries = 1
 
                 while(jimLinks.length < 20 && jimRetries < 20) {
                     console.log("Jim retrying getting links...");
                     await sleep(1000)
-                    jimLinks = await jim.perspective.queryLinks(jimP1!.uuid, new LinkQuery({source: 'root'}))
+                    jimLinks = await jim.perspective.queryLinks(jimP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                     jimRetries++
                 }
                 
                 expect(jimLinks.length).to.be.equal(20)
 
                 //Alice bob and jim all collectively add 10 links and then check can be received by all agents
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await bob.perspective.addLink(bobP1.uuid, {source: 'root', target: 'test://test'})
-                await jim.perspective.addLink(jimP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await bob.perspective.addLink(bobP1.uuid, {source: 'root', target: 'test://test'})
-                await jim.perspective.addLink(jimP1.uuid, {source: 'root', target: 'test://test'})
-                await alice.perspective.addLink(aliceP1.uuid, {source: 'root', target: 'test://test'})
-                await bob.perspective.addLink(bobP1.uuid, {source: 'root', target: 'test://test'})
-                await jim.perspective.addLink(jimP1.uuid, {source: 'root', target: 'test://test'})
-                await jim.perspective.addLink(jimP1.uuid, {source: 'root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await bob.perspective.addLink(bobP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await jim.perspective.addLink(jimP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await bob.perspective.addLink(bobP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await jim.perspective.addLink(jimP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await bob.perspective.addLink(bobP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await jim.perspective.addLink(jimP1.uuid, {source: 'ad4m://root', target: 'test://test'})
+                await jim.perspective.addLink(jimP1.uuid, {source: 'ad4m://root', target: 'test://test'})
 
-                let aliceLinks = await alice.perspective.queryLinks(aliceP1!.uuid, new LinkQuery({source: 'root'}))
+                let aliceLinks = await alice.perspective.queryLinks(aliceP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                 tries = 1
 
                 while(aliceLinks.length < 30 && tries < 20) {
                     console.log("Alice retrying getting links...");
                     await sleep(1000)
-                    aliceLinks = await alice.perspective.queryLinks(aliceP1!.uuid, new LinkQuery({source: 'root'}))
+                    aliceLinks = await alice.perspective.queryLinks(aliceP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                     tries++
                 }
                 
@@ -113,13 +113,13 @@ export default function tripleAgentTests(testContext: TestContext) {
 
 
 
-                bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'root'}))
+                bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                 tries = 1
 
                 while(bobLinks.length < 30 && tries < 20) {
                     console.log("Bob retrying getting links...");
                     await sleep(1000)
-                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'root'}))
+                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                     tries++
                 }
                 
@@ -128,13 +128,13 @@ export default function tripleAgentTests(testContext: TestContext) {
 
 
 
-                jimLinks = await jim.perspective.queryLinks(jimP1!.uuid, new LinkQuery({source: 'root'}))
+                jimLinks = await jim.perspective.queryLinks(jimP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                 tries = 1
 
                 while(jimLinks.length < 30 && tries < 20) {
                     console.log("Jim retrying getting links...");
                     await sleep(1000)
-                    jimLinks = await jim.perspective.queryLinks(jimP1!.uuid, new LinkQuery({source: 'root'}))
+                    jimLinks = await jim.perspective.queryLinks(jimP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                     tries++
                 }
                 


### PR DESCRIPTION
  Add Link::validate() that enforces RFC 3986 scheme presence
  ([a-zA-Z][a-zA-Z0-9+\-.]*:) on source, target, and predicate before
  any link is stored. Called at all four entry points: add_link,
  add_links, add_link_expression, and link_mutations. Any invalid link
  now returns an error immediately instead of silently corrupting the
  perspective graph.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added earlier, stricter validation of link data so invalid links are rejected before persistence.
  * Normalized string/number literals into valid URIs with scheme detection to prevent malformed links.
  * Standardized predicate namespaces to ad4m:// across link handling and queries.

* **Tests**
  * Updated test data and expectations to reflect URI normalization and ad4m:// predicate namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->