### PR TITLE
fix: route neighbourhood signals to main agent when co-located with managed users

### DIFF
--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -2994,20 +2994,21 @@ impl PerspectiveInstance {
                 }
             }
 
-            // Check if the main agent is the recipient
+            // Check if the main agent is the recipient.
+            // Treat owners=None or owners=[] as implicit main-agent ownership (legacy perspectives).
             let main_agent_did = AgentService::with_global_instance(|s| s.did.clone());
             if let Some(main_agent_did) = main_agent_did {
                 if main_agent_did == remote_agent_did {
-                    if let Some(owners) = &current_perspective_handle.owners {
-                        if owners.contains(&remote_agent_did) {
-                            log::debug!(
-                                "Routing signal locally to main agent in neighbourhood {:?}",
-                                current_perspective_handle.shared_url
-                            );
-                            let handle = self.persisted.lock().await.clone();
-                            publish_local(handle, payload, remote_agent_did).await;
-                            return Ok(());
-                        }
+                    let is_owner = current_perspective_handle.owners.as_ref()
+                        .map_or(true, |o| o.is_empty() || o.contains(&remote_agent_did));
+                    if is_owner {
+                        log::debug!(
+                            "Routing signal locally to main agent in neighbourhood {:?}",
+                            current_perspective_handle.shared_url
+                        );
+                        let handle = self.persisted.lock().await.clone();
+                        publish_local(handle, payload, remote_agent_did).await;
+                        return Ok(());
                     }
                 }
             }

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -3085,7 +3085,9 @@ impl PerspectiveInstance {
             if let Some(main_agent_did) = main_agent_did {
                 let is_owner = current_perspective_handle.owners.as_ref()
                     .map_or(true, |o| o.is_empty() || o.contains(&main_agent_did));
-                if is_owner {
+                // Don't echo the broadcast back to the sender (loopback is handled separately).
+                let is_sender = payload.author == main_agent_did;
+                if is_owner && !is_sender {
                     let handle = self.persisted.lock().await.clone();
                     let mut signal = payload.clone();
                     signal.verify_signatures();

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -3050,8 +3050,8 @@ impl PerspectiveInstance {
 
         // Route signals to all local agents (managed users + main agent) who are owners
         if current_perspective_handle.shared_url.is_some() {
+            // Send to each local managed email user who is an explicit owner
             if let Some(owners) = &current_perspective_handle.owners {
-                // Send to each local managed email user who is an owner
                 if let Ok(user_emails) = AgentService::list_user_emails() {
                     for user_email in user_emails {
                         if let Ok(user_did) = AgentService::get_user_did_by_email(&user_email) {
@@ -3076,34 +3076,37 @@ impl PerspectiveInstance {
                         }
                     }
                 }
+            }
 
-                // Also send to the main agent if it is an owner.
-                // The main agent is not in list_user_emails(), so it must be handled separately.
-                let main_agent_did = AgentService::with_global_instance(|s| s.did.clone());
-                if let Some(main_agent_did) = main_agent_did {
-                    if owners.contains(&main_agent_did) {
-                        let handle = self.persisted.lock().await.clone();
-                        let mut signal = payload.clone();
-                        signal.verify_signatures();
+            // Send to the main agent if it is an owner.
+            // The main agent is not in list_user_emails(), so it must be handled separately.
+            // Treat owners=None or owners=[] as implicit main-agent ownership (legacy perspectives).
+            let main_agent_did = AgentService::with_global_instance(|s| s.did.clone());
+            if let Some(main_agent_did) = main_agent_did {
+                let is_owner = current_perspective_handle.owners.as_ref()
+                    .map_or(true, |o| o.is_empty() || o.contains(&main_agent_did));
+                if is_owner {
+                    let handle = self.persisted.lock().await.clone();
+                    let mut signal = payload.clone();
+                    signal.verify_signatures();
 
-                        log::debug!(
-                            "Broadcasting signal locally to main agent in neighbourhood {:?}",
-                            current_perspective_handle.shared_url
-                        );
+                    log::debug!(
+                        "Broadcasting signal locally to main agent in neighbourhood {:?}",
+                        current_perspective_handle.shared_url
+                    );
 
-                        get_global_pubsub()
-                            .await
-                            .publish(
-                                &NEIGHBOURHOOD_SIGNAL_TOPIC,
-                                &serde_json::to_string(&NeighbourhoodSignalFilter {
-                                    perspective: handle,
-                                    signal,
-                                    recipient: Some(main_agent_did),
-                                })
-                                .unwrap(),
-                            )
-                            .await;
-                    }
+                    get_global_pubsub()
+                        .await
+                        .publish(
+                            &NEIGHBOURHOOD_SIGNAL_TOPIC,
+                            &serde_json::to_string(&NeighbourhoodSignalFilter {
+                                perspective: handle,
+                                signal,
+                                recipient: Some(main_agent_did),
+                            })
+                            .unwrap(),
+                        )
+                        .await;
                 }
             }
         }

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -2999,7 +2999,9 @@ impl PerspectiveInstance {
             let main_agent_did = AgentService::with_global_instance(|s| s.did.clone());
             if let Some(main_agent_did) = main_agent_did {
                 if main_agent_did == remote_agent_did {
-                    let is_owner = current_perspective_handle.owners.as_ref()
+                    let is_owner = current_perspective_handle
+                        .owners
+                        .as_ref()
                         .map_or(true, |o| o.is_empty() || o.contains(&remote_agent_did));
                     if is_owner {
                         log::debug!(
@@ -3083,7 +3085,9 @@ impl PerspectiveInstance {
             // Treat owners=None or owners=[] as implicit main-agent ownership (legacy perspectives).
             let main_agent_did = AgentService::with_global_instance(|s| s.did.clone());
             if let Some(main_agent_did) = main_agent_did {
-                let is_owner = current_perspective_handle.owners.as_ref()
+                let is_owner = current_perspective_handle
+                    .owners
+                    .as_ref()
                     .map_or(true, |o| o.is_empty() || o.contains(&main_agent_did));
                 // Don't echo the broadcast back to the sender (loopback is handled separately).
                 let is_sender = payload.author == main_agent_did;

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -2946,45 +2946,60 @@ impl PerspectiveInstance {
 
         // Check if this perspective is part of a neighbourhood
         if current_perspective_handle.shared_url.is_some() {
-            // Get all local user emails
+            // Helper closure: publish a signal locally and return Ok(())
+            let publish_local = |handle: PerspectiveHandle,
+                                 mut signal: PerspectiveExpression,
+                                 recipient: String| async move {
+                signal.verify_signatures();
+                get_global_pubsub()
+                    .await
+                    .publish(
+                        &NEIGHBOURHOOD_SIGNAL_TOPIC,
+                        &serde_json::to_string(&NeighbourhoodSignalFilter {
+                            perspective: handle,
+                            signal,
+                            recipient: Some(recipient),
+                        })
+                        .unwrap(),
+                    )
+                    .await;
+            };
+
+            // Check if any managed email user is the recipient
             if let Ok(user_emails) = AgentService::list_user_emails() {
-                // Check if any local user has the recipient DID
                 for user_email in user_emails {
                     if let Ok(user_did) = AgentService::get_user_did_by_email(&user_email) {
                         if user_did == remote_agent_did {
-                            // This is a locally managed user!
-                            // Check if they own a perspective for this neighbourhood
                             if let Some(owners) = &current_perspective_handle.owners {
                                 if owners.contains(&remote_agent_did) {
-                                    // The recipient owns this perspective (they're in the same neighbourhood)
-                                    // Send signal directly via local pubsub
                                     log::debug!(
-                                        "Routing signal locally to user {} in neighbourhood {:?}",
+                                        "Routing signal locally to managed user {} in neighbourhood {:?}",
                                         user_email,
                                         current_perspective_handle.shared_url
                                     );
-
                                     let handle = self.persisted.lock().await.clone();
-                                    let mut signal = payload.clone();
-                                    signal.verify_signatures();
-
-                                    get_global_pubsub()
-                                        .await
-                                        .publish(
-                                            &NEIGHBOURHOOD_SIGNAL_TOPIC,
-                                            &serde_json::to_string(&NeighbourhoodSignalFilter {
-                                                perspective: handle,
-                                                signal,
-                                                recipient: Some(remote_agent_did.clone()),
-                                            })
-                                            .unwrap(),
-                                        )
-                                        .await;
-
-                                    // Signal delivered locally, no need to go through link language
+                                    publish_local(handle, payload, remote_agent_did).await;
                                     return Ok(());
                                 }
                             }
+                        }
+                    }
+                }
+            }
+
+            // Check if the main agent is the recipient
+            let main_agent_did = AgentService::with_global_instance(|s| s.did.clone());
+            if let Some(main_agent_did) = main_agent_did {
+                if main_agent_did == remote_agent_did {
+                    if let Some(owners) = &current_perspective_handle.owners {
+                        if owners.contains(&remote_agent_did) {
+                            log::debug!(
+                                "Routing signal locally to main agent in neighbourhood {:?}",
+                                current_perspective_handle.shared_url
+                            );
+                            let handle = self.persisted.lock().await.clone();
+                            publish_local(handle, payload, remote_agent_did).await;
+                            return Ok(());
                         }
                     }
                 }
@@ -3025,12 +3040,11 @@ impl PerspectiveInstance {
             });
         }
 
-        // Route signals to local managed users who are owners of this perspective
+        // Route signals to all local agents (managed users + main agent) who are owners
         if current_perspective_handle.shared_url.is_some() {
             if let Some(owners) = &current_perspective_handle.owners {
-                // Get all local user emails
+                // Send to each local managed email user who is an owner
                 if let Ok(user_emails) = AgentService::list_user_emails() {
-                    // Send signal to each local managed user who is an owner
                     for user_email in user_emails {
                         if let Ok(user_did) = AgentService::get_user_did_by_email(&user_email) {
                             if owners.contains(&user_did) {
@@ -3038,21 +3052,49 @@ impl PerspectiveInstance {
                                 let mut signal = payload.clone();
                                 signal.verify_signatures();
 
-                                let filter_data = NeighbourhoodSignalFilter {
-                                    perspective: handle.clone(),
-                                    signal: signal.clone(),
-                                    recipient: Some(user_did.clone()),
-                                };
-
                                 get_global_pubsub()
                                     .await
                                     .publish(
                                         &NEIGHBOURHOOD_SIGNAL_TOPIC,
-                                        &serde_json::to_string(&filter_data).unwrap(),
+                                        &serde_json::to_string(&NeighbourhoodSignalFilter {
+                                            perspective: handle,
+                                            signal,
+                                            recipient: Some(user_did),
+                                        })
+                                        .unwrap(),
                                     )
                                     .await;
                             }
                         }
+                    }
+                }
+
+                // Also send to the main agent if it is an owner.
+                // The main agent is not in list_user_emails(), so it must be handled separately.
+                let main_agent_did = AgentService::with_global_instance(|s| s.did.clone());
+                if let Some(main_agent_did) = main_agent_did {
+                    if owners.contains(&main_agent_did) {
+                        let handle = self.persisted.lock().await.clone();
+                        let mut signal = payload.clone();
+                        signal.verify_signatures();
+
+                        log::debug!(
+                            "Broadcasting signal locally to main agent in neighbourhood {:?}",
+                            current_perspective_handle.shared_url
+                        );
+
+                        get_global_pubsub()
+                            .await
+                            .publish(
+                                &NEIGHBOURHOOD_SIGNAL_TOPIC,
+                                &serde_json::to_string(&NeighbourhoodSignalFilter {
+                                    perspective: handle,
+                                    signal,
+                                    recipient: Some(main_agent_did),
+                                })
+                                .unwrap(),
+                            )
+                            .await;
                     }
                 }
             }

--- a/tests/js/tests/multi-user-simple.test.ts
+++ b/tests/js/tests/multi-user-simple.test.ts
@@ -1568,6 +1568,116 @@ describe("Multi-User Simple integration tests", () => {
 
             console.log("✅ Neighbourhood signals working between managed users (Flux scenario)");
         });
+
+        it("should exchange neighbourhood signals between main agent and managed user", async () => {
+            console.log("\n=== Testing signals between main agent and managed user ===");
+
+            // The admin client (empty/admin-credential token) IS the main agent.
+            // A managed user joins the same neighbourhood.  Signals must work both ways.
+            const mainAgentStatus = await adminAd4mClient!.agent.status();
+            const mainAgentDid = mainAgentStatus.did!;
+            console.log("Main agent DID:", mainAgentDid);
+
+            // Create and login a managed user
+            await adminAd4mClient!.agent.createUser("main_agent_signal@example.com", "password");
+            const userToken = await adminAd4mClient!.agent.loginUser("main_agent_signal@example.com", "password");
+            // @ts-ignore
+            const userClient = new Ad4mClient(apolloClient(gqlPort, userToken), false);
+
+            const userStatus = await userClient.agent.me();
+            const userDid = userStatus.did!;
+            console.log("Managed user DID:", userDid);
+
+            // Main agent creates the neighbourhood
+            const mainPerspective = await adminAd4mClient!.perspective.add("Main-Agent Neighbourhood");
+            const linkLanguage = await adminAd4mClient!.languages.applyTemplateAndPublish(
+                DIFF_SYNC_OFFICIAL,
+                JSON.stringify({ uid: uuidv4(), name: "Main-Agent Signal Test" })
+            );
+            const neighbourhoodUrl = await adminAd4mClient!.neighbourhood.publishFromPerspective(
+                mainPerspective.uuid,
+                linkLanguage.address,
+                new Perspective([])
+            );
+            console.log("Main agent created neighbourhood:", neighbourhoodUrl);
+            await new Promise(resolve => setTimeout(resolve, 2000));
+
+            // Managed user joins the neighbourhood
+            await userClient.neighbourhood.joinFromUrl(neighbourhoodUrl);
+            const userPerspectives = await userClient.perspective.all();
+            const userSharedPerspective = userPerspectives.find(p => p.sharedUrl === neighbourhoodUrl);
+            expect(userSharedPerspective).to.not.be.null;
+            console.log("Managed user joined neighbourhood");
+            await new Promise(resolve => setTimeout(resolve, 2000));
+
+            // Get neighbourhood proxies for both sides
+            const mainAgentNH = await mainPerspective.getNeighbourhoodProxy();
+            const userNH = await userSharedPerspective!.getNeighbourhoodProxy();
+            expect(mainAgentNH).to.not.be.null;
+            expect(userNH).to.not.be.null;
+
+            // Register signal listeners on both sides
+            const mainAgentReceivedSignals: any[] = [];
+            const userReceivedSignals: any[] = [];
+
+            mainAgentNH!.addSignalHandler((signal) => {
+                console.log("✉️ Main agent received signal:", JSON.stringify(signal));
+                mainAgentReceivedSignals.push(signal);
+            });
+            userNH!.addSignalHandler((signal) => {
+                console.log("✉️ Managed user received signal:", JSON.stringify(signal));
+                userReceivedSignals.push(signal);
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 1000));
+
+            // --- Test 1: main agent sends signal to managed user ---
+            console.log("\n--- Main agent sending signal to managed user ---");
+            await mainAgentNH!.sendSignalU(userDid, new PerspectiveUnsignedInput([
+                new Link({ source: "test://signal", predicate: "test://main_to_user", target: mainAgentDid })
+            ]));
+
+            const maxWait = 5000;
+            let start = Date.now();
+            while (userReceivedSignals.length === 0 && Date.now() - start < maxWait) {
+                await new Promise(r => setTimeout(r, 100));
+            }
+            expect(userReceivedSignals.length).to.be.greaterThan(0, "Managed user should receive signal from main agent");
+            expect(userReceivedSignals[0].data.links[0].data.predicate).to.equal("test://main_to_user");
+            console.log("✅ Managed user received signal from main agent");
+
+            // --- Test 2: managed user sends signal to main agent ---
+            console.log("\n--- Managed user sending signal to main agent ---");
+            await userNH!.sendSignalU(mainAgentDid, new PerspectiveUnsignedInput([
+                new Link({ source: "test://signal", predicate: "test://user_to_main", target: userDid })
+            ]));
+
+            start = Date.now();
+            while (mainAgentReceivedSignals.length === 0 && Date.now() - start < maxWait) {
+                await new Promise(r => setTimeout(r, 100));
+            }
+            expect(mainAgentReceivedSignals.length).to.be.greaterThan(0, "Main agent should receive signal from managed user");
+            expect(mainAgentReceivedSignals[0].data.links[0].data.predicate).to.equal("test://user_to_main");
+            console.log("✅ Main agent received signal from managed user");
+
+            // --- Test 3: managed user broadcasts, main agent receives ---
+            console.log("\n--- Managed user broadcasting, main agent should receive ---");
+            const mainAgentCountBefore = mainAgentReceivedSignals.length;
+            await userNH!.sendBroadcastU(new PerspectiveUnsignedInput([
+                new Link({ source: "test://broadcast", predicate: "test://user_broadcast", target: userDid })
+            ]));
+
+            start = Date.now();
+            while (mainAgentReceivedSignals.length === mainAgentCountBefore && Date.now() - start < maxWait) {
+                await new Promise(r => setTimeout(r, 100));
+            }
+            expect(mainAgentReceivedSignals.length).to.be.greaterThan(mainAgentCountBefore, "Main agent should receive broadcast from managed user");
+            const broadcastSignal = mainAgentReceivedSignals[mainAgentReceivedSignals.length - 1];
+            expect(broadcastSignal.data.links[0].data.predicate).to.equal("test://user_broadcast");
+            console.log("✅ Main agent received broadcast from managed user");
+
+            console.log("✅ Signal exchange between main agent and managed user works correctly");
+        });
     });
 
     describe("Multi-Node Multi-User Integration", () => {


### PR DESCRIPTION

   send_signal() and send_broadcast() in perspective_instance.rs only searched
   AgentService::list_user_emails() when deciding whether a recipient is local.
   The main agent has no email, so signals addressed to it always fell through to
   the link language — which on a single executor does not loop back, causing
   signal delivery to silently fail whenever a managed email user and the main
   agent were both owners of the same neighbourhood.

   Fix both functions to also check the main agent's DID after the email-user
   loop.  If the main agent is a neighbourhood owner (send_broadcast) or is the
   intended recipient (send_signal), the signal is now published directly to the
   local pubsub, matching the same short-circuit path used for managed users.

   Add a regression test "should exchange neighbourhood signals between main agent
   and managed user" in multi-user-simple.test.ts covering direct signals in both
   directions and a broadcast from the managed user to the main agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signal delivery routing within neighborhoods to prioritize direct local delivery to owners and members, enhancing responsiveness and reliability of inter-agent communication.

* **Tests**
  * Added comprehensive test coverage for bi-directional signal exchange between agents within a neighborhood context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->