### PR TITLE
feat(agent-language): multi-key support for agent identity

### DIFF
--- a/bootstrap-languages/agent-language/adapter.ts
+++ b/bootstrap-languages/agent-language/adapter.ts
@@ -23,6 +23,33 @@ export default class ExpressionAdapterImpl implements ExpressionAdapter {
 
     return expression
   };
+
+  async addAuthorisedKey(did: string, key: string, name: string, proof: { authorising_key: string, signature: string }): Promise<any> {
+    return await this.#DNA.call(
+      DNA_ROLE,
+      ZOME_NAME,
+      "add_authorised_key",
+      { did, key, name, proof }
+    );
+  }
+
+  async revokeKey(did: string, key: string, signature: string, reason?: string): Promise<any> {
+    return await this.#DNA.call(
+      DNA_ROLE,
+      ZOME_NAME,
+      "revoke_key",
+      { did, key, signature, reason: reason || null }
+    );
+  }
+
+  async isKeyValid(did: string, key: string): Promise<boolean> {
+    return await this.#DNA.call(
+      DNA_ROLE,
+      ZOME_NAME,
+      "is_key_valid",
+      { did, key }
+    );
+  }
 }
 
 class Sharing implements PublicSharing {

--- a/bootstrap-languages/agent-language/adapter.ts
+++ b/bootstrap-languages/agent-language/adapter.ts
@@ -24,22 +24,46 @@ export default class ExpressionAdapterImpl implements ExpressionAdapter {
     return expression
   };
 
-  async addAuthorisedKey(did: string, key: string, name: string, proof: { authorising_key: string, signature: string }): Promise<any> {
-    return await this.#DNA.call(
+  async addAuthorisedKey(did: string, key: string, name: string, proof: { authorising_key: string, signature: string, timestamp: string }): Promise<any> {
+    // Zome validates and returns updated AgentExpressionData
+    const updatedData = await this.#DNA.call(
       DNA_ROLE,
       ZOME_NAME,
       "add_authorised_key",
       { did, key, name, proof }
     );
+
+    // Re-sign with the agent's key and store the full expression
+    const signedExpression = this.#agent.createSignedExpression(updatedData);
+    await this.#DNA.call(
+      DNA_ROLE,
+      ZOME_NAME,
+      "create_agent_expression",
+      signedExpression
+    );
+
+    return signedExpression;
   }
 
-  async revokeKey(did: string, key: string, signature: string, reason?: string): Promise<any> {
-    return await this.#DNA.call(
+  async revokeKey(did: string, key: string, revokedByKey: string, signature: string, timestamp: string, reason?: string): Promise<any> {
+    // Zome validates and returns updated AgentExpressionData
+    const updatedData = await this.#DNA.call(
       DNA_ROLE,
       ZOME_NAME,
       "revoke_key",
-      { did, key, signature, reason: reason || null }
+      { did, key, revokedByKey, signature, timestamp, reason: reason ?? null }
     );
+
+    // Re-sign with the agent's key and store the full expression
+    const signedExpression = this.#agent.createSignedExpression(updatedData);
+    await this.#DNA.call(
+      DNA_ROLE,
+      ZOME_NAME,
+      "create_agent_expression",
+      signedExpression
+    );
+
+    return signedExpression;
   }
 
   async isKeyValid(did: string, key: string): Promise<boolean> {

--- a/bootstrap-languages/agent-language/hc-dna/Cargo.lock
+++ b/bootstrap-languages/agent-language/hc-dna/Cargo.lock
@@ -50,6 +50,7 @@ name = "agent_store"
 version = "0.0.1"
 dependencies = [
  "agent_store_integrity",
+ "bs58",
  "chrono",
  "derive_more 0.99.20",
  "getrandom 0.3.4",
@@ -78,7 +79,9 @@ name = "agent_store_tests"
 version = "0.1.0"
 dependencies = [
  "agent_store_integrity",
+ "bs58",
  "chrono",
+ "ed25519-dalek 2.2.0",
  "futures",
  "hdi",
  "hdk",
@@ -87,6 +90,7 @@ dependencies = [
  "holochain_types",
  "holochain_zome_types",
  "pretty_assertions",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tokio",
@@ -694,6 +698,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1715,7 +1728,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1943,7 +1956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5032,7 +5045,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5880,7 +5893,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6601,7 +6614,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7611,7 +7624,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8889,7 +8902,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/bootstrap-languages/agent-language/hc-dna/tests/sweettest/Cargo.toml
+++ b/bootstrap-languages/agent-language/hc-dna/tests/sweettest/Cargo.toml
@@ -30,6 +30,9 @@ tokio = { version = "1", features = ["full"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 uuid = { version = "1.0", features = ["v4"] }
+ed25519-dalek = { version = "2", features = ["rand_core"] }
+rand = "0.8"
+bs58 = "0.5"
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/bootstrap-languages/agent-language/hc-dna/tests/sweettest/src/integration_tests.rs
+++ b/bootstrap-languages/agent-language/hc-dna/tests/sweettest/src/integration_tests.rs
@@ -4,3 +4,4 @@
 
 mod utils;
 mod test_agent_expression;
+mod test_multi_key;

--- a/bootstrap-languages/agent-language/hc-dna/tests/sweettest/src/test_multi_key.rs
+++ b/bootstrap-languages/agent-language/hc-dna/tests/sweettest/src/test_multi_key.rs
@@ -1,29 +1,54 @@
-//! Tests for multi-key agent identity support
+//! Tests for multi-key agent identity support with Ed25519 signature verification
 
 use crate::utils::{call_zome, create_test_agent_expression, setup_1_conductor};
 use agent_store_integrity::{
     AddAuthorisedKeyInput, AgentExpression, IsKeyValidInput, KeyAuthorisation, RevokeKeyInput,
 };
+use ed25519_dalek::{Signer, SigningKey};
+use rand::rngs::OsRng;
+
+/// Helper: generate an Ed25519 keypair and return (multibase_key_string, signing_key)
+fn generate_test_keypair() -> (String, SigningKey) {
+    let signing_key = SigningKey::generate(&mut OsRng);
+    let verifying_key = signing_key.verifying_key();
+    // Encode as multibase (z = base58btc) with Ed25519 multicodec prefix (0xed 0x01)
+    let mut prefixed = vec![0xed, 0x01];
+    prefixed.extend_from_slice(verifying_key.as_bytes());
+    let encoded = format!("z{}", bs58::encode(&prefixed).into_string());
+    (encoded, signing_key)
+}
+
+/// Helper: sign (subject_key + did + timestamp) and return hex-encoded signature
+fn sign_key_message(signing_key: &SigningKey, subject_key: &str, did: &str, timestamp: &str) -> String {
+    let message = format!("{}{}{}", subject_key, did, timestamp);
+    let signature = signing_key.sign(message.as_bytes());
+    hex::encode(signature.to_bytes())
+}
+
+/// Simple hex encoding (tests only)
+mod hex {
+    pub fn encode(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{:02x}", b)).collect()
+    }
+}
 
 /// Test that creating an agent expression with a did:key DID auto-populates root key
 #[tokio::test(flavor = "multi_thread")]
 async fn test_create_expression_auto_populates_root_key() {
     let (conductor, cell) = setup_1_conductor().await;
 
-    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-    let agent_expression = create_test_agent_expression(did, None);
+    let (root_key, _signing_key) = generate_test_keypair();
+    let did = format!("did:key:{}", root_key);
+    let agent_expression = create_test_agent_expression(&did, None);
 
     let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
 
     let retrieved: Option<AgentExpression> =
-        call_zome(&conductor, &cell, "get_agent_expression", did.to_string()).await;
+        call_zome(&conductor, &cell, "get_agent_expression", did.clone()).await;
 
     let expr = retrieved.expect("Should exist");
     assert_eq!(expr.data.authorised_keys.len(), 1, "Should have root key auto-populated");
-    assert_eq!(
-        expr.data.authorised_keys[0].key,
-        "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
-    );
+    assert_eq!(expr.data.authorised_keys[0].key, root_key);
     assert_eq!(expr.data.authorised_keys[0].name, "Root Key");
     assert_eq!(expr.data.authorised_keys[0].proof.signature, "self");
 }
@@ -48,31 +73,100 @@ async fn test_create_expression_non_did_key_no_auto_populate() {
     );
 }
 
-/// Test adding an authorised key with a valid (existing) authorising key
+/// Test adding an authorised key with a valid Ed25519 signature
 #[tokio::test(flavor = "multi_thread")]
-async fn test_add_authorised_key_success() {
+async fn test_add_authorised_key_valid_signature() {
     let (conductor, cell) = setup_1_conductor().await;
 
-    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-    let root_key = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-    let agent_expression = create_test_agent_expression(did, None);
+    let (root_key, root_signing_key) = generate_test_keypair();
+    let did = format!("did:key:{}", root_key);
+    let agent_expression = create_test_agent_expression(&did, None);
     let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
 
+    let (new_key, _new_signing_key) = generate_test_keypair();
+    let timestamp = "2025-01-01T00:00:00Z";
+    let signature = sign_key_message(&root_signing_key, &new_key, &did, timestamp);
+
     let input = AddAuthorisedKeyInput {
-        did: did.to_string(),
-        key: "new-device-key-123".to_string(),
+        did: did.clone(),
+        key: new_key.clone(),
         name: "My Phone".to_string(),
         proof: KeyAuthorisation {
-            authorising_key: root_key.to_string(),
-            signature: "test-signature".to_string(),
+            authorising_key: root_key.clone(),
+            signature,
+            timestamp: timestamp.to_string(),
         },
     };
 
     let result: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", input).await;
 
     assert_eq!(result.data.authorised_keys.len(), 2);
-    assert_eq!(result.data.authorised_keys[1].key, "new-device-key-123");
+    assert_eq!(result.data.authorised_keys[1].key, new_key);
     assert_eq!(result.data.authorised_keys[1].name, "My Phone");
+}
+
+/// Test adding a key with an invalid/tampered signature fails
+#[tokio::test(flavor = "multi_thread")]
+#[should_panic(expected = "Invalid signature")]
+async fn test_add_authorised_key_invalid_signature_fails() {
+    let (conductor, cell) = setup_1_conductor().await;
+
+    let (root_key, _root_signing_key) = generate_test_keypair();
+    let did = format!("did:key:{}", root_key);
+    let agent_expression = create_test_agent_expression(&did, None);
+    let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
+
+    let (new_key, _) = generate_test_keypair();
+    let timestamp = "2025-01-01T00:00:00Z";
+
+    // Use a different key to sign (wrong signer)
+    let (_other_key, other_signing_key) = generate_test_keypair();
+    let bad_signature = sign_key_message(&other_signing_key, &new_key, &did, timestamp);
+
+    let input = AddAuthorisedKeyInput {
+        did: did.clone(),
+        key: new_key.clone(),
+        name: "Attacker".to_string(),
+        proof: KeyAuthorisation {
+            authorising_key: root_key.clone(),
+            signature: bad_signature,
+            timestamp: timestamp.to_string(),
+        },
+    };
+
+    let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", input).await;
+}
+
+/// Test adding a key with a tampered message (wrong key in message) fails
+#[tokio::test(flavor = "multi_thread")]
+#[should_panic(expected = "Invalid signature")]
+async fn test_add_authorised_key_tampered_message_fails() {
+    let (conductor, cell) = setup_1_conductor().await;
+
+    let (root_key, root_signing_key) = generate_test_keypair();
+    let did = format!("did:key:{}", root_key);
+    let agent_expression = create_test_agent_expression(&did, None);
+    let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
+
+    let (new_key, _) = generate_test_keypair();
+    let timestamp = "2025-01-01T00:00:00Z";
+
+    // Sign over a different key than what we submit
+    let (different_key, _) = generate_test_keypair();
+    let signature = sign_key_message(&root_signing_key, &different_key, &did, timestamp);
+
+    let input = AddAuthorisedKeyInput {
+        did: did.clone(),
+        key: new_key.clone(), // Different from what was signed
+        name: "Tampered".to_string(),
+        proof: KeyAuthorisation {
+            authorising_key: root_key.clone(),
+            signature,
+            timestamp: timestamp.to_string(),
+        },
+    };
+
+    let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", input).await;
 }
 
 /// Test adding a key with an unauthorised (unknown) authorising key fails
@@ -81,17 +175,24 @@ async fn test_add_authorised_key_success() {
 async fn test_add_key_with_invalid_authorising_key_fails() {
     let (conductor, cell) = setup_1_conductor().await;
 
-    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-    let agent_expression = create_test_agent_expression(did, None);
+    let (root_key, _) = generate_test_keypair();
+    let did = format!("did:key:{}", root_key);
+    let agent_expression = create_test_agent_expression(&did, None);
     let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
 
+    let (unknown_key, unknown_signing_key) = generate_test_keypair();
+    let (new_key, _) = generate_test_keypair();
+    let timestamp = "2025-01-01T00:00:00Z";
+    let signature = sign_key_message(&unknown_signing_key, &new_key, &did, timestamp);
+
     let input = AddAuthorisedKeyInput {
-        did: did.to_string(),
-        key: "malicious-key".to_string(),
+        did: did.clone(),
+        key: new_key,
         name: "Attacker".to_string(),
         proof: KeyAuthorisation {
-            authorising_key: "unknown-key-not-authorised".to_string(),
-            signature: "fake-sig".to_string(),
+            authorising_key: unknown_key,
+            signature,
+            timestamp: timestamp.to_string(),
         },
     };
 
@@ -104,101 +205,116 @@ async fn test_add_key_with_invalid_authorising_key_fails() {
 async fn test_add_duplicate_key_fails() {
     let (conductor, cell) = setup_1_conductor().await;
 
-    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-    let root_key = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-    let agent_expression = create_test_agent_expression(did, None);
+    let (root_key, root_signing_key) = generate_test_keypair();
+    let did = format!("did:key:{}", root_key);
+    let agent_expression = create_test_agent_expression(&did, None);
     let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
 
-    // Try to add the root key again
+    let timestamp = "2025-01-01T00:00:00Z";
+    let signature = sign_key_message(&root_signing_key, &root_key, &did, timestamp);
+
     let input = AddAuthorisedKeyInput {
-        did: did.to_string(),
-        key: root_key.to_string(),
+        did: did.clone(),
+        key: root_key.clone(),
         name: "Duplicate".to_string(),
         proof: KeyAuthorisation {
-            authorising_key: root_key.to_string(),
-            signature: "sig".to_string(),
+            authorising_key: root_key.clone(),
+            signature,
+            timestamp: timestamp.to_string(),
         },
     };
 
     let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", input).await;
 }
 
-/// Test revoking a key moves it from authorised to revoked
+/// Test revoking a key with valid signature moves it from authorised to revoked
 #[tokio::test(flavor = "multi_thread")]
-async fn test_revoke_key_success() {
+async fn test_revoke_key_valid_signature() {
     let (conductor, cell) = setup_1_conductor().await;
 
-    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-    let root_key = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-    let agent_expression = create_test_agent_expression(did, None);
+    let (root_key, root_signing_key) = generate_test_keypair();
+    let did = format!("did:key:{}", root_key);
+    let agent_expression = create_test_agent_expression(&did, None);
     let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
 
-    // Add a second key first
+    // Add a second key
+    let (device_key, _device_signing_key) = generate_test_keypair();
+    let add_ts = "2025-01-01T00:00:00Z";
+    let add_sig = sign_key_message(&root_signing_key, &device_key, &did, add_ts);
+
     let add_input = AddAuthorisedKeyInput {
-        did: did.to_string(),
-        key: "device-key-2".to_string(),
+        did: did.clone(),
+        key: device_key.clone(),
         name: "Phone".to_string(),
         proof: KeyAuthorisation {
-            authorising_key: root_key.to_string(),
-            signature: "sig".to_string(),
+            authorising_key: root_key.clone(),
+            signature: add_sig,
+            timestamp: add_ts.to_string(),
         },
     };
     let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", add_input).await;
 
-    // Now revoke the second key
+    // Revoke the device key using root key
+    let revoke_ts = "2025-01-02T00:00:00Z";
+    let revoke_sig = sign_key_message(&root_signing_key, &device_key, &did, revoke_ts);
+
     let revoke_input = RevokeKeyInput {
-        did: did.to_string(),
-        key: "device-key-2".to_string(),
-        signature: "revoke-sig".to_string(),
+        did: did.clone(),
+        key: device_key.clone(),
+        revoked_by_key: root_key.clone(),
+        signature: revoke_sig,
+        timestamp: revoke_ts.to_string(),
         reason: Some("Lost device".to_string()),
     };
     let result: AgentExpression = call_zome(&conductor, &cell, "revoke_key", revoke_input).await;
 
-    assert_eq!(result.data.authorised_keys.len(), 1, "Revoked key should be removed from authorised");
+    assert_eq!(result.data.authorised_keys.len(), 1, "Revoked key should be removed");
     assert_eq!(result.data.revoked_keys.len(), 1);
-    assert_eq!(result.data.revoked_keys[0].revoked_key, "device-key-2");
+    assert_eq!(result.data.revoked_keys[0].revoked_key, device_key);
     assert_eq!(result.data.revoked_keys[0].reason, Some("Lost device".to_string()));
 }
 
-/// Test revoking an already-revoked key fails
+/// Test revoking a key with invalid signature fails
 #[tokio::test(flavor = "multi_thread")]
-#[should_panic(expected = "Key not found in authorised keys")]
-async fn test_revoke_already_revoked_key_fails() {
+#[should_panic(expected = "Invalid signature")]
+async fn test_revoke_key_invalid_signature_fails() {
     let (conductor, cell) = setup_1_conductor().await;
 
-    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-    let root_key = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-    let agent_expression = create_test_agent_expression(did, None);
+    let (root_key, root_signing_key) = generate_test_keypair();
+    let did = format!("did:key:{}", root_key);
+    let agent_expression = create_test_agent_expression(&did, None);
     let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
 
-    // Add then revoke a key
+    // Add a second key
+    let (device_key, _) = generate_test_keypair();
+    let add_ts = "2025-01-01T00:00:00Z";
+    let add_sig = sign_key_message(&root_signing_key, &device_key, &did, add_ts);
+
     let add_input = AddAuthorisedKeyInput {
-        did: did.to_string(),
-        key: "temp-key".to_string(),
-        name: "Temp".to_string(),
+        did: did.clone(),
+        key: device_key.clone(),
+        name: "Phone".to_string(),
         proof: KeyAuthorisation {
-            authorising_key: root_key.to_string(),
-            signature: "sig".to_string(),
+            authorising_key: root_key.clone(),
+            signature: add_sig,
+            timestamp: add_ts.to_string(),
         },
     };
     let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", add_input).await;
 
+    // Try to revoke with a bad signature
+    let revoke_ts = "2025-01-02T00:00:00Z";
+    let bad_sig = "00".repeat(64); // 64 zero bytes — invalid signature
+
     let revoke_input = RevokeKeyInput {
-        did: did.to_string(),
-        key: "temp-key".to_string(),
-        signature: "sig".to_string(),
+        did: did.clone(),
+        key: device_key.clone(),
+        revoked_by_key: root_key.clone(),
+        signature: bad_sig,
+        timestamp: revoke_ts.to_string(),
         reason: None,
     };
     let _: AgentExpression = call_zome(&conductor, &cell, "revoke_key", revoke_input).await;
-
-    // Try to revoke again — should fail (key no longer in authorised_keys)
-    let revoke_input2 = RevokeKeyInput {
-        did: did.to_string(),
-        key: "temp-key".to_string(),
-        signature: "sig".to_string(),
-        reason: None,
-    };
-    let _: AgentExpression = call_zome(&conductor, &cell, "revoke_key", revoke_input2).await;
 }
 
 /// Test is_key_valid returns true for authorised keys, false for revoked/unknown
@@ -206,9 +322,9 @@ async fn test_revoke_already_revoked_key_fails() {
 async fn test_is_key_valid() {
     let (conductor, cell) = setup_1_conductor().await;
 
-    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-    let root_key = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-    let agent_expression = create_test_agent_expression(did, None);
+    let (root_key, _) = generate_test_keypair();
+    let did = format!("did:key:{}", root_key);
+    let agent_expression = create_test_agent_expression(&did, None);
     let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
 
     // Root key should be valid
@@ -217,8 +333,8 @@ async fn test_is_key_valid() {
         &cell,
         "is_key_valid",
         IsKeyValidInput {
-            did: did.to_string(),
-            key: root_key.to_string(),
+            did: did.clone(),
+            key: root_key.clone(),
         },
     )
     .await;
@@ -230,25 +346,12 @@ async fn test_is_key_valid() {
         &cell,
         "is_key_valid",
         IsKeyValidInput {
-            did: did.to_string(),
+            did: did.clone(),
             key: "unknown-key".to_string(),
         },
     )
     .await;
     assert!(!valid, "Unknown key should be invalid");
-
-    // Non-existent DID should return false
-    let valid: bool = call_zome(
-        &conductor,
-        &cell,
-        "is_key_valid",
-        IsKeyValidInput {
-            did: "did:key:nonexistent".to_string(),
-            key: root_key.to_string(),
-        },
-    )
-    .await;
-    assert!(!valid, "Non-existent DID should return false");
 }
 
 /// Test that a revoked key cannot be used to add new keys
@@ -257,52 +360,66 @@ async fn test_is_key_valid() {
 async fn test_revoked_key_cannot_add_new_keys() {
     let (conductor, cell) = setup_1_conductor().await;
 
-    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-    let root_key = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
-    let agent_expression = create_test_agent_expression(did, None);
+    let (root_key, root_signing_key) = generate_test_keypair();
+    let did = format!("did:key:{}", root_key);
+    let agent_expression = create_test_agent_expression(&did, None);
     let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
 
-    // Add a second key
+    // Add a secondary key
+    let (secondary_key, secondary_signing_key) = generate_test_keypair();
+    let ts1 = "2025-01-01T00:00:00Z";
+    let sig1 = sign_key_message(&root_signing_key, &secondary_key, &did, ts1);
+
     let add_input = AddAuthorisedKeyInput {
-        did: did.to_string(),
-        key: "secondary-key".to_string(),
+        did: did.clone(),
+        key: secondary_key.clone(),
         name: "Secondary".to_string(),
         proof: KeyAuthorisation {
-            authorising_key: root_key.to_string(),
-            signature: "sig".to_string(),
+            authorising_key: root_key.clone(),
+            signature: sig1,
+            timestamp: ts1.to_string(),
         },
     };
     let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", add_input).await;
 
     // Revoke the secondary key
+    let ts2 = "2025-01-02T00:00:00Z";
+    let revoke_sig = sign_key_message(&root_signing_key, &secondary_key, &did, ts2);
+
     let revoke_input = RevokeKeyInput {
-        did: did.to_string(),
-        key: "secondary-key".to_string(),
-        signature: "sig".to_string(),
+        did: did.clone(),
+        key: secondary_key.clone(),
+        revoked_by_key: root_key.clone(),
+        signature: revoke_sig,
+        timestamp: ts2.to_string(),
         reason: None,
     };
     let _: AgentExpression = call_zome(&conductor, &cell, "revoke_key", revoke_input).await;
 
-    // Try to use revoked key to add another key — should fail
+    // Try to use revoked key to add another — should fail
+    let (new_key, _) = generate_test_keypair();
+    let ts3 = "2025-01-03T00:00:00Z";
+    let sig3 = sign_key_message(&secondary_signing_key, &new_key, &did, ts3);
+
     let add_with_revoked = AddAuthorisedKeyInput {
-        did: did.to_string(),
-        key: "malicious-new-key".to_string(),
+        did: did.clone(),
+        key: new_key,
         name: "Malicious".to_string(),
         proof: KeyAuthorisation {
-            authorising_key: "secondary-key".to_string(),
-            signature: "fake-sig".to_string(),
+            authorising_key: secondary_key,
+            signature: sig3,
+            timestamp: ts3.to_string(),
         },
     };
     let _: AgentExpression =
         call_zome(&conductor, &cell, "add_authorised_key", add_with_revoked).await;
 }
 
-/// Test backward compatibility: old-format expressions without authorised_keys deserialize correctly
+/// Test backward compatibility: old-format expressions without authorised_keys
 #[tokio::test(flavor = "multi_thread")]
 async fn test_backward_compat_old_format() {
     let (conductor, cell) = setup_1_conductor().await;
 
-    // Create expression with did:test (non-did:key), which won't auto-populate
     let did = "did:test:legacy-agent";
     let agent_expression = create_test_agent_expression(did, Some("lang://old".to_string()));
     let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
@@ -311,7 +428,6 @@ async fn test_backward_compat_old_format() {
         call_zome(&conductor, &cell, "get_agent_expression", did.to_string()).await;
 
     let expr = retrieved.expect("Should exist");
-    // #[serde(default)] should give empty vecs
     assert!(expr.data.authorised_keys.is_empty());
     assert!(expr.data.revoked_keys.is_empty());
     assert_eq!(expr.data.direct_message_language, Some("lang://old".to_string()));

--- a/bootstrap-languages/agent-language/hc-dna/tests/sweettest/src/test_multi_key.rs
+++ b/bootstrap-languages/agent-language/hc-dna/tests/sweettest/src/test_multi_key.rs
@@ -2,6 +2,7 @@
 
 use crate::utils::{call_zome, create_test_agent_expression, setup_1_conductor};
 use agent_store_integrity::{
+    AgentExpressionData,
     AddAuthorisedKeyInput, AgentExpression, IsKeyValidInput, KeyAuthorisation, RevokeKeyInput,
 };
 use ed25519_dalek::{Signer, SigningKey};
@@ -98,11 +99,11 @@ async fn test_add_authorised_key_valid_signature() {
         },
     };
 
-    let result: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", input).await;
+    let result: AgentExpressionData = call_zome(&conductor, &cell, "add_authorised_key", input).await;
 
-    assert_eq!(result.data.authorised_keys.len(), 2);
-    assert_eq!(result.data.authorised_keys[1].key, new_key);
-    assert_eq!(result.data.authorised_keys[1].name, "My Phone");
+    assert_eq!(result.authorised_keys.len(), 2);
+    assert_eq!(result.authorised_keys[1].key, new_key);
+    assert_eq!(result.authorised_keys[1].name, "My Phone");
 }
 
 /// Test adding a key with an invalid/tampered signature fails
@@ -134,7 +135,7 @@ async fn test_add_authorised_key_invalid_signature_fails() {
         },
     };
 
-    let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", input).await;
+    let _: AgentExpressionData = call_zome(&conductor, &cell, "add_authorised_key", input).await;
 }
 
 /// Test adding a key with a tampered message (wrong key in message) fails
@@ -166,7 +167,7 @@ async fn test_add_authorised_key_tampered_message_fails() {
         },
     };
 
-    let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", input).await;
+    let _: AgentExpressionData = call_zome(&conductor, &cell, "add_authorised_key", input).await;
 }
 
 /// Test adding a key with an unauthorised (unknown) authorising key fails
@@ -196,7 +197,7 @@ async fn test_add_key_with_invalid_authorising_key_fails() {
         },
     };
 
-    let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", input).await;
+    let _: AgentExpressionData = call_zome(&conductor, &cell, "add_authorised_key", input).await;
 }
 
 /// Test adding a key that is already authorised fails
@@ -224,7 +225,7 @@ async fn test_add_duplicate_key_fails() {
         },
     };
 
-    let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", input).await;
+    let _: AgentExpressionData = call_zome(&conductor, &cell, "add_authorised_key", input).await;
 }
 
 /// Test revoking a key with valid signature moves it from authorised to revoked
@@ -252,7 +253,7 @@ async fn test_revoke_key_valid_signature() {
             timestamp: add_ts.to_string(),
         },
     };
-    let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", add_input).await;
+    let _: AgentExpressionData = call_zome(&conductor, &cell, "add_authorised_key", add_input).await;
 
     // Revoke the device key using root key
     let revoke_ts = "2025-01-02T00:00:00Z";
@@ -266,12 +267,12 @@ async fn test_revoke_key_valid_signature() {
         timestamp: revoke_ts.to_string(),
         reason: Some("Lost device".to_string()),
     };
-    let result: AgentExpression = call_zome(&conductor, &cell, "revoke_key", revoke_input).await;
+    let result: AgentExpressionData = call_zome(&conductor, &cell, "revoke_key", revoke_input).await;
 
-    assert_eq!(result.data.authorised_keys.len(), 1, "Revoked key should be removed");
-    assert_eq!(result.data.revoked_keys.len(), 1);
-    assert_eq!(result.data.revoked_keys[0].revoked_key, device_key);
-    assert_eq!(result.data.revoked_keys[0].reason, Some("Lost device".to_string()));
+    assert_eq!(result.authorised_keys.len(), 1, "Revoked key should be removed");
+    assert_eq!(result.revoked_keys.len(), 1);
+    assert_eq!(result.revoked_keys[0].revoked_key, device_key);
+    assert_eq!(result.revoked_keys[0].reason, Some("Lost device".to_string()));
 }
 
 /// Test revoking a key with invalid signature fails
@@ -300,7 +301,7 @@ async fn test_revoke_key_invalid_signature_fails() {
             timestamp: add_ts.to_string(),
         },
     };
-    let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", add_input).await;
+    let _: AgentExpressionData = call_zome(&conductor, &cell, "add_authorised_key", add_input).await;
 
     // Try to revoke with a bad signature
     let revoke_ts = "2025-01-02T00:00:00Z";
@@ -314,7 +315,7 @@ async fn test_revoke_key_invalid_signature_fails() {
         timestamp: revoke_ts.to_string(),
         reason: None,
     };
-    let _: AgentExpression = call_zome(&conductor, &cell, "revoke_key", revoke_input).await;
+    let _: AgentExpressionData = call_zome(&conductor, &cell, "revoke_key", revoke_input).await;
 }
 
 /// Test is_key_valid returns true for authorised keys, false for revoked/unknown
@@ -380,7 +381,7 @@ async fn test_revoked_key_cannot_add_new_keys() {
             timestamp: ts1.to_string(),
         },
     };
-    let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", add_input).await;
+    let _: AgentExpressionData = call_zome(&conductor, &cell, "add_authorised_key", add_input).await;
 
     // Revoke the secondary key
     let ts2 = "2025-01-02T00:00:00Z";
@@ -394,7 +395,7 @@ async fn test_revoked_key_cannot_add_new_keys() {
         timestamp: ts2.to_string(),
         reason: None,
     };
-    let _: AgentExpression = call_zome(&conductor, &cell, "revoke_key", revoke_input).await;
+    let _: AgentExpressionData = call_zome(&conductor, &cell, "revoke_key", revoke_input).await;
 
     // Try to use revoked key to add another — should fail
     let (new_key, _) = generate_test_keypair();
@@ -411,8 +412,89 @@ async fn test_revoked_key_cannot_add_new_keys() {
             timestamp: ts3.to_string(),
         },
     };
-    let _: AgentExpression =
+    let _: AgentExpressionData =
         call_zome(&conductor, &cell, "add_authorised_key", add_with_revoked).await;
+}
+
+/// Test that is_key_valid returns false after a key is revoked
+#[tokio::test(flavor = "multi_thread")]
+async fn test_is_key_valid_after_revocation() {
+    let (conductor, cell) = setup_1_conductor().await;
+
+    let (root_key, root_signing_key) = generate_test_keypair();
+    let did = format!("did:key:{}", root_key);
+    let agent_expression = create_test_agent_expression(&did, None);
+    let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
+
+    // Add a second key
+    let (device_key, _device_signing_key) = generate_test_keypair();
+    let add_ts = "2025-01-01T00:00:00Z";
+    let add_sig = sign_key_message(&root_signing_key, &device_key, &did, add_ts);
+
+    let add_input = AddAuthorisedKeyInput {
+        did: did.clone(),
+        key: device_key.clone(),
+        name: "Phone".to_string(),
+        proof: KeyAuthorisation {
+            authorising_key: root_key.clone(),
+            signature: add_sig,
+            timestamp: add_ts.to_string(),
+        },
+    };
+    let _: AgentExpressionData = call_zome(&conductor, &cell, "add_authorised_key", add_input).await;
+
+    // Verify device key is valid before revocation
+    let valid_before: bool = call_zome(
+        &conductor,
+        &cell,
+        "is_key_valid",
+        IsKeyValidInput {
+            did: did.clone(),
+            key: device_key.clone(),
+        },
+    )
+    .await;
+    assert!(valid_before, "Device key should be valid before revocation");
+
+    // Revoke the device key
+    let revoke_ts = "2025-01-02T00:00:00Z";
+    let revoke_sig = sign_key_message(&root_signing_key, &device_key, &did, revoke_ts);
+
+    let revoke_input = RevokeKeyInput {
+        did: did.clone(),
+        key: device_key.clone(),
+        revoked_by_key: root_key.clone(),
+        signature: revoke_sig,
+        timestamp: revoke_ts.to_string(),
+        reason: Some("Compromised".to_string()),
+    };
+    let _: AgentExpressionData = call_zome(&conductor, &cell, "revoke_key", revoke_input).await;
+
+    // Verify device key is now invalid
+    let valid_after: bool = call_zome(
+        &conductor,
+        &cell,
+        "is_key_valid",
+        IsKeyValidInput {
+            did: did.clone(),
+            key: device_key.clone(),
+        },
+    )
+    .await;
+    assert!(!valid_after, "Device key should be invalid after revocation");
+
+    // Root key should still be valid
+    let root_valid: bool = call_zome(
+        &conductor,
+        &cell,
+        "is_key_valid",
+        IsKeyValidInput {
+            did: did.clone(),
+            key: root_key.clone(),
+        },
+    )
+    .await;
+    assert!(root_valid, "Root key should still be valid");
 }
 
 /// Test backward compatibility: old-format expressions without authorised_keys

--- a/bootstrap-languages/agent-language/hc-dna/tests/sweettest/src/test_multi_key.rs
+++ b/bootstrap-languages/agent-language/hc-dna/tests/sweettest/src/test_multi_key.rs
@@ -1,0 +1,318 @@
+//! Tests for multi-key agent identity support
+
+use crate::utils::{call_zome, create_test_agent_expression, setup_1_conductor};
+use agent_store_integrity::{
+    AddAuthorisedKeyInput, AgentExpression, IsKeyValidInput, KeyAuthorisation, RevokeKeyInput,
+};
+
+/// Test that creating an agent expression with a did:key DID auto-populates root key
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_expression_auto_populates_root_key() {
+    let (conductor, cell) = setup_1_conductor().await;
+
+    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    let agent_expression = create_test_agent_expression(did, None);
+
+    let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
+
+    let retrieved: Option<AgentExpression> =
+        call_zome(&conductor, &cell, "get_agent_expression", did.to_string()).await;
+
+    let expr = retrieved.expect("Should exist");
+    assert_eq!(expr.data.authorised_keys.len(), 1, "Should have root key auto-populated");
+    assert_eq!(
+        expr.data.authorised_keys[0].key,
+        "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+    );
+    assert_eq!(expr.data.authorised_keys[0].name, "Root Key");
+    assert_eq!(expr.data.authorised_keys[0].proof.signature, "self");
+}
+
+/// Test that creating with a non-did:key DID does NOT auto-populate
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_expression_non_did_key_no_auto_populate() {
+    let (conductor, cell) = setup_1_conductor().await;
+
+    let did = "did:test:alice";
+    let agent_expression = create_test_agent_expression(did, None);
+
+    let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
+
+    let retrieved: Option<AgentExpression> =
+        call_zome(&conductor, &cell, "get_agent_expression", did.to_string()).await;
+
+    let expr = retrieved.expect("Should exist");
+    assert!(
+        expr.data.authorised_keys.is_empty(),
+        "Non did:key DID should not auto-populate keys"
+    );
+}
+
+/// Test adding an authorised key with a valid (existing) authorising key
+#[tokio::test(flavor = "multi_thread")]
+async fn test_add_authorised_key_success() {
+    let (conductor, cell) = setup_1_conductor().await;
+
+    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    let root_key = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    let agent_expression = create_test_agent_expression(did, None);
+    let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
+
+    let input = AddAuthorisedKeyInput {
+        did: did.to_string(),
+        key: "new-device-key-123".to_string(),
+        name: "My Phone".to_string(),
+        proof: KeyAuthorisation {
+            authorising_key: root_key.to_string(),
+            signature: "test-signature".to_string(),
+        },
+    };
+
+    let result: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", input).await;
+
+    assert_eq!(result.data.authorised_keys.len(), 2);
+    assert_eq!(result.data.authorised_keys[1].key, "new-device-key-123");
+    assert_eq!(result.data.authorised_keys[1].name, "My Phone");
+}
+
+/// Test adding a key with an unauthorised (unknown) authorising key fails
+#[tokio::test(flavor = "multi_thread")]
+#[should_panic(expected = "Authorising key is not in the current authorised keys")]
+async fn test_add_key_with_invalid_authorising_key_fails() {
+    let (conductor, cell) = setup_1_conductor().await;
+
+    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    let agent_expression = create_test_agent_expression(did, None);
+    let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
+
+    let input = AddAuthorisedKeyInput {
+        did: did.to_string(),
+        key: "malicious-key".to_string(),
+        name: "Attacker".to_string(),
+        proof: KeyAuthorisation {
+            authorising_key: "unknown-key-not-authorised".to_string(),
+            signature: "fake-sig".to_string(),
+        },
+    };
+
+    let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", input).await;
+}
+
+/// Test adding a key that is already authorised fails
+#[tokio::test(flavor = "multi_thread")]
+#[should_panic(expected = "Key is already authorised")]
+async fn test_add_duplicate_key_fails() {
+    let (conductor, cell) = setup_1_conductor().await;
+
+    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    let root_key = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    let agent_expression = create_test_agent_expression(did, None);
+    let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
+
+    // Try to add the root key again
+    let input = AddAuthorisedKeyInput {
+        did: did.to_string(),
+        key: root_key.to_string(),
+        name: "Duplicate".to_string(),
+        proof: KeyAuthorisation {
+            authorising_key: root_key.to_string(),
+            signature: "sig".to_string(),
+        },
+    };
+
+    let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", input).await;
+}
+
+/// Test revoking a key moves it from authorised to revoked
+#[tokio::test(flavor = "multi_thread")]
+async fn test_revoke_key_success() {
+    let (conductor, cell) = setup_1_conductor().await;
+
+    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    let root_key = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    let agent_expression = create_test_agent_expression(did, None);
+    let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
+
+    // Add a second key first
+    let add_input = AddAuthorisedKeyInput {
+        did: did.to_string(),
+        key: "device-key-2".to_string(),
+        name: "Phone".to_string(),
+        proof: KeyAuthorisation {
+            authorising_key: root_key.to_string(),
+            signature: "sig".to_string(),
+        },
+    };
+    let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", add_input).await;
+
+    // Now revoke the second key
+    let revoke_input = RevokeKeyInput {
+        did: did.to_string(),
+        key: "device-key-2".to_string(),
+        signature: "revoke-sig".to_string(),
+        reason: Some("Lost device".to_string()),
+    };
+    let result: AgentExpression = call_zome(&conductor, &cell, "revoke_key", revoke_input).await;
+
+    assert_eq!(result.data.authorised_keys.len(), 1, "Revoked key should be removed from authorised");
+    assert_eq!(result.data.revoked_keys.len(), 1);
+    assert_eq!(result.data.revoked_keys[0].revoked_key, "device-key-2");
+    assert_eq!(result.data.revoked_keys[0].reason, Some("Lost device".to_string()));
+}
+
+/// Test revoking an already-revoked key fails
+#[tokio::test(flavor = "multi_thread")]
+#[should_panic(expected = "Key not found in authorised keys")]
+async fn test_revoke_already_revoked_key_fails() {
+    let (conductor, cell) = setup_1_conductor().await;
+
+    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    let root_key = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    let agent_expression = create_test_agent_expression(did, None);
+    let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
+
+    // Add then revoke a key
+    let add_input = AddAuthorisedKeyInput {
+        did: did.to_string(),
+        key: "temp-key".to_string(),
+        name: "Temp".to_string(),
+        proof: KeyAuthorisation {
+            authorising_key: root_key.to_string(),
+            signature: "sig".to_string(),
+        },
+    };
+    let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", add_input).await;
+
+    let revoke_input = RevokeKeyInput {
+        did: did.to_string(),
+        key: "temp-key".to_string(),
+        signature: "sig".to_string(),
+        reason: None,
+    };
+    let _: AgentExpression = call_zome(&conductor, &cell, "revoke_key", revoke_input).await;
+
+    // Try to revoke again — should fail (key no longer in authorised_keys)
+    let revoke_input2 = RevokeKeyInput {
+        did: did.to_string(),
+        key: "temp-key".to_string(),
+        signature: "sig".to_string(),
+        reason: None,
+    };
+    let _: AgentExpression = call_zome(&conductor, &cell, "revoke_key", revoke_input2).await;
+}
+
+/// Test is_key_valid returns true for authorised keys, false for revoked/unknown
+#[tokio::test(flavor = "multi_thread")]
+async fn test_is_key_valid() {
+    let (conductor, cell) = setup_1_conductor().await;
+
+    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    let root_key = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    let agent_expression = create_test_agent_expression(did, None);
+    let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
+
+    // Root key should be valid
+    let valid: bool = call_zome(
+        &conductor,
+        &cell,
+        "is_key_valid",
+        IsKeyValidInput {
+            did: did.to_string(),
+            key: root_key.to_string(),
+        },
+    )
+    .await;
+    assert!(valid, "Root key should be valid");
+
+    // Unknown key should be invalid
+    let valid: bool = call_zome(
+        &conductor,
+        &cell,
+        "is_key_valid",
+        IsKeyValidInput {
+            did: did.to_string(),
+            key: "unknown-key".to_string(),
+        },
+    )
+    .await;
+    assert!(!valid, "Unknown key should be invalid");
+
+    // Non-existent DID should return false
+    let valid: bool = call_zome(
+        &conductor,
+        &cell,
+        "is_key_valid",
+        IsKeyValidInput {
+            did: "did:key:nonexistent".to_string(),
+            key: root_key.to_string(),
+        },
+    )
+    .await;
+    assert!(!valid, "Non-existent DID should return false");
+}
+
+/// Test that a revoked key cannot be used to add new keys
+#[tokio::test(flavor = "multi_thread")]
+#[should_panic(expected = "Authorising key has been revoked")]
+async fn test_revoked_key_cannot_add_new_keys() {
+    let (conductor, cell) = setup_1_conductor().await;
+
+    let did = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    let root_key = "z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+    let agent_expression = create_test_agent_expression(did, None);
+    let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
+
+    // Add a second key
+    let add_input = AddAuthorisedKeyInput {
+        did: did.to_string(),
+        key: "secondary-key".to_string(),
+        name: "Secondary".to_string(),
+        proof: KeyAuthorisation {
+            authorising_key: root_key.to_string(),
+            signature: "sig".to_string(),
+        },
+    };
+    let _: AgentExpression = call_zome(&conductor, &cell, "add_authorised_key", add_input).await;
+
+    // Revoke the secondary key
+    let revoke_input = RevokeKeyInput {
+        did: did.to_string(),
+        key: "secondary-key".to_string(),
+        signature: "sig".to_string(),
+        reason: None,
+    };
+    let _: AgentExpression = call_zome(&conductor, &cell, "revoke_key", revoke_input).await;
+
+    // Try to use revoked key to add another key — should fail
+    let add_with_revoked = AddAuthorisedKeyInput {
+        did: did.to_string(),
+        key: "malicious-new-key".to_string(),
+        name: "Malicious".to_string(),
+        proof: KeyAuthorisation {
+            authorising_key: "secondary-key".to_string(),
+            signature: "fake-sig".to_string(),
+        },
+    };
+    let _: AgentExpression =
+        call_zome(&conductor, &cell, "add_authorised_key", add_with_revoked).await;
+}
+
+/// Test backward compatibility: old-format expressions without authorised_keys deserialize correctly
+#[tokio::test(flavor = "multi_thread")]
+async fn test_backward_compat_old_format() {
+    let (conductor, cell) = setup_1_conductor().await;
+
+    // Create expression with did:test (non-did:key), which won't auto-populate
+    let did = "did:test:legacy-agent";
+    let agent_expression = create_test_agent_expression(did, Some("lang://old".to_string()));
+    let _: () = call_zome(&conductor, &cell, "create_agent_expression", agent_expression).await;
+
+    let retrieved: Option<AgentExpression> =
+        call_zome(&conductor, &cell, "get_agent_expression", did.to_string()).await;
+
+    let expr = retrieved.expect("Should exist");
+    // #[serde(default)] should give empty vecs
+    assert!(expr.data.authorised_keys.is_empty());
+    assert!(expr.data.revoked_keys.is_empty());
+    assert_eq!(expr.data.direct_message_language, Some("lang://old".to_string()));
+}

--- a/bootstrap-languages/agent-language/hc-dna/tests/sweettest/src/utils.rs
+++ b/bootstrap-languages/agent-language/hc-dna/tests/sweettest/src/utils.rs
@@ -87,6 +87,8 @@ pub fn create_test_agent_expression(did: &str, direct_message_language: Option<S
             did: did.to_string(),
             perspective: None,
             direct_message_language,
+            authorised_keys: vec![],
+            revoked_keys: vec![],
         },
         proof: ExpressionProof {
             signature: format!("sig_{}", Uuid::new_v4()),

--- a/bootstrap-languages/agent-language/hc-dna/zomes/agent_store/Cargo.toml
+++ b/bootstrap-languages/agent-language/hc-dna/zomes/agent_store/Cargo.toml
@@ -14,6 +14,7 @@ serde = "1"
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 thiserror = "1"
 getrandom = { version = "0.3" }
+bs58 = "0.5"
 
 hdk = { version = "0.7.0-dev.6", git = "https://github.com/coasys/holochain.git", branch = "0.7.0-dev.10-coasys" }
 holo_hash =  { version = "0.7.0-dev.3", git = "https://github.com/coasys/holochain.git", branch = "0.7.0-dev.10-coasys" }

--- a/bootstrap-languages/agent-language/hc-dna/zomes/agent_store/src/lib.rs
+++ b/bootstrap-languages/agent-language/hc-dna/zomes/agent_store/src/lib.rs
@@ -1,4 +1,7 @@
-use agent_store_integrity::{AgentExpression, Did, EntryTypes, LinkTypes};
+use agent_store_integrity::{
+    AddAuthorisedKeyInput, AgentExpression, AuthorisedKey, Did, EntryTypes,
+    IsKeyValidInput, KeyAuthorisation, KeyRevocation, LinkTypes, RevokeKeyInput,
+};
 use hdk::prelude::*;
 
 mod utils;
@@ -10,8 +13,34 @@ fn init(_: ()) -> ExternResult<InitCallbackResult> {
     Ok(InitCallbackResult::Pass)
 }
 
+/// Extract the key portion from a did:key: URI
+fn extract_key_from_did(did: &str) -> Option<String> {
+    if did.starts_with("did:key:") {
+        Some(did.trim_start_matches("did:key:").to_string())
+    } else {
+        None
+    }
+}
+
 #[hdk_extern]
-pub fn create_agent_expression(agent_expression: AgentExpression) -> ExternResult<()> {
+pub fn create_agent_expression(mut agent_expression: AgentExpression) -> ExternResult<()> {
+    // Auto-populate authorised_keys with the DID root key if empty (migration path)
+    if agent_expression.data.authorised_keys.is_empty() {
+        if let Some(root_key) = extract_key_from_did(&agent_expression.author) {
+            let now = chrono::Utc::now();
+            agent_expression.data.authorised_keys.push(AuthorisedKey {
+                key: root_key.clone(),
+                name: "Root Key".to_string(),
+                added_at: now,
+                added_by: agent_expression.author.clone(),
+                proof: KeyAuthorisation {
+                    authorising_key: root_key,
+                    signature: "self".to_string(),
+                },
+            });
+        }
+    }
+
     let did = EntryTypes::Did(Did(agent_expression.author.clone()));
     let did_hash = hash_entry(&did)?;
 
@@ -30,6 +59,145 @@ pub fn create_agent_expression(agent_expression: AgentExpression) -> ExternResul
     )?;
 
     Ok(())
+}
+
+/// Helper to get current agent expression for a DID
+fn get_current_expression(did: &str) -> ExternResult<Option<AgentExpression>> {
+    let did_entry = Did(did.to_string());
+    get_agent_expression(did_entry)
+}
+
+#[hdk_extern]
+pub fn add_authorised_key(input: AddAuthorisedKeyInput) -> ExternResult<AgentExpression> {
+    let current = get_current_expression(&input.did)?
+        .ok_or_else(|| err("Agent expression not found"))?;
+
+    // Check that the authorising key is in the current authorised_keys
+    let authorising_key_valid = current
+        .data
+        .authorised_keys
+        .iter()
+        .any(|k| k.key == input.proof.authorising_key);
+
+    if !authorising_key_valid {
+        return Err(err("Authorising key is not in the current authorised keys"));
+    }
+
+    // Check key is not already revoked
+    let is_revoked = current
+        .data
+        .revoked_keys
+        .iter()
+        .any(|r| r.revoked_key == input.proof.authorising_key);
+
+    if is_revoked {
+        return Err(err("Authorising key has been revoked"));
+    }
+
+    // Check the new key isn't already authorised
+    let already_exists = current.data.authorised_keys.iter().any(|k| k.key == input.key);
+    if already_exists {
+        return Err(err("Key is already authorised"));
+    }
+
+    let now = chrono::Utc::now();
+    let new_key = AuthorisedKey {
+        key: input.key,
+        name: input.name,
+        added_at: now,
+        added_by: input.did.clone(),
+        proof: input.proof,
+    };
+
+    let mut new_data = current.data.clone();
+    new_data.authorised_keys.push(new_key);
+
+    let new_expression = AgentExpression {
+        author: current.author.clone(),
+        timestamp: now,
+        data: new_data,
+        proof: current.proof.clone(),
+    };
+
+    // Store updated expression
+    let did = EntryTypes::Did(Did(current.author.clone()));
+    let did_hash = hash_entry(&did)?;
+    let entry = EntryTypes::AgentExpression(new_expression.clone());
+    let entry_hash = hash_entry(&entry)?;
+    create_entry(&entry)?;
+    create_link(
+        did_hash,
+        entry_hash,
+        LinkTypes::ProfileLink,
+        LinkTag::new("profile"),
+    )?;
+
+    Ok(new_expression)
+}
+
+#[hdk_extern]
+pub fn revoke_key(input: RevokeKeyInput) -> ExternResult<AgentExpression> {
+    let current = get_current_expression(&input.did)?
+        .ok_or_else(|| err("Agent expression not found"))?;
+
+    // Check the key exists in authorised_keys
+    let key_exists = current.data.authorised_keys.iter().any(|k| k.key == input.key);
+    if !key_exists {
+        return Err(err("Key not found in authorised keys"));
+    }
+
+    // Check not already revoked
+    let already_revoked = current.data.revoked_keys.iter().any(|r| r.revoked_key == input.key);
+    if already_revoked {
+        return Err(err("Key is already revoked"));
+    }
+
+    let now = chrono::Utc::now();
+    let revocation = KeyRevocation {
+        revoked_key: input.key.clone(),
+        revoked_at: now,
+        revoked_by: input.did.clone(),
+        signature: input.signature,
+        reason: input.reason,
+    };
+
+    let mut new_data = current.data.clone();
+    new_data.authorised_keys.retain(|k| k.key != input.key);
+    new_data.revoked_keys.push(revocation);
+
+    let new_expression = AgentExpression {
+        author: current.author.clone(),
+        timestamp: now,
+        data: new_data,
+        proof: current.proof.clone(),
+    };
+
+    let did = EntryTypes::Did(Did(current.author.clone()));
+    let did_hash = hash_entry(&did)?;
+    let entry = EntryTypes::AgentExpression(new_expression.clone());
+    let entry_hash = hash_entry(&entry)?;
+    create_entry(&entry)?;
+    create_link(
+        did_hash,
+        entry_hash,
+        LinkTypes::ProfileLink,
+        LinkTag::new("profile"),
+    )?;
+
+    Ok(new_expression)
+}
+
+#[hdk_extern]
+pub fn is_key_valid(input: IsKeyValidInput) -> ExternResult<bool> {
+    let current = match get_current_expression(&input.did)? {
+        Some(expr) => expr,
+        None => return Ok(false),
+    };
+
+    let in_authorised = current.data.authorised_keys.iter().any(|k| k.key == input.key);
+    let in_revoked = current.data.revoked_keys.iter().any(|r| r.revoked_key == input.key);
+
+    Ok(in_authorised && !in_revoked)
 }
 
 #[hdk_extern]

--- a/bootstrap-languages/agent-language/hc-dna/zomes/agent_store/src/lib.rs
+++ b/bootstrap-languages/agent-language/hc-dna/zomes/agent_store/src/lib.rs
@@ -1,5 +1,5 @@
 use agent_store_integrity::{
-    AddAuthorisedKeyInput, AgentExpression, AuthorisedKey, Did, EntryTypes,
+    AddAuthorisedKeyInput, AgentExpression, AgentExpressionData, AuthorisedKey, Did, EntryTypes,
     IsKeyValidInput, KeyAuthorisation, KeyRevocation, LinkTypes, RevokeKeyInput,
 };
 use hdk::prelude::*;
@@ -14,11 +14,11 @@ fn init(_: ()) -> ExternResult<InitCallbackResult> {
 }
 
 /// Extract the key portion from a did:key: URI
-fn extract_key_from_did(did: &str) -> Option<String> {
+fn extract_key_from_did(did: &str) -> Result<String, WasmError> {
     if did.starts_with("did:key:") {
-        Some(did.trim_start_matches("did:key:").to_string())
+        Ok(did.trim_start_matches("did:key:").to_string())
     } else {
-        None
+        Err(err(&format!("Cannot extract key from non did:key DID: {}", did)))
     }
 }
 
@@ -119,7 +119,7 @@ fn verify_key_signature(
 pub fn create_agent_expression(mut agent_expression: AgentExpression) -> ExternResult<()> {
     // Auto-populate authorised_keys with the DID root key if empty (migration path)
     if agent_expression.data.authorised_keys.is_empty() {
-        if let Some(root_key) = extract_key_from_did(&agent_expression.author) {
+        if let Ok(root_key) = extract_key_from_did(&agent_expression.author) {
             let now = chrono::Utc::now();
             agent_expression.data.authorised_keys.push(AuthorisedKey {
                 key: root_key.clone(),
@@ -162,7 +162,7 @@ fn get_current_expression(did: &str) -> ExternResult<Option<AgentExpression>> {
 }
 
 #[hdk_extern]
-pub fn add_authorised_key(input: AddAuthorisedKeyInput) -> ExternResult<AgentExpression> {
+pub fn add_authorised_key(input: AddAuthorisedKeyInput) -> ExternResult<AgentExpressionData> {
     let current = get_current_expression(&input.did)?
         .ok_or_else(|| err("Agent expression not found"))?;
 
@@ -218,31 +218,12 @@ pub fn add_authorised_key(input: AddAuthorisedKeyInput) -> ExternResult<AgentExp
     let mut new_data = current.data.clone();
     new_data.authorised_keys.push(new_key);
 
-    let new_expression = AgentExpression {
-        author: current.author.clone(),
-        timestamp: now,
-        data: new_data,
-        proof: current.proof.clone(),
-    };
-
-    // Store updated expression
-    let did = EntryTypes::Did(Did(current.author.clone()));
-    let did_hash = hash_entry(&did)?;
-    let entry = EntryTypes::AgentExpression(new_expression.clone());
-    let entry_hash = hash_entry(&entry)?;
-    create_entry(&entry)?;
-    create_link(
-        did_hash,
-        entry_hash,
-        LinkTypes::ProfileLink,
-        LinkTag::new("profile"),
-    )?;
-
-    Ok(new_expression)
+    // Return updated data — the adapter is responsible for signing and storing
+    Ok(new_data)
 }
 
 #[hdk_extern]
-pub fn revoke_key(input: RevokeKeyInput) -> ExternResult<AgentExpression> {
+pub fn revoke_key(input: RevokeKeyInput) -> ExternResult<AgentExpressionData> {
     let current = get_current_expression(&input.did)?
         .ok_or_else(|| err("Agent expression not found"))?;
 
@@ -304,26 +285,8 @@ pub fn revoke_key(input: RevokeKeyInput) -> ExternResult<AgentExpression> {
     new_data.authorised_keys.retain(|k| k.key != input.key);
     new_data.revoked_keys.push(revocation);
 
-    let new_expression = AgentExpression {
-        author: current.author.clone(),
-        timestamp: now,
-        data: new_data,
-        proof: current.proof.clone(),
-    };
-
-    let did = EntryTypes::Did(Did(current.author.clone()));
-    let did_hash = hash_entry(&did)?;
-    let entry = EntryTypes::AgentExpression(new_expression.clone());
-    let entry_hash = hash_entry(&entry)?;
-    create_entry(&entry)?;
-    create_link(
-        did_hash,
-        entry_hash,
-        LinkTypes::ProfileLink,
-        LinkTag::new("profile"),
-    )?;
-
-    Ok(new_expression)
+    // Return updated data — the adapter is responsible for signing and storing
+    Ok(new_data)
 }
 
 #[hdk_extern]

--- a/bootstrap-languages/agent-language/hc-dna/zomes/agent_store/src/lib.rs
+++ b/bootstrap-languages/agent-language/hc-dna/zomes/agent_store/src/lib.rs
@@ -22,6 +22,99 @@ fn extract_key_from_did(did: &str) -> Option<String> {
     }
 }
 
+/// Decode a multibase/multicodec Ed25519 public key string to raw 32 bytes.
+///
+/// Expected format: base58btc-encoded (prefix 'z') with Ed25519 multicodec
+/// prefix bytes `0xed 0x01` followed by 32 bytes of public key.
+fn decode_ed25519_pubkey(key_str: &str) -> ExternResult<[u8; 32]> {
+    // Strip 'z' multibase prefix (base58btc)
+    let without_prefix = key_str.strip_prefix('z').unwrap_or(key_str);
+    let decoded = bs58::decode(without_prefix)
+        .into_vec()
+        .map_err(|e| err(&format!("Failed to base58-decode key: {}", e)))?;
+
+    // Ed25519 multicodec: 0xed 0x01 + 32 bytes = 34 bytes
+    if decoded.len() == 34 && decoded[0] == 0xed && decoded[1] == 0x01 {
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&decoded[2..]);
+        Ok(key)
+    } else if decoded.len() == 32 {
+        // Raw 32-byte key without multicodec prefix
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&decoded);
+        Ok(key)
+    } else {
+        Err(err(&format!(
+            "Invalid Ed25519 key: expected 34 bytes (multicodec) or 32 bytes (raw), got {}",
+            decoded.len()
+        )))
+    }
+}
+
+/// Decode a hex-encoded Ed25519 signature to a Signature (64 bytes).
+fn decode_signature(sig_hex: &str) -> ExternResult<Signature> {
+    let bytes = hex_decode(sig_hex)
+        .map_err(|e| err(&format!("Failed to decode signature hex: {}", e)))?;
+    if bytes.len() != 64 {
+        return Err(err(&format!(
+            "Invalid signature length: expected 64 bytes, got {}",
+            bytes.len()
+        )));
+    }
+    let mut sig = [0u8; 64];
+    sig.copy_from_slice(&bytes);
+    Ok(Signature(sig))
+}
+
+/// Simple hex decoding (no external crate needed)
+fn hex_decode(hex: &str) -> Result<Vec<u8>, String> {
+    if hex.len() % 2 != 0 {
+        return Err("Hex string has odd length".to_string());
+    }
+    (0..hex.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&hex[i..i + 2], 16)
+                .map_err(|e| format!("Invalid hex at position {}: {}", i, e))
+        })
+        .collect()
+}
+
+/// Verify an Ed25519 signature using Holochain's built-in verify_signature_raw.
+///
+/// ## Signature message format
+///
+/// The signed message is the UTF-8 bytes of the concatenation:
+///   `<key> + <did> + <timestamp>`
+///
+/// Where:
+/// - `key` is the key being added or revoked (the multibase-encoded string)
+/// - `did` is the DID string (e.g., `did:key:z...`)
+/// - `timestamp` is the ISO 8601 timestamp string (e.g., `2024-01-01T00:00:00Z`)
+///
+/// Example: `"zABC123did:key:zXYZ7892024-01-01T00:00:00Z"`
+fn verify_key_signature(
+    signing_key_str: &str,
+    signature_hex: &str,
+    subject_key: &str,
+    did: &str,
+    timestamp: &str,
+) -> ExternResult<bool> {
+    // Skip verification for self-signed root keys
+    if signature_hex == "self" {
+        return Ok(true);
+    }
+
+    let pubkey_bytes = decode_ed25519_pubkey(signing_key_str)?;
+    let agent_pubkey = AgentPubKey::from_raw_32(pubkey_bytes.to_vec());
+    let signature = decode_signature(signature_hex)?;
+
+    // Message = subject_key + did + timestamp (UTF-8 bytes)
+    let message = format!("{}{}{}", subject_key, did, timestamp);
+
+    verify_signature_raw(agent_pubkey, signature, message.into_bytes())
+}
+
 #[hdk_extern]
 pub fn create_agent_expression(mut agent_expression: AgentExpression) -> ExternResult<()> {
     // Auto-populate authorised_keys with the DID root key if empty (migration path)
@@ -36,6 +129,7 @@ pub fn create_agent_expression(mut agent_expression: AgentExpression) -> ExternR
                 proof: KeyAuthorisation {
                     authorising_key: root_key,
                     signature: "self".to_string(),
+                    timestamp: now.to_rfc3339(),
                 },
             });
         }
@@ -92,6 +186,18 @@ pub fn add_authorised_key(input: AddAuthorisedKeyInput) -> ExternResult<AgentExp
 
     if is_revoked {
         return Err(err("Authorising key has been revoked"));
+    }
+
+    // Verify the signature over (new_key + did + timestamp)
+    let sig_valid = verify_key_signature(
+        &input.proof.authorising_key,
+        &input.proof.signature,
+        &input.key,
+        &input.did,
+        &input.proof.timestamp,
+    )?;
+    if !sig_valid {
+        return Err(err("Invalid signature: Ed25519 verification failed for add_authorised_key proof"));
     }
 
     // Check the new key isn't already authorised
@@ -152,11 +258,44 @@ pub fn revoke_key(input: RevokeKeyInput) -> ExternResult<AgentExpression> {
         return Err(err("Key is already revoked"));
     }
 
+    // Check that the revoking key is currently authorised
+    let revoker_valid = current
+        .data
+        .authorised_keys
+        .iter()
+        .any(|k| k.key == input.revoked_by_key);
+    if !revoker_valid {
+        return Err(err("Revoking key is not in the current authorised keys"));
+    }
+
+    // Check revoking key is not itself revoked
+    let revoker_revoked = current
+        .data
+        .revoked_keys
+        .iter()
+        .any(|r| r.revoked_key == input.revoked_by_key);
+    if revoker_revoked {
+        return Err(err("Revoking key has been revoked"));
+    }
+
+    // Verify the signature over (revoked_key + did + timestamp)
+    let sig_valid = verify_key_signature(
+        &input.revoked_by_key,
+        &input.signature,
+        &input.key,
+        &input.did,
+        &input.timestamp,
+    )?;
+    if !sig_valid {
+        return Err(err("Invalid signature: Ed25519 verification failed for revoke_key"));
+    }
+
     let now = chrono::Utc::now();
     let revocation = KeyRevocation {
         revoked_key: input.key.clone(),
         revoked_at: now,
         revoked_by: input.did.clone(),
+        revoked_by_key: input.revoked_by_key,
         signature: input.signature,
         reason: input.reason,
     };

--- a/bootstrap-languages/agent-language/hc-dna/zomes/agent_store_integrity/src/lib.rs
+++ b/bootstrap-languages/agent-language/hc-dna/zomes/agent_store_integrity/src/lib.rs
@@ -57,6 +57,7 @@ pub struct AgentExpression {
 app_entry!(AgentExpression);
 
 #[derive(Serialize, Deserialize, Clone, SerializedBytes, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct KeyAuthorisation {
     pub authorising_key: String,
     pub signature: String,
@@ -65,6 +66,7 @@ pub struct KeyAuthorisation {
 }
 
 #[derive(Serialize, Deserialize, Clone, SerializedBytes, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct AuthorisedKey {
     pub key: String,
     pub name: String,
@@ -74,6 +76,7 @@ pub struct AuthorisedKey {
 }
 
 #[derive(Serialize, Deserialize, Clone, SerializedBytes, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct KeyRevocation {
     pub revoked_key: String,
     pub revoked_at: DateTime<Utc>,
@@ -85,6 +88,7 @@ pub struct KeyRevocation {
 }
 
 #[derive(Serialize, Deserialize, Clone, SerializedBytes, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct AddAuthorisedKeyInput {
     pub did: String,
     pub key: String,
@@ -93,6 +97,7 @@ pub struct AddAuthorisedKeyInput {
 }
 
 #[derive(Serialize, Deserialize, Clone, SerializedBytes, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct RevokeKeyInput {
     pub did: String,
     pub key: String,
@@ -105,6 +110,7 @@ pub struct RevokeKeyInput {
 }
 
 #[derive(Serialize, Deserialize, Clone, SerializedBytes, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct IsKeyValidInput {
     pub did: String,
     pub key: String,
@@ -117,8 +123,8 @@ pub struct AgentExpressionData {
     #[serde(rename(serialize = "directMessageLanguage"))]
     #[serde(rename(deserialize = "directMessageLanguage"))]
     pub direct_message_language: Option<String>,
-    #[serde(default)]
+    #[serde(default, rename = "authorisedKeys")]
     pub authorised_keys: Vec<AuthorisedKey>,
-    #[serde(default)]
+    #[serde(default, rename = "revokedKeys")]
     pub revoked_keys: Vec<KeyRevocation>,
 }

--- a/bootstrap-languages/agent-language/hc-dna/zomes/agent_store_integrity/src/lib.rs
+++ b/bootstrap-languages/agent-language/hc-dna/zomes/agent_store_integrity/src/lib.rs
@@ -60,6 +60,8 @@ app_entry!(AgentExpression);
 pub struct KeyAuthorisation {
     pub authorising_key: String,
     pub signature: String,
+    /// ISO 8601 timestamp that was included in the signed message
+    pub timestamp: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, SerializedBytes, Debug)]
@@ -76,6 +78,8 @@ pub struct KeyRevocation {
     pub revoked_key: String,
     pub revoked_at: DateTime<Utc>,
     pub revoked_by: String,
+    /// The authorised key that signed this revocation
+    pub revoked_by_key: String,
     pub signature: String,
     pub reason: Option<String>,
 }
@@ -92,7 +96,11 @@ pub struct AddAuthorisedKeyInput {
 pub struct RevokeKeyInput {
     pub did: String,
     pub key: String,
+    /// The authorised key used to sign the revocation
+    pub revoked_by_key: String,
     pub signature: String,
+    /// ISO 8601 timestamp that was included in the signed message
+    pub timestamp: String,
     pub reason: Option<String>,
 }
 

--- a/bootstrap-languages/agent-language/hc-dna/zomes/agent_store_integrity/src/lib.rs
+++ b/bootstrap-languages/agent-language/hc-dna/zomes/agent_store_integrity/src/lib.rs
@@ -57,10 +57,60 @@ pub struct AgentExpression {
 app_entry!(AgentExpression);
 
 #[derive(Serialize, Deserialize, Clone, SerializedBytes, Debug)]
+pub struct KeyAuthorisation {
+    pub authorising_key: String,
+    pub signature: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, SerializedBytes, Debug)]
+pub struct AuthorisedKey {
+    pub key: String,
+    pub name: String,
+    pub added_at: DateTime<Utc>,
+    pub added_by: String,
+    pub proof: KeyAuthorisation,
+}
+
+#[derive(Serialize, Deserialize, Clone, SerializedBytes, Debug)]
+pub struct KeyRevocation {
+    pub revoked_key: String,
+    pub revoked_at: DateTime<Utc>,
+    pub revoked_by: String,
+    pub signature: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, SerializedBytes, Debug)]
+pub struct AddAuthorisedKeyInput {
+    pub did: String,
+    pub key: String,
+    pub name: String,
+    pub proof: KeyAuthorisation,
+}
+
+#[derive(Serialize, Deserialize, Clone, SerializedBytes, Debug)]
+pub struct RevokeKeyInput {
+    pub did: String,
+    pub key: String,
+    pub signature: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, SerializedBytes, Debug)]
+pub struct IsKeyValidInput {
+    pub did: String,
+    pub key: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, SerializedBytes, Debug)]
 pub struct AgentExpressionData {
     pub did: String,
     pub perspective: Option<Perspective>,
     #[serde(rename(serialize = "directMessageLanguage"))]
     #[serde(rename(deserialize = "directMessageLanguage"))]
     pub direct_message_language: Option<String>,
+    #[serde(default)]
+    pub authorised_keys: Vec<AuthorisedKey>,
+    #[serde(default)]
+    pub revoked_keys: Vec<KeyRevocation>,
 }

--- a/core/src/agent/Agent.ts
+++ b/core/src/agent/Agent.ts
@@ -2,22 +2,6 @@ import { Field, ObjectType, InputType } from "type-graphql";
 import { Perspective } from "../perspectives/Perspective";
 import { ExpressionGeneric } from "../expression/Expression";
 
-/**  AD4M's representation of an Agent
- *
- * AD4M Agents are build around DIDs, which are used to identify and authenticate the Agent.
- * Conceptually, an Agent is regarded as something that can speak and that can listen.
- *
- * Agents speak by creating Expressions in AD4M Languages which are signed by the Agent's DID key,
- * And they also speak (broadcast) by putting semantic statements into their public "Agent Perspective".
- * They listen (can receive messages) through their "direct message Language".
- *
- * These three aspects are represented by the three fields of this class.
- *
- * This class is used as format for the Expressions in the Agent language.
- * Since AD4M treats DID URIs as addresses for the Agent Language,
- * DIDs are resolved to Expressions that are objects of this class.
- * Thus, this is how agents see (other) agents.
- */
 @ObjectType()
 export class KeyAuthorisation {
   @Field()
@@ -98,6 +82,22 @@ export class KeyRevocation {
   }
 }
 
+/**  AD4M's representation of an Agent
+ *
+ * AD4M Agents are build around DIDs, which are used to identify and authenticate the Agent.
+ * Conceptually, an Agent is regarded as something that can speak and that can listen.
+ *
+ * Agents speak by creating Expressions in AD4M Languages which are signed by the Agent's DID key,
+ * And they also speak (broadcast) by putting semantic statements into their public "Agent Perspective".
+ * They listen (can receive messages) through their "direct message Language".
+ *
+ * These three aspects are represented by the three fields of this class.
+ *
+ * This class is used as format for the Expressions in the Agent language.
+ * Since AD4M treats DID URIs as addresses for the Agent Language,
+ * DIDs are resolved to Expressions that are objects of this class.
+ * Thus, this is how agents see (other) agents.
+ */
 @ObjectType()
 export class Agent {
   /** The DID of the Agent

--- a/core/src/agent/Agent.ts
+++ b/core/src/agent/Agent.ts
@@ -19,6 +19,86 @@ import { ExpressionGeneric } from "../expression/Expression";
  * Thus, this is how agents see (other) agents.
  */
 @ObjectType()
+export class KeyAuthorisation {
+  @Field()
+  authorisingKey: string;
+
+  @Field()
+  signature: string;
+
+  constructor(authorisingKey: string, signature: string) {
+    this.authorisingKey = authorisingKey;
+    this.signature = signature;
+  }
+}
+
+@InputType()
+export class KeyAuthorisationInput {
+  @Field()
+  authorisingKey: string;
+
+  @Field()
+  signature: string;
+
+  constructor(authorisingKey: string, signature: string) {
+    this.authorisingKey = authorisingKey;
+    this.signature = signature;
+  }
+}
+
+@ObjectType()
+export class AuthorisedKey {
+  @Field()
+  key: string;
+
+  @Field()
+  name: string;
+
+  @Field()
+  addedAt: string;
+
+  @Field()
+  addedBy: string;
+
+  @Field((type) => KeyAuthorisation)
+  proof: KeyAuthorisation;
+
+  constructor(key: string, name: string, addedAt: string, addedBy: string, proof: KeyAuthorisation) {
+    this.key = key;
+    this.name = name;
+    this.addedAt = addedAt;
+    this.addedBy = addedBy;
+    this.proof = proof;
+  }
+}
+
+@ObjectType()
+export class KeyRevocation {
+  @Field()
+  revokedKey: string;
+
+  @Field()
+  revokedAt: string;
+
+  @Field()
+  revokedBy: string;
+
+  @Field()
+  signature: string;
+
+  @Field({ nullable: true })
+  reason?: string;
+
+  constructor(revokedKey: string, revokedAt: string, revokedBy: string, signature: string, reason?: string) {
+    this.revokedKey = revokedKey;
+    this.revokedAt = revokedAt;
+    this.revokedBy = revokedBy;
+    this.signature = signature;
+    this.reason = reason;
+  }
+}
+
+@ObjectType()
 export class Agent {
   /** The DID of the Agent
    * All epxressions authored by them are signed with the keys mentioned
@@ -38,6 +118,14 @@ export class Agent {
   /** Address of the Language by which the Agent will receive DMs */
   @Field({ nullable: true })
   directMessageLanguage?: string;
+
+  /** List of authorised keys for this agent identity */
+  @Field((type) => [AuthorisedKey], { nullable: true })
+  authorisedKeys?: AuthorisedKey[];
+
+  /** List of revoked keys for this agent identity */
+  @Field((type) => [KeyRevocation], { nullable: true })
+  revokedKeys?: KeyRevocation[];
 
   constructor(did: string, perspective?: Perspective) {
     this.did = did;

--- a/core/src/agent/AgentClient.ts
+++ b/core/src/agent/AgentClient.ts
@@ -9,6 +9,7 @@ import {
   AuthorisedKey,
   EntanglementProof,
   EntanglementProofInput,
+  KeyAuthorisationInput,
   KeyRevocation,
   UserCreationResult,
 } from "./Agent";
@@ -138,6 +139,8 @@ export class AgentClient {
     );
     let agentObject = new Agent(agent.did, agent.perspective);
     agentObject.directMessageLanguage = agent.directMessageLanguage;
+    agentObject.authorisedKeys = agent.authorisedKeys;
+    agentObject.revokedKeys = agent.revokedKeys;
     return agentObject;
   }
 
@@ -255,6 +258,8 @@ export class AgentClient {
     const a = agentUpdatePublicPerspective;
     const agent = new Agent(a.did, a.perspective);
     agent.directMessageLanguage = a.directMessageLanguage;
+    agent.authorisedKeys = a.authorisedKeys;
+    agent.revokedKeys = a.revokedKeys;
     return agent;
   }
 
@@ -305,18 +310,20 @@ export class AgentClient {
     const a = agentUpdateDirectMessageLanguage;
     const agent = new Agent(a.did, a.perspective);
     agent.directMessageLanguage = a.directMessageLanguage;
+    agent.authorisedKeys = a.authorisedKeys;
+    agent.revokedKeys = a.revokedKeys;
     return agent;
   }
 
-  async addAuthorisedKey(key: string, name: string): Promise<Agent> {
+  async addAuthorisedKey(key: string, name: string, proof: KeyAuthorisationInput): Promise<Agent> {
     const { agentAddAuthorisedKey } = unwrapApolloResult(
       await this.#apolloClient.mutate({
-        mutation: gql`mutation agentAddAuthorisedKey($key: String!, $name: String!) {
-                agentAddAuthorisedKey(key: $key, name: $name) {
+        mutation: gql`mutation agentAddAuthorisedKey($key: String!, $name: String!, $proof: KeyAuthorisationInput!) {
+                agentAddAuthorisedKey(key: $key, name: $name, proof: $proof) {
                     ${AGENT_SUBITEMS}
                 }
             }`,
-        variables: { key, name },
+        variables: { key, name, proof },
       })
     );
     return agentAddAuthorisedKey as Agent;

--- a/core/src/agent/AgentClient.ts
+++ b/core/src/agent/AgentClient.ts
@@ -6,8 +6,10 @@ import {
   Apps,
   AuthInfo,
   AuthInfoInput,
+  AuthorisedKey,
   EntanglementProof,
   EntanglementProofInput,
+  KeyRevocation,
   UserCreationResult,
 } from "./Agent";
 import { AgentStatus } from "./AgentStatus";
@@ -28,6 +30,23 @@ const AGENT_SUBITEMS = `
                 source, predicate, target
             }
         }
+    }
+    authorisedKeys {
+        key
+        name
+        addedAt
+        addedBy
+        proof {
+            authorisingKey
+            signature
+        }
+    }
+    revokedKeys {
+        revokedKey
+        revokedAt
+        revokedBy
+        signature
+        reason
     }
 `;
 
@@ -287,6 +306,83 @@ export class AgentClient {
     const agent = new Agent(a.did, a.perspective);
     agent.directMessageLanguage = a.directMessageLanguage;
     return agent;
+  }
+
+  async addAuthorisedKey(key: string, name: string): Promise<Agent> {
+    const { agentAddAuthorisedKey } = unwrapApolloResult(
+      await this.#apolloClient.mutate({
+        mutation: gql`mutation agentAddAuthorisedKey($key: String!, $name: String!) {
+                agentAddAuthorisedKey(key: $key, name: $name) {
+                    ${AGENT_SUBITEMS}
+                }
+            }`,
+        variables: { key, name },
+      })
+    );
+    return agentAddAuthorisedKey as Agent;
+  }
+
+  async revokeKey(key: string, reason?: string): Promise<Agent> {
+    const { agentRevokeKey } = unwrapApolloResult(
+      await this.#apolloClient.mutate({
+        mutation: gql`mutation agentRevokeKey($key: String!, $reason: String) {
+                agentRevokeKey(key: $key, reason: $reason) {
+                    ${AGENT_SUBITEMS}
+                }
+            }`,
+        variables: { key, reason },
+      })
+    );
+    return agentRevokeKey as Agent;
+  }
+
+  async authorisedKeys(): Promise<AuthorisedKey[]> {
+    const { agentAuthorisedKeys } = unwrapApolloResult(
+      await this.#apolloClient.query({
+        query: gql`query agentAuthorisedKeys {
+                agentAuthorisedKeys {
+                    key
+                    name
+                    addedAt
+                    addedBy
+                    proof {
+                        authorisingKey
+                        signature
+                    }
+                }
+            }`,
+      })
+    );
+    return agentAuthorisedKeys;
+  }
+
+  async revokedKeys(): Promise<KeyRevocation[]> {
+    const { agentRevokedKeys } = unwrapApolloResult(
+      await this.#apolloClient.query({
+        query: gql`query agentRevokedKeys {
+                agentRevokedKeys {
+                    revokedKey
+                    revokedAt
+                    revokedBy
+                    signature
+                    reason
+                }
+            }`,
+      })
+    );
+    return agentRevokedKeys;
+  }
+
+  async isKeyValid(did: string, key: string): Promise<boolean> {
+    const { agentIsKeyValid } = unwrapApolloResult(
+      await this.#apolloClient.query({
+        query: gql`query agentIsKeyValid($did: String!, $key: String!) {
+                agentIsKeyValid(did: $did, key: $key)
+            }`,
+        variables: { did, key },
+      })
+    );
+    return agentIsKeyValid;
   }
 
   async addEntanglementProofs(

--- a/core/src/agent/AgentResolver.ts
+++ b/core/src/agent/AgentResolver.ts
@@ -12,8 +12,11 @@ import {
   AgentSignature,
   Apps,
   AuthInfoInput,
+  AuthorisedKey,
   EntanglementProof,
   EntanglementProofInput,
+  KeyAuthorisation,
+  KeyRevocation,
 } from "./Agent";
 import { AgentStatus } from "./AgentStatus";
 import { AGENT_STATUS_CHANGED, AGENT_UPDATED, APPS_CHANGED } from "../PubSub";
@@ -259,5 +262,67 @@ export default class AgentResolver {
   @Mutation((returns) => AgentSignature)
   agentSignMessage(@Arg("message") message: string): AgentSignature {
     return new AgentSignature("test-message-signature", "test-public-key");
+  }
+
+  @Mutation((returns) => Agent)
+  agentAddAuthorisedKey(
+    @Arg("key") key: string,
+    @Arg("name") name: string
+  ): Agent {
+    const agent = new Agent(TEST_AGENT_DID);
+    agent.authorisedKeys = [
+      new AuthorisedKey(
+        key,
+        name,
+        new Date().toISOString(),
+        TEST_AGENT_DID,
+        new KeyAuthorisation(key, "test-signature")
+      ),
+    ];
+    return agent;
+  }
+
+  @Mutation((returns) => Agent)
+  agentRevokeKey(
+    @Arg("key") key: string,
+    @Arg("reason", { nullable: true }) reason?: string
+  ): Agent {
+    const agent = new Agent(TEST_AGENT_DID);
+    agent.revokedKeys = [
+      new KeyRevocation(
+        key,
+        new Date().toISOString(),
+        TEST_AGENT_DID,
+        "test-signature",
+        reason
+      ),
+    ];
+    return agent;
+  }
+
+  @Query((returns) => [AuthorisedKey])
+  agentAuthorisedKeys(): AuthorisedKey[] {
+    return [
+      new AuthorisedKey(
+        "test-key",
+        "Root Key",
+        new Date().toISOString(),
+        TEST_AGENT_DID,
+        new KeyAuthorisation("test-key", "self")
+      ),
+    ];
+  }
+
+  @Query((returns) => [KeyRevocation])
+  agentRevokedKeys(): KeyRevocation[] {
+    return [];
+  }
+
+  @Query((returns) => Boolean)
+  agentIsKeyValid(
+    @Arg("did") did: string,
+    @Arg("key") key: string
+  ): Boolean {
+    return true;
   }
 }

--- a/core/src/agent/AgentResolver.ts
+++ b/core/src/agent/AgentResolver.ts
@@ -16,6 +16,7 @@ import {
   EntanglementProof,
   EntanglementProofInput,
   KeyAuthorisation,
+  KeyAuthorisationInput,
   KeyRevocation,
 } from "./Agent";
 import { AgentStatus } from "./AgentStatus";
@@ -267,19 +268,11 @@ export default class AgentResolver {
   @Mutation((returns) => Agent)
   agentAddAuthorisedKey(
     @Arg("key") key: string,
-    @Arg("name") name: string
+    @Arg("name") name: string,
+    @Arg("proof") proof: KeyAuthorisationInput
   ): Agent {
-    const agent = new Agent(TEST_AGENT_DID);
-    agent.authorisedKeys = [
-      new AuthorisedKey(
-        key,
-        name,
-        new Date().toISOString(),
-        TEST_AGENT_DID,
-        new KeyAuthorisation(key, "test-signature")
-      ),
-    ];
-    return agent;
+    // TODO: Wire through to executor's agent subsystem → adapter → zome
+    throw new Error("Not implemented - requires executor wiring for multi-key agent identity");
   }
 
   @Mutation((returns) => Agent)
@@ -287,35 +280,20 @@ export default class AgentResolver {
     @Arg("key") key: string,
     @Arg("reason", { nullable: true }) reason?: string
   ): Agent {
-    const agent = new Agent(TEST_AGENT_DID);
-    agent.revokedKeys = [
-      new KeyRevocation(
-        key,
-        new Date().toISOString(),
-        TEST_AGENT_DID,
-        "test-signature",
-        reason
-      ),
-    ];
-    return agent;
+    // TODO: Wire through to executor's agent subsystem → adapter → zome
+    throw new Error("Not implemented - requires executor wiring for multi-key agent identity");
   }
 
   @Query((returns) => [AuthorisedKey])
   agentAuthorisedKeys(): AuthorisedKey[] {
-    return [
-      new AuthorisedKey(
-        "test-key",
-        "Root Key",
-        new Date().toISOString(),
-        TEST_AGENT_DID,
-        new KeyAuthorisation("test-key", "self")
-      ),
-    ];
+    // TODO: Wire through to executor's agent subsystem → adapter → zome
+    throw new Error("Not implemented - requires executor wiring for multi-key agent identity");
   }
 
   @Query((returns) => [KeyRevocation])
   agentRevokedKeys(): KeyRevocation[] {
-    return [];
+    // TODO: Wire through to executor's agent subsystem → adapter → zome
+    throw new Error("Not implemented - requires executor wiring for multi-key agent identity");
   }
 
   @Query((returns) => Boolean)
@@ -323,6 +301,7 @@ export default class AgentResolver {
     @Arg("did") did: string,
     @Arg("key") key: string
   ): Boolean {
-    return true;
+    // TODO: Wire through to executor's agent subsystem → adapter → zome
+    throw new Error("Not implemented - requires executor wiring for multi-key agent identity");
   }
 }


### PR DESCRIPTION
## Multi-Key Agent Identity Support

Implements multi-key support for agent identity as outlined in #660.

### Phase 1: Data Model + Zome Updates
- **Integrity zome**: Added `AuthorisedKey`, `KeyAuthorisation`, `KeyRevocation` structs
- **`AgentExpressionData`**: Extended with `authorised_keys` and `revoked_keys` fields (`#[serde(default)]` for backward compatibility)
- **New zome functions**: `add_authorised_key`, `revoke_key`, `is_key_valid`
- **Migration path**: `create_agent_expression` auto-populates the DID root key as first authorised key when `authorised_keys` is empty

### Phase 2: Client API
- **TypeScript types**: `AuthorisedKey`, `KeyAuthorisation`, `KeyRevocation` with `@ObjectType()`/`@InputType()` decorators
- **GraphQL mutations**: `agentAddAuthorisedKey(key, name)`, `agentRevokeKey(key, reason?)`
- **GraphQL queries**: `agentAuthorisedKeys`, `agentRevokedKeys`, `agentIsKeyValid(did, key)`
- **AgentClient methods**: `addAuthorisedKey()`, `revokeKey()`, `authorisedKeys()`, `revokedKeys()`, `isKeyValid()`
- **Expression adapter**: Exposes new zome functions

### Test Coverage (NEW)
- Sweettest suite with 10 integration tests covering:
  - Root key auto-population from `did:key` DIDs
  - Adding authorised keys (success + edge cases)
  - Revoking keys and re-revocation prevention
  - `is_key_valid` correctness for authorised, revoked, and unknown keys
  - Backward compatibility with old-format expressions
  - Security: revoked keys cannot add new keys

### Backward Compatibility
- All new `Vec` fields use `#[serde(default)]` — existing agent expressions deserialize without issues
- The DID's original key (from `did:key:...`) is always the implicit root key
- No existing tests broken

### ⚠️ Security Review Findings (Phase 3 TODO)
These issues are by-design for Phase 1 (data model only) but **must be addressed before production use**:

1. **No cryptographic signature verification** — `add_authorised_key` and `revoke_key` store signatures but never verify them cryptographically. The `proof.signature` field is currently just stored, not validated against the authorising key. This means any caller who knows an authorised key string can add arbitrary new keys.

2. **No caller authorization** — Any Holochain agent can call `add_authorised_key` or `revoke_key` for any DID. There is no check that the zome caller owns or controls the DID. This needs to be enforced either in the zome (via `agent_info()`) or at a higher layer.

3. **`revoke_key` doesn't verify who is revoking** — The revocation stores `revoked_by` as the DID but doesn't verify the caller has authority to revoke (i.e., holds an authorised key).

4. **Root key uses `"self"` as signature** — The auto-populated root key has `proof.signature = "self"` which is a sentinel value. This is fine for bootstrapping but should be documented as a special case.

These are tracked for Phase 3 (signature verification + authorization enforcement).

Related to #660 (Phases 1 & 2 only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Key management: add authorised keys (with proof), revoke keys (optional reason), and validate key status.
  * Agent schema extended to store authorised keys and revocation history with proof metadata.
  * New API endpoints and client methods for adding/revoking keys, listing authorised/revoked keys, and checking key validity.

* **Tests**
  * Added comprehensive multi-key integration tests covering add/revoke/validation and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->