### PR TITLE
Fix multi-user agent publishing after language controller refactor

### DIFF
--- a/rust-executor/src/agent/mod.rs
+++ b/rust-executor/src/agent/mod.rs
@@ -189,6 +189,22 @@ pub fn sign_string_hex(data: String) -> Result<String, AnyError> {
     Ok(sig_hex)
 }
 
+/// Convert an Agent's decorated perspective to plain LinkExpressions for publishing.
+/// Returns a JSON value with non-decorated types (no proof.valid/invalid, no status).
+fn agent_to_publish_json(agent: &Agent) -> Result<serde_json::Value, AnyError> {
+    use crate::types::{LinkExpression, Perspective as PlainPerspective};
+
+    let plain_perspective = agent.perspective.as_ref().map(|p| PlainPerspective {
+        links: p.links.iter().cloned().map(LinkExpression::from).collect(),
+    });
+
+    Ok(serde_json::json!({
+        "did": agent.did,
+        "directMessageLanguage": agent.direct_message_language,
+        "perspective": plain_perspective,
+    }))
+}
+
 pub struct AgentSignature {
     pub signature: String,
     pub public_key: String,
@@ -466,29 +482,41 @@ impl AgentService {
         Ok(())
     }
 
-    /// Publish agent to the agent language (decentralized storage)
-    pub async fn publish_user_agent_to_language(
-        user_email: &str,
-        agent: &Agent,
-    ) -> Result<(), AnyError> {
+    /// Unified method to publish an agent profile to the agent language.
+    /// Works for both the main agent and managed users.
+    /// Strips link decorations before publishing.
+    pub async fn publish_agent_to_language(context: &AgentContext) -> Result<(), AnyError> {
         let controller = crate::languages::LanguageController::global_instance();
         let agent_lang = controller
             .get_agent_language()
             .await
             .map_err(|e| anyhow!("Agent language not available: {}", e))?;
 
-        let agent_json = serde_json::to_value(agent)?;
-        let agent_context = AgentContext::for_user_email(user_email.to_string());
+        let agent = Self::get_agent_for_context(context)?;
+        let agent_json = agent_to_publish_json(&agent)?;
         controller
-            .expression_create(agent_lang.address(), agent_json, &agent_context)
+            .expression_create(agent_lang.address(), agent_json, context)
             .await
             .map_err(|e| anyhow!("Failed to publish agent to language: {}", e))?;
 
-        log::info!(
-            "Successfully published agent {} to agent language",
-            agent.did
-        );
+        log::info!("Published agent {} to agent language", agent.did);
         Ok(())
+    }
+
+    /// Get the Agent data for a given context (main agent or managed user).
+    fn get_agent_for_context(context: &AgentContext) -> Result<Agent, AnyError> {
+        match &context.user_email {
+            Some(email) => {
+                let agent =
+                    AgentService::with_global_instance(|svc| svc.load_user_agent_profile(email))?;
+                agent.ok_or_else(|| anyhow!("User profile not found for {}", email))
+            }
+            None => AgentService::with_global_instance(|svc| {
+                svc.agent
+                    .clone()
+                    .ok_or_else(|| anyhow!("Agent not initialized"))
+            }),
+        }
     }
 
     /// Load agent profile for a specific user
@@ -513,70 +541,8 @@ impl AgentService {
         .expect("Failed to write agent profile file");
 
         // Note: callers who need the agent published to the agent language
-        // should call publish_main_agent_to_language() separately (this method
+        // should call publish_agent_to_language() separately (this method
         // is sync and cannot await).
-    }
-
-    /// Publish the main agent's profile to the agent language (decentralized storage).
-    /// Mirrors publish_user_agent_to_language() but for the main agent context.
-    pub async fn publish_main_agent_to_language() -> Result<(), AnyError> {
-        let agent_data =
-            AgentService::with_global_instance(|agent_service| agent_service.agent.clone());
-        let agent = agent_data.ok_or_else(|| anyhow!("Agent not initialized"))?;
-
-        let controller = crate::languages::LanguageController::global_instance();
-        let agent_lang = controller
-            .get_agent_language()
-            .await
-            .map_err(|e| anyhow!("Agent language not available: {}", e))?;
-
-        let agent_json = serde_json::to_value(&agent)?;
-        let agent_context = AgentContext::main_agent();
-        controller
-            .expression_create(agent_lang.address(), agent_json, &agent_context)
-            .await
-            .map_err(|e| anyhow!("Failed to publish main agent to language: {}", e))?;
-
-        log::info!("Successfully published main agent to agent language");
-        Ok(())
-    }
-
-    /// Publish the main agent's current profile to the agent language.
-    /// Always updates the expression (creates or overwrites).
-    pub async fn ensure_agent_expression() -> Result<(), AnyError> {
-        let controller = crate::languages::LanguageController::global_instance();
-
-        // Get the agent language
-        let agent_language = match controller.get_agent_language().await {
-            Ok(lang) => lang,
-            Err(e) => {
-                log::warn!("Agent language not available yet: {:?}", e);
-                return Ok(());
-            }
-        };
-
-        // Get current agent data and publish it
-        let agent_data =
-            AgentService::with_global_instance(|agent_service| agent_service.agent.clone());
-
-        if let Some(agent) = agent_data {
-            let agent_json = serde_json::to_string(&agent)
-                .map_err(|e| anyhow!("Failed to serialize agent: {}", e))?;
-            let create_script = format!(
-                r#"JSON.stringify(await language.expressionAdapter.putAdapter.createPublic({}))"#,
-                agent_json
-            );
-
-            controller
-                .execute_on_language(agent_language.address(), &create_script)
-                .await
-                .map_err(|e| anyhow!("Error creating agent expression: {:?}", e))?;
-            log::info!("Agent expression published successfully");
-        } else {
-            log::warn!("No agent data available to publish");
-        }
-
-        Ok(())
     }
 
     pub fn save_agent_profile(&mut self, agent: Agent) {

--- a/rust-executor/src/agent/mod.rs
+++ b/rust-executor/src/agent/mod.rs
@@ -515,6 +515,14 @@ impl AgentService {
             .map_err(|e| anyhow!("Agent language not available: {}", e))?;
 
         let agent = Self::get_agent_for_context(context)?;
+        let context_did = did_for_context(context)?;
+        if agent.did != context_did {
+            return Err(anyhow!(
+                "DID mismatch: stored profile has DID {} but signing context resolves to {}",
+                agent.did,
+                context_did
+            ));
+        }
         let agent_json = agent_to_publish_json(&agent)?;
         controller
             .expression_create(agent_lang.address(), agent_json, context)

--- a/rust-executor/src/agent/mod.rs
+++ b/rust-executor/src/agent/mod.rs
@@ -182,11 +182,18 @@ pub fn create_signed_expression<T: Serialize>(
     })
 }
 
-pub fn sign_string_hex(data: String) -> Result<String, AnyError> {
+pub fn sign_string_hex_for_context(
+    data: String,
+    context: &AgentContext,
+) -> Result<String, AnyError> {
     let payload_bytes = signatures::hash_message(&data);
-    let signature = sign_for_context(&payload_bytes, &AgentContext::main_agent())?;
+    let signature = sign_for_context(&payload_bytes, context)?;
     let sig_hex = hex::encode(signature);
     Ok(sig_hex)
+}
+
+pub fn sign_string_hex(data: String) -> Result<String, AnyError> {
+    sign_string_hex_for_context(data, &AgentContext::main_agent())
 }
 
 /// Convert an Agent's decorated perspective to plain LinkExpressions for publishing.

--- a/rust-executor/src/agent/mod.rs
+++ b/rust-executor/src/agent/mod.rs
@@ -216,7 +216,16 @@ fn agent_to_publish_json(agent: &Agent) -> Result<serde_json::Value, AnyError> {
     use crate::types::{LinkExpression, Perspective as PlainPerspective};
 
     let plain_perspective = agent.perspective.as_ref().map(|p| PlainPerspective {
-        links: p.links.iter().cloned().map(LinkExpression::from).collect(),
+        links: p
+            .links
+            .iter()
+            .cloned()
+            .map(|d| {
+                let mut le = LinkExpression::from(d);
+                le.status = None;
+                le
+            })
+            .collect(),
     });
 
     Ok(serde_json::json!({

--- a/rust-executor/src/agent/mod.rs
+++ b/rust-executor/src/agent/mod.rs
@@ -12,6 +12,20 @@ use crate::wallet::Wallet;
 pub mod capabilities;
 pub mod signatures;
 
+/// Validate that a user email is safe to use as a filesystem path segment.
+/// Rejects path separators, "..", null bytes, and other unsafe characters.
+fn validate_user_email_for_path(email: &str) -> Result<(), AnyError> {
+    if email.is_empty() {
+        return Err(anyhow!("User email cannot be empty"));
+    }
+    if email.contains('/') || email.contains('\\') || email.contains('\0') || email.contains("..") {
+        return Err(anyhow!(
+            "Invalid user email: contains unsafe path characters"
+        ));
+    }
+    Ok(())
+}
+
 /// Context for determining which agent to use for operations
 #[derive(Debug, Clone, PartialEq)]
 pub struct AgentContext {
@@ -477,6 +491,7 @@ impl AgentService {
         user_email: &str,
         agent: &Agent,
     ) -> Result<(), AnyError> {
+        validate_user_email_for_path(user_email)?;
         // Create user-specific profile directory
         let user_profile_dir = format!("{}/{}", self.users_dir, user_email);
         std::fs::create_dir_all(&user_profile_dir)?;
@@ -528,6 +543,7 @@ impl AgentService {
 
     /// Load agent profile for a specific user
     pub fn load_user_agent_profile(&self, user_email: &str) -> Result<Option<Agent>, AnyError> {
+        validate_user_email_for_path(user_email)?;
         let profile_path = format!("{}/{}/profile.json", self.users_dir, user_email);
 
         if !std::path::Path::new(&profile_path).exists() {

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -211,9 +211,9 @@ impl Mutation {
             log::info!("System languages loaded");
         }
 
-        // Ensure agent expression exists in the agent language
-        if let Err(e) = AgentService::ensure_agent_expression().await {
-            log::warn!("Error ensuring public agent expression: {}", e);
+        // Publish agent expression to the agent language
+        if let Err(e) = AgentService::publish_agent_to_language(&AgentContext::main_agent()).await {
+            log::warn!("Error publishing agent expression: {}", e);
         }
 
         if !init_errors.is_empty() {
@@ -392,9 +392,11 @@ impl Mutation {
 
             log::info!("AD4M init complete");
 
-            // Ensure agent expression exists in the agent language
-            if let Err(e) = AgentService::ensure_agent_expression().await {
-                log::warn!("Error ensuring public agent expression: {}", e);
+            // Publish agent expression to the agent language
+            if let Err(e) =
+                AgentService::publish_agent_to_language(&AgentContext::main_agent()).await
+            {
+                log::warn!("Error publishing agent expression: {}", e);
             }
         }
 
@@ -448,7 +450,7 @@ impl Mutation {
         })?;
 
         // Publish updated agent to agent language
-        if let Err(e) = AgentService::ensure_agent_expression().await {
+        if let Err(e) = AgentService::publish_agent_to_language(&AgentContext::main_agent()).await {
             log::warn!(
                 "Failed to publish agent expression after DM language update: {}",
                 e
@@ -509,7 +511,10 @@ impl Mutation {
             })?;
 
             // Publish the updated agent to the agent language
-            if let Err(e) = AgentService::publish_user_agent_to_language(&user_email, &agent).await
+            if let Err(e) = AgentService::publish_agent_to_language(&AgentContext::for_user_email(
+                user_email.clone(),
+            ))
+            .await
             {
                 log::warn!(
                     "Failed to publish updated user {} profile to agent language: {}",
@@ -544,16 +549,18 @@ impl Mutation {
             })?;
 
             // Publish updated agent to agent language
-            AgentService::ensure_agent_expression().await.map_err(|e| {
-                log::warn!(
-                    "Failed to publish agent expression after profile update: {}",
-                    e
-                );
-                FieldError::new(
-                    format!("Profile updated but failed to publish: {}", e),
-                    Value::null(),
-                )
-            })?;
+            AgentService::publish_agent_to_language(&AgentContext::main_agent())
+                .await
+                .map_err(|e| {
+                    log::warn!(
+                        "Failed to publish agent expression after profile update: {}",
+                        e
+                    );
+                    FieldError::new(
+                        format!("Profile updated but failed to publish: {}", e),
+                        Value::null(),
+                    )
+                })?;
 
             // Notify subscribers
             get_global_pubsub()
@@ -686,7 +693,10 @@ impl Mutation {
         })?;
 
         // Publish the agent to the agent language
-        if let Err(e) = AgentService::publish_user_agent_to_language(&email, &initial_agent).await {
+        if let Err(e) =
+            AgentService::publish_agent_to_language(&AgentContext::for_user_email(email.clone()))
+                .await
+        {
             log::warn!("Failed to publish user {} to agent language: {}", did, e);
             // Don't fail the user creation, just log the warning
         }

--- a/rust-executor/src/js_core/agent_extension.rs
+++ b/rust-executor/src/js_core/agent_extension.rs
@@ -1,13 +1,13 @@
 use super::utils::sort_json_value;
 use crate::js_core::error::AnyhowWrapperError;
+use crate::languages::language_runtime::get_runtime_agent_context;
 use crate::{
     agent::{
         create_signed_expression, did, did_document, did_for_context, sign_for_context,
-        sign_string_hex, signing_key_id, AgentContext, AgentService,
+        sign_string_hex, signing_key_id_for_context, AgentContext, AgentService,
     },
     graphql::graphql_types::{Agent, AgentStatus},
 };
-// use coasys_juniper::{FieldError, Value};
 use deno_core::anyhow;
 use deno_core::op2;
 
@@ -20,13 +20,13 @@ fn agent_did_document() -> Result<did_key::Document, AnyhowWrapperError> {
 #[op2]
 #[string]
 fn agent_signing_key_id() -> Result<String, AnyhowWrapperError> {
-    Ok(signing_key_id())
+    signing_key_id_for_context(&get_runtime_agent_context()).map_err(AnyhowWrapperError::from)
 }
 
 #[op2]
 #[string]
 fn agent_did() -> Result<String, AnyhowWrapperError> {
-    did_for_context(&AgentContext::main_agent()).map_err(AnyhowWrapperError::from)
+    did_for_context(&get_runtime_agent_context()).map_err(AnyhowWrapperError::from)
 }
 
 #[op2]
@@ -34,9 +34,10 @@ fn agent_did() -> Result<String, AnyhowWrapperError> {
 fn agent_create_signed_expression(
     #[serde] data: serde_json::Value,
 ) -> Result<serde_json::Value, AnyhowWrapperError> {
+    let ctx = get_runtime_agent_context();
     let sorted_json = sort_json_value(&data);
-    let signed_expression = create_signed_expression(sorted_json, &AgentContext::main_agent())
-        .map_err(AnyhowWrapperError::from)?;
+    let signed_expression =
+        create_signed_expression(sorted_json, &ctx).map_err(AnyhowWrapperError::from)?;
     serde_json::to_value(signed_expression).map_err(AnyhowWrapperError::from)
 }
 
@@ -45,9 +46,10 @@ fn agent_create_signed_expression(
 fn agent_create_signed_expression_stringified(
     #[string] data: String,
 ) -> Result<String, AnyhowWrapperError> {
+    let ctx = get_runtime_agent_context();
     let data: serde_json::Value = serde_json::from_str(&data)?;
     let sorted_json = sort_json_value(&data);
-    let signed_expression = create_signed_expression(sorted_json, &AgentContext::main_agent())?;
+    let signed_expression = create_signed_expression(sorted_json, &ctx)?;
     let stringified =
         serde_json::to_string(&signed_expression).map_err(AnyhowWrapperError::from)?;
     Ok(stringified)
@@ -120,7 +122,7 @@ fn agent_agent_for_user(
 #[op2]
 #[serde]
 fn agent_sign(#[buffer] payload: &[u8]) -> Result<Vec<u8>, AnyhowWrapperError> {
-    sign_for_context(payload, &AgentContext::main_agent()).map_err(AnyhowWrapperError::from)
+    sign_for_context(payload, &get_runtime_agent_context()).map_err(AnyhowWrapperError::from)
 }
 
 #[op2]

--- a/rust-executor/src/js_core/agent_extension.rs
+++ b/rust-executor/src/js_core/agent_extension.rs
@@ -4,7 +4,7 @@ use crate::languages::language_runtime::get_runtime_agent_context;
 use crate::{
     agent::{
         create_signed_expression, did, did_document, did_for_context, sign_for_context,
-        sign_string_hex, signing_key_id_for_context, AgentContext, AgentService,
+        sign_string_hex_for_context, signing_key_id_for_context, AgentContext, AgentService,
     },
     graphql::graphql_types::{Agent, AgentStatus},
 };
@@ -128,7 +128,8 @@ fn agent_sign(#[buffer] payload: &[u8]) -> Result<Vec<u8>, AnyhowWrapperError> {
 #[op2]
 #[string]
 fn agent_sign_string_hex(#[string] payload: String) -> Result<String, AnyhowWrapperError> {
-    sign_string_hex(payload).map_err(AnyhowWrapperError::from)
+    sign_string_hex_for_context(payload, &get_runtime_agent_context())
+        .map_err(AnyhowWrapperError::from)
 }
 
 #[op2(fast)]

--- a/rust-executor/src/js_core/language_bootstrap.js
+++ b/rust-executor/src/js_core/language_bootstrap.js
@@ -259,11 +259,13 @@ async function initLanguage(contextJson) {
     const holochainDelegate = createHolochainDelegate(languageAddress);
     const ad4mSignal = createAd4mSignal(languageAddress);
 
-    // Build an agent proxy that exposes static properties (did, signingKeyId)
-    // and delegates method calls to the global AGENT ops provided by agent_extension.
+    // Build an agent proxy that delegates to the global AGENT ops.
+    // `did` and `signingKeyId` are getters so they reflect the current
+    // thread-local AgentContext (which may be a managed user's context
+    // when expression_create runs with a user agent context).
     const agentProxy = {
-        did: context.agent.did,
-        signingKeyId: context.agent.signingKeyId,
+        get did() { return AGENT.did(); },
+        get signingKeyId() { return AGENT.signingKeyId(); },
         createSignedExpression: (data) => AGENT.createSignedExpression(data),
         sign: (payload) => AGENT.sign(payload),
         signStringHex: (payload) => AGENT.signStringHex(payload),

--- a/rust-executor/src/languages/language_runtime.rs
+++ b/rust-executor/src/languages/language_runtime.rs
@@ -1,8 +1,61 @@
+use crate::agent::AgentContext;
 use crate::js_core::JsCore;
 use log::{debug, error, info, warn};
 use serde_json::Value as JsonValue;
+use std::cell::RefCell;
 use std::path::PathBuf;
 use tokio::sync::{mpsc::UnboundedReceiver, oneshot};
+
+// ---------------------------------------------------------------------------
+// Per-thread agent context for language runtimes
+// ---------------------------------------------------------------------------
+//
+// CURRENT DESIGN (one language runtime per language, shared across users):
+//
+// Each language runtime runs in its own dedicated thread and processes
+// requests sequentially. When an operation needs to run as a specific user
+// (e.g. publishing a managed user's agent profile), the caller passes an
+// AgentContext through the channel. Before executing the script, the runtime
+// sets this thread-local to the caller's context. The Deno ops (agent_did,
+// agent_sign, agent_create_signed_expression, agent_signing_key_id) read
+// from this thread-local, so the JS code sees the correct DID and signs
+// with the correct key. After execution, the context resets to main_agent().
+//
+// The JS-side `agentProxy` in language_bootstrap.js uses getters for `did`
+// and `signingKeyId` that call back into these ops, so they dynamically
+// reflect the current thread-local context rather than caching the init-time
+// values.
+//
+// FUTURE REFACTOR (one language runtime per user per language):
+//
+// When languages are spawned per user, each runtime would have a fixed
+// AgentContext set once at construction time (no need for thread-local
+// switching). The changes needed:
+//   1. Remove the thread-local and set/get helpers below
+//   2. Store AgentContext as a field on LanguageRuntime
+//   3. Pass it to JsCore or set it once in process_requests() init
+//   4. The agentProxy getters in language_bootstrap.js would still work
+//      (they call ops which would read from the runtime's fixed context)
+//   5. LanguageController would manage runtimes keyed by (address, user)
+//      instead of just address
+//   6. execute_on_language_with_context() could route to the correct
+//      per-user runtime instead of overriding the thread-local
+// ---------------------------------------------------------------------------
+thread_local! {
+    static CURRENT_AGENT_CONTEXT: RefCell<AgentContext> = RefCell::new(AgentContext::main_agent());
+}
+
+/// Set the agent context for the current language runtime thread.
+pub fn set_runtime_agent_context(ctx: &AgentContext) {
+    CURRENT_AGENT_CONTEXT.with(|c| {
+        *c.borrow_mut() = ctx.clone();
+    });
+}
+
+/// Get the agent context for the current language runtime thread.
+pub fn get_runtime_agent_context() -> AgentContext {
+    CURRENT_AGENT_CONTEXT.with(|c| c.borrow().clone())
+}
 
 /// Request sent to a LanguageRuntime via its channel
 #[derive(Debug)]
@@ -14,7 +67,7 @@ pub(crate) struct LanguageRuntimeRequest {
 /// Operations that can be sent to a LanguageRuntime
 #[derive(Debug)]
 pub(crate) enum LanguageOperation {
-    Execute(String),
+    Execute(String, AgentContext),
     LoadModule(String),
     LoadLanguage(JsonValue),
     RegisterCallbacks,
@@ -224,7 +277,12 @@ impl LanguageRuntime {
                                 debug!("[lang:{}] Processing operation: {:?}", addr, request.operation);
 
                                 let result = match request.operation {
-                                    LanguageOperation::Execute(script) => self.execute(&script).await,
+                                    LanguageOperation::Execute(script, ref agent_ctx) => {
+                                        set_runtime_agent_context(agent_ctx);
+                                        let r = self.execute(&script).await;
+                                        set_runtime_agent_context(&AgentContext::main_agent());
+                                        r
+                                    }
                                     LanguageOperation::LoadModule(path) => {
                                         self.load_module(&path).await.map(|_| String::new())
                                     }

--- a/rust-executor/src/languages/language_runtime_handle.rs
+++ b/rust-executor/src/languages/language_runtime_handle.rs
@@ -7,6 +7,8 @@ use tokio::sync::{
     oneshot,
 };
 
+use crate::agent::AgentContext;
+
 use super::language_runtime::{LanguageOperation, LanguageRuntime, LanguageRuntimeRequest};
 
 /// Handle to a per-language runtime running in its own thread.
@@ -99,7 +101,20 @@ impl LanguageRuntimeHandle {
     }
 
     pub async fn execute(&self, script: String) -> Result<String, String> {
-        self.send(LanguageOperation::Execute(script)).await
+        self.send(LanguageOperation::Execute(
+            script,
+            AgentContext::main_agent(),
+        ))
+        .await
+    }
+
+    pub async fn execute_with_context(
+        &self,
+        script: String,
+        agent_context: AgentContext,
+    ) -> Result<String, String> {
+        self.send(LanguageOperation::Execute(script, agent_context))
+            .await
     }
 
     pub async fn load_module(&self, path: String) -> Result<(), String> {

--- a/rust-executor/src/languages/mod.rs
+++ b/rust-executor/src/languages/mod.rs
@@ -322,6 +322,35 @@ impl LanguageController {
         })
     }
 
+    /// Execute a script in a language runtime with a specific agent context.
+    /// The agent context is passed through the channel so the runtime thread
+    /// sets it as the thread-local before executing the script.
+    pub async fn execute_on_language_with_context(
+        &self,
+        language_address: &str,
+        script: &str,
+        agent_context: &AgentContext,
+    ) -> Result<String, LanguageError> {
+        let handle = {
+            let runtimes = self.runtimes.lock().await;
+            runtimes.get(language_address).cloned()
+        };
+
+        if let Some(handle) = handle {
+            return handle
+                .execute_with_context(script.to_string(), agent_context.clone())
+                .await
+                .map_err(|e| LanguageError::RuntimeError {
+                    address: language_address.to_string(),
+                    message: e,
+                });
+        }
+
+        Err(LanguageError::NotFound {
+            address: language_address.to_string(),
+        })
+    }
+
     /// Calculate IPFS hash for a language bundle using the same algorithm as utils_extension::hash()
     fn calculate_language_hash(&self, bundle_content: &str) -> String {
         use cid::Cid;
@@ -2208,7 +2237,9 @@ impl LanguageController {
             content_json, content_json
         );
 
-        let result = self.execute_on_language(&resolved_address, &script).await?;
+        let result = self
+            .execute_on_language_with_context(&resolved_address, &script, agent_context)
+            .await?;
 
         // Strip surrounding quotes from the result (it's a JSON-encoded string)
         let expression_address = result.trim().trim_matches('"').to_string();

--- a/tests/js/email-verification-test-with-setup.sh
+++ b/tests/js/email-verification-test-with-setup.sh
@@ -74,6 +74,13 @@ sleep 3
 # Step 4: Run the email-verification test
 echo "🧪 Running Email-Verification test..."
 pnpm run test-email-verification
+TEST_EXIT_CODE=$?
 
-echo "✅ Email-verification test with setup complete!"
+if [ $TEST_EXIT_CODE -ne 0 ]; then
+    echo "❌ Email-verification test failed with exit code $TEST_EXIT_CODE"
+else
+    echo "✅ Email-verification test with setup complete!"
+fi
+
+exit $TEST_EXIT_CODE
 

--- a/tests/js/test-multi-user-with-setup.sh
+++ b/tests/js/test-multi-user-with-setup.sh
@@ -74,6 +74,13 @@ sleep 3
 # Step 4: Run the multi-user test
 echo "🧪 Running multi-user test..."
 pnpm run test-multi-user-simple
+TEST_EXIT_CODE=$?
 
-echo "✅ Multi-user test with setup complete!"
+if [ $TEST_EXIT_CODE -ne 0 ]; then
+    echo "❌ Multi-user test failed with exit code $TEST_EXIT_CODE"
+else
+    echo "✅ Multi-user test with setup complete!"
+fi
+
+exit $TEST_EXIT_CODE
 

--- a/tests/js/tests/multi-user-simple.test.ts
+++ b/tests/js/tests/multi-user-simple.test.ts
@@ -1068,7 +1068,7 @@ describe("Multi-User Simple integration tests", () => {
             console.log("User 1 created perspective:", perspective1.uuid);
 
             // Add some initial links to the perspective
-            const link1 = new Link({source: "user1", target: "data1", predicate: "test://created"});
+            const link1 = new Link({source: "test://user1", target: "test://data1", predicate: "test://created"});
             await client1.perspective.addLink(perspective1.uuid, link1);
 
             console.log("Cloning link language...");
@@ -1111,7 +1111,7 @@ describe("Multi-User Simple integration tests", () => {
             console.log("✅ Both users can access the shared neighbourhood");
 
             // User 2 adds a link to the shared perspective
-            const link2 = new Link({source: "user2", target: "data2", predicate: "test://added"});
+            const link2 = new Link({source: "test://user2", target: "test://data2", predicate: "test://added"});
             await client2.perspective.addLink(user2SharedPerspective!.uuid, link2);
 
             // Wait for sync
@@ -1129,11 +1129,11 @@ describe("Multi-User Simple integration tests", () => {
             expect(user2Links.length).to.be.greaterThan(1);
 
             // Verify specific links exist
-            const user1SeesUser2Link = user1Links.some(l => 
-                l.data.source === "user2" && l.data.target === "data2"
+            const user1SeesUser2Link = user1Links.some(l =>
+                l.data.source === "test://user2" && l.data.target === "test://data2"
             );
-            const user2SeesUser1Link = user2Links.some(l => 
-                l.data.source === "user1" && l.data.target === "data1"
+            const user2SeesUser1Link = user2Links.some(l =>
+                l.data.source === "test://user1" && l.data.target === "test://data1"
             );
 
             expect(user1SeesUser2Link).to.be.true;

--- a/tests/js/tests/multi-user-simple.test.ts
+++ b/tests/js/tests/multi-user-simple.test.ts
@@ -2131,35 +2131,43 @@ describe("Multi-User Simple integration tests", () => {
             });
             console.log("Node 2 User 2 added link");
 
-            // Wait for synchronization
-            console.log("\nWaiting for sync...");
-            await sleep(10000);
+            // Wait for cross-node Holochain gossip synchronization with retry
+            console.log("\nWaiting for cross-node sync (polling until all users see >= 5 links)...");
+            const syncTimeout = 120000; // 2 minutes max
+            const syncStart = Date.now();
+            let synced = false;
 
-            // Query links from each user's perspective
-            console.log("\nQuerying links from each user's perspective...");
+            let node1User1Links: any[] = [];
+            let node1User2Links: any[] = [];
+            let node2User1Links: any[] = [];
+            let node2User2Links: any[] = [];
 
-            const node1User1Links = await node1User1Client!.perspective.queryLinks(
-                node1User1Neighbourhood!.uuid,
-                new LinkQuery({})
-            );
+            while (!synced && Date.now() - syncStart < syncTimeout) {
+                await sleep(5000);
+
+                node1User1Links = await node1User1Client!.perspective.queryLinks(
+                    node1User1Neighbourhood!.uuid, new LinkQuery({})
+                );
+                node1User2Links = await node1User2Client!.perspective.queryLinks(
+                    node1User2Neighbourhood!.uuid, new LinkQuery({})
+                );
+                node2User1Links = await node2User1Client!.perspective.queryLinks(
+                    node2User1Neighbourhood!.uuid, new LinkQuery({})
+                );
+                node2User2Links = await node2User2Client!.perspective.queryLinks(
+                    node2User2Neighbourhood!.uuid, new LinkQuery({})
+                );
+
+                const counts = [node1User1Links.length, node1User2Links.length, node2User1Links.length, node2User2Links.length];
+                console.log(`  Sync check: link counts = [${counts.join(', ')}] (need >= 5 each)`);
+
+                synced = counts.every(c => c >= 5);
+            }
+
+            console.log(`\nQuerying links from each user's perspective...`);
             console.log(`Node 1 User 1 sees ${node1User1Links.length} links`);
-
-            const node1User2Links = await node1User2Client!.perspective.queryLinks(
-                node1User2Neighbourhood!.uuid,
-                new LinkQuery({})
-            );
             console.log(`Node 1 User 2 sees ${node1User2Links.length} links`);
-
-            const node2User1Links = await node2User1Client!.perspective.queryLinks(
-                node2User1Neighbourhood!.uuid,
-                new LinkQuery({})
-            );
             console.log(`Node 2 User 1 sees ${node2User1Links.length} links`);
-
-            const node2User2Links = await node2User2Client!.perspective.queryLinks(
-                node2User2Neighbourhood!.uuid,
-                new LinkQuery({})
-            );
             console.log(`Node 2 User 2 sees ${node2User2Links.length} links`);
 
             // All users should see at least 5 links (1 from setup + 4 from each user)

--- a/tests/js/tests/multi-user-simple.test.ts
+++ b/tests/js/tests/multi-user-simple.test.ts
@@ -1238,13 +1238,15 @@ describe("Multi-User Simple integration tests", () => {
             
             let classesSeenByUser1 = await perspective1.subjectClasses()
             console.log("User 1 sees classes:", classesSeenByUser1);
-            expect(classesSeenByUser1.length).to.equal(1);
+            // In a shared neighbourhood, SDNA links propagate, so both users
+            // eventually see both classes once sync completes.
+            expect(classesSeenByUser1.length).to.equal(2);
 
             let classesSeenByUser2 = await user2SharedPerspective!.subjectClasses()
             console.log("User 2 sees classes:", classesSeenByUser2);
             expect(classesSeenByUser2.length).to.equal(2);
 
-            console.log("✅ Prolog pool isolation working correctly - users have separate SDNA contexts");
+            console.log("✅ Prolog pool working correctly - both users see shared SDNA classes");
         });
 
         it("should route neighbourhood signals locally between users on the same node", async () => {


### PR DESCRIPTION
## Nico's tl;dr:
multi-user and email tests did not propagate the exit code to the CI so they were green dispite failures.

Because of that, the [LanguageController refactoring](https://github.com/coasys/ad4m/pull/693) introduced failures: agent profiles were not written to the agent language for managed users. The language was not run with the right user context and the agent language refused to store a profile for someone else (the main agent).

This PR:
 - (re)-introduces a per-runtime thread-local `AgentContext` that gets set before each script execution so that language JS code dynamically resolves to the correct user's DID and signing keys. (we had that in the old JS LanguageController)
 - fixes multi-user and email test CI integration to actually report failures
 - adjust tests in multi-user to current situation in dev (got missed in other PRs for the same reason)
    - invalid link URLs now get rejected
    - all users see all subject classes since SHACL (Prolog was checking the author before loading code)
    - polling for HC sync (upgrade to 0.7.0 with occasional blocked messages in the beginning)  




## Claude's verbose description:

  ### Core fix — per-runtime agent context

  - **`language_runtime.rs`**: Added `thread_local! CURRENT_AGENT_CONTEXT` with `set_runtime_agent_context()` / `get_runtime_agent_context()` helpers. In `process_requests()`, the context is set from the channel message before script execution and reset to `main_agent()` afterward. Extended `LanguageOperation::Execute` to carry an `AgentContext`.

  - **`language_runtime_handle.rs`**: Added `execute_with_context(script, agent_context)` method that passes the context through the channel alongside the script.

  - **`agent_extension.rs`**: Changed `agent_did()`, `agent_sign()`, `agent_signing_key_id()`, and `agent_create_signed_expression()` Deno ops to read from `get_runtime_agent_context()` instead of hardcoded `AgentContext::main_agent()`.

  - **`language_bootstrap.js`**: Changed `agentProxy.did` and `agentProxy.signingKeyId` from static values (cached at init time) to **getters** that call `AGENT.did()` / `AGENT.signingKeyId()` on every access, so they dynamically reflect the current thread-local context.

  - **`mod.rs` (languages)**: Added `execute_on_language_with_context()`. Updated `expression_create()` to route through this method, passing the `agent_context` parameter that was previously ignored for non-literal languages.

  ### Agent service consolidation

  - **`agent/mod.rs`**: Unified `ensure_agent_expression()`, `publish_main_agent_to_language()`, and `publish_user_agent_to_language()` into a single `publish_agent_to_language(context: &AgentContext)`. Added `agent_to_publish_json()` which strips link decoration fields (`proof.valid`/`proof.invalid`/`status`) in Rust before publishing, rather than relying on the JS side.

  - **`mutation_resolvers.rs`**: All 6 publish call sites now use the unified `publish_agent_to_language()` with the appropriate `AgentContext`.

  ### Test script fix

  - **`test-multi-user-with-setup.sh`** and **`email-verification-test-with-setup.sh`**: Propagate the test process exit code instead of always exiting 0 (previously CI would report success even when tests failed).

  ### Test fixes

  - Fixed invalid link URIs (`"user1"` → `"test://user1"`) to satisfy link source validation.
  - Fixed prolog pool test: in shared neighbourhoods, SDNA classes propagate to all users (expect 2 classes, not 1).
  - Fixed flaky cross-node sync test: replaced fixed 10s sleep with a polling retry loop (up to 2 minutes) for Holochain gossip.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core signing/publishing paths and introduces thread-local context switching in language runtimes, which could cause incorrect authorship/signatures if context reset or concurrency assumptions break.
> 
> **Overview**
> Fixes multi-user agent publishing after the language controller refactor by propagating `AgentContext` through language runtime execution and making JS agent identifiers/signing resolve dynamically per request.
> 
> Introduces a per-runtime thread-local agent context (`LanguageOperation::Execute(script, AgentContext)` plus `execute_on_language_with_context`) and updates Deno agent ops and `language_bootstrap.js` to use the runtime context so expressions are created/signed as the intended managed user.
> 
> Consolidates agent profile publishing into `AgentService::publish_agent_to_language(context)` with DID mismatch checks, strips decorated link fields before publishing, adds basic filesystem-path validation for user emails, and updates GraphQL mutation call sites accordingly. Test harness scripts now propagate exit codes, and multi-user tests are adjusted for stricter link URIs, shared SDNA propagation expectations, and more reliable cross-node sync via polling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 703dc7959f8c25deed7d2826af5ea20d314a6d8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context-aware agent publishing and signing for per-user and runtime flows.
  * Thread-local runtime agent context with runtime getter/setter and execute-with-context support.
  * Dynamic runtime accessors for current agent identifiers and expanded JS bridge helpers.

* **Bug Fixes**
  * Consolidated publish flow with clearer logging.
  * Email validation to prevent unsafe profile storage/loading paths.

* **Tests**
  * Standardized test URIs, replaced fixed delays with polling, and scripts now propagate real exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->