### PR TITLE
feat(test-runner): auto-transform CJS bundles to ESM for Deno runtime

### DIFF
--- a/test-runner/src/bundleTransform.ts
+++ b/test-runner/src/bundleTransform.ts
@@ -1,0 +1,162 @@
+/**
+ * Bundle Transform Utilities
+ *
+ * Converts CJS system language bundles to ESM for Deno runtime compatibility,
+ * and patches out removed IPFS references from the Language Language bundle.
+ *
+ * Background: System language bundles downloaded from perspect3vism repos are
+ * CommonJS, but the AD4M executor's Deno runtime requires ESM. Additionally,
+ * the Language Language bundle still references `context.IPFS.add()` which was
+ * removed from the executor, causing crashes during language publishing.
+ *
+ * @module bundleTransform
+ */
+
+import { logger } from './utils';
+
+/** Node built-in modules that need 'node:' prefix in Deno */
+const NODE_BUILTINS = new Set([
+  'assert', 'buffer', 'child_process', 'cluster', 'console', 'constants',
+  'crypto', 'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'https',
+  'module', 'net', 'os', 'path', 'perf_hooks', 'process', 'punycode',
+  'querystring', 'readline', 'repl', 'stream', 'string_decoder', 'sys',
+  'timers', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'worker_threads', 'zlib'
+]);
+
+/**
+ * Detect whether a bundle is CJS (contains require() or exports assignments).
+ */
+export function isCjsBundle(code: string): boolean {
+  return /\brequire\s*\(/.test(code) || /\bexports\s*[.[]/.test(code);
+}
+
+/**
+ * Convert a CJS bundle to ESM.
+ *
+ * Handles:
+ * - `var x = require('module')` → `import x from 'module'`
+ * - `exports.name = value` → `export { value as name }`
+ * - `exports.default = value` / `exports["default"] = value` → `export default value`
+ * - Node builtin requires get `node:` prefix for Deno compatibility
+ * - Strips `'use strict'`, `Object.defineProperty(exports, '__esModule', ...)`, sourcemaps
+ */
+export function convertCjsToEsm(code: string): string {
+  let esm = code;
+
+  // Strip CJS boilerplate
+  esm = esm.replace(/^'use strict';\s*/m, '');
+  esm = esm.replace(/Object\.defineProperty\(exports,\s*'__esModule'.*?\);\s*/g, '');
+
+  // Extract require() calls → import statements
+  const requires: Array<{ varName: string; modName: string }> = [];
+  esm = esm.replace(
+    /(?:var|let|const)\s+(\w+)\s*=\s*require\('([^']+)'\);?/g,
+    (_match, varName, modName) => {
+      const resolvedMod = NODE_BUILTINS.has(modName) ? `node:${modName}` : modName;
+      requires.push({ varName, modName: resolvedMod });
+      return '';
+    }
+  );
+
+  // Extract exports → export statements
+  const namedExports = new Set<string>();
+
+  esm = esm.replace(/exports\["default"\]\s*=\s*(\w+);/g, (_m, name) => {
+    namedExports.add(`default:${name}`);
+    return '';
+  });
+  esm = esm.replace(/exports\.default\s*=\s*(\w+);/g, (_m, name) => {
+    namedExports.add(`default:${name}`);
+    return '';
+  });
+  esm = esm.replace(/exports\.(\w+)\s*=\s*(\w+);/g, (_m, exportName, localName) => {
+    namedExports.add(`named:${exportName}:${localName}`);
+    return '';
+  });
+
+  // Strip sourcemaps
+  esm = esm.replace(/\/\/# sourceMappingURL=.*$/m, '');
+
+  // Build import block
+  const imports = requires.map(r => `import ${r.varName} from '${r.modName}';`).join('\n');
+
+  // Build export block
+  const exportLines: string[] = [];
+  for (const exp of namedExports) {
+    if (exp.startsWith('default:')) {
+      exportLines.push(`export default ${exp.split(':')[1]};`);
+    } else {
+      const [, exportName, localName] = exp.split(':');
+      if (exportName === localName) {
+        exportLines.push(`export { ${exportName} };`);
+      } else {
+        exportLines.push(`export { ${localName} as ${exportName} };`);
+      }
+    }
+  }
+
+  return `${imports}\n${esm}\n${exportLines.join('\n')}\n`;
+}
+
+/**
+ * Patch out IPFS references from the Language Language bundle.
+ *
+ * The Language Language's PutAdapter originally used `context.IPFS.add()` to
+ * content-address language bundles, but IPFS was removed from the executor.
+ * This patches the compiled bundle to skip the IPFS verification and use the
+ * address from language.meta directly.
+ */
+export function patchIpfsReferences(code: string): string {
+  let patched = code;
+
+  // Remove the IPFS.add() call and hash comparison
+  const ipfsPatterns = [
+    'const ipfsAddress = await __classPrivateFieldGet$1(this, _PutAdapter_IPFS, "f").add({ content: language.bundle.toString() }, { onlyHash: true });',
+    '// @ts-ignore',
+    'const hash = ipfsAddress.cid.toString();',
+    'if (hash != language.meta.address)',
+  ];
+
+  for (const pattern of ipfsPatterns) {
+    patched = patched.split(pattern).join('');
+  }
+
+  // Replace the error throw with a direct address assignment
+  patched = patched.replace(
+    /throw new Error\(`Language Persistence: Can't store language[^`]*`\);/,
+    'const hash = language.meta.address;'
+  );
+
+  return patched;
+}
+
+/**
+ * Transform a bundle: CJS→ESM conversion + IPFS patching if needed.
+ *
+ * @param code - The raw bundle source
+ * @param name - Bundle name for logging
+ * @param isLanguageLanguage - Whether this is the Language Language bundle (needs IPFS patching)
+ * @returns Transformed bundle, or original if no transform needed
+ */
+export function transformBundle(code: string, name: string, isLanguageLanguage = false): string {
+  let result = code;
+  let transformed = false;
+
+  if (isCjsBundle(result)) {
+    result = convertCjsToEsm(result);
+    transformed = true;
+    logger.info(`Converted ${name} bundle from CJS to ESM`);
+  }
+
+  if (isLanguageLanguage) {
+    result = patchIpfsReferences(result);
+    logger.info(`Patched IPFS references in ${name} bundle`);
+    transformed = true;
+  }
+
+  if (!transformed) {
+    logger.info(`${name} bundle already ESM-compatible, no transform needed`);
+  }
+
+  return result;
+}

--- a/test-runner/src/installSystemLanguages.ts
+++ b/test-runner/src/installSystemLanguages.ts
@@ -5,6 +5,7 @@ import { ChildProcessWithoutNullStreams, execFileSync, spawn } from "child_proce
 import { ad4mDataDirectory, deleteAllAd4mData, findAndKillProcess, getAd4mHostBinary, logger } from "./utils";
 import kill from 'tree-kill'
 import { buildAd4mClient } from "./client";
+import { transformBundle } from "./bundleTransform";
 
 let seed = {
   trustedAgents: [],
@@ -56,8 +57,12 @@ export async function installSystemLanguages(relativePath = '') {
     let child: ChildProcessWithoutNullStreams;
 
     const languageLanguageBundlePath = path.join(__dirname, 'languages', "languages", "build", "bundle.js");
-        
-    seed['languageLanguageBundle'] = fs.readFileSync(languageLanguageBundlePath).toString();
+
+    // Transform Language Language bundle: CJS→ESM + IPFS patch for Deno compatibility
+    const rawLangLangBundle = fs.readFileSync(languageLanguageBundlePath).toString();
+    const transformedLangLangBundle = transformBundle(rawLangLangBundle, 'Language Language', true);
+    fs.writeFileSync(languageLanguageBundlePath, transformedLangLangBundle);
+    seed['languageLanguageBundle'] = transformedLangLangBundle;
     seed['languageLanguageSettings'] = { storagePath: path.join(__dirname, 'publishedLanguages') }
     seed['neighbourhoodLanguageSettings'] = { storagePath: path.join(__dirname, 'publishedNeighbourhood') }
 
@@ -95,6 +100,11 @@ export async function installSystemLanguages(relativePath = '') {
           const client = await buildAd4mClient(4000);
 
           const bundlePath = path.join(__dirname, 'languages', lang, 'build', 'bundle.js')
+
+          // Transform bundle: CJS→ESM for Deno compatibility
+          const rawBundle = fs.readFileSync(bundlePath).toString();
+          const transformedBundle = transformBundle(rawBundle, lang);
+          fs.writeFileSync(bundlePath, transformedBundle);
 
           const language = await client.languages.publish(bundlePath, languageMeta);
 


### PR DESCRIPTION
## Summary

Follow-up to #670 — addresses the remaining items from #671 (issues 6, 7, 10) that could not be fixed in the first PR.

### Problem

System language bundles downloaded by `@coasys/ad4m-test` from the perspect3vism repos are CommonJS, but the executor's Deno JS runtime requires ESM. This causes:

- **`ReferenceError: exports is not defined`** — CJS `exports` object doesn't exist in ESM context
- **`ReferenceError: require is not defined`** — CJS `require()` calls fail in Deno
- **IPFS crash** — Language Language bundle calls `context.IPFS.add()` which was removed from the executor
- **Node builtin resolution** — `require("path")` needs `node:path` prefix for Deno

Previously users needed a [custom patch script](https://github.com/HexaField/nextgraph-adam-language/blob/main/scripts/patch-ad4m-test.cjs) to handle all of this. This PR integrates the transform directly into the test-runner.

### Changes

**New: `test-runner/src/bundleTransform.ts`**
- `convertCjsToEsm()` — converts `require()` → `import`, `exports.x` → `export`, adds `node:` prefix for builtins
- `patchIpfsReferences()` — removes dead IPFS code from Language Language bundle
- `transformBundle()` — orchestrates both transforms with detection and logging

**Modified: `test-runner/src/installSystemLanguages.ts`**
- Language Language bundle is transformed (CJS→ESM + IPFS patch) before embedding in `bootstrapSeed.json`
- All system language bundles are transformed before publishing to the executor

### Testing

This transform logic has been running successfully in CI for [nextgraph-adam-language](https://github.com/HexaField/nextgraph-adam-language) and [harvest AD4M integration](https://github.com/HexaField/harvest) — both have green CI pipelines using the exact same conversion logic.

Closes remaining items from #671.

/cc @lucksus @data-bot-coasys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Language bundles are now automatically transformed to ensure compatibility with the runtime environment.
  * Enhanced bundle processing with support for automatic format conversion and optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->