### PR TITLE
fix(mcp): improve auth error messages and add wallet-locked guards

### DIFF
--- a/rust-executor/src/agent/capabilities/token.rs
+++ b/rust-executor/src/agent/capabilities/token.rs
@@ -61,3 +61,144 @@ pub fn decode_jwt(token: String) -> Result<Claims, AnyError> {
 
     Ok(result.claims)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wallet::Wallet;
+
+    fn test_auth_info() -> AuthInfo {
+        AuthInfo {
+            app_name: "test-app".to_string(),
+            app_desc: "test".to_string(),
+            app_domain: None,
+            app_url: None,
+            app_icon_path: None,
+            capabilities: None,
+            user_email: None,
+        }
+    }
+
+    /// Reproduces the original bug: calling generate_jwt when the wallet is locked
+    /// used to return "main key not found. call createMainKey() first" which was
+    /// misleading. Now it should return a clear "Wallet is locked" error.
+    #[test]
+    fn generate_jwt_on_locked_wallet_gives_clear_error() {
+        let wallet_instance = Wallet::instance();
+        {
+            let mut wallet = wallet_instance.lock().unwrap();
+            let w = wallet.as_mut().unwrap();
+            // Generate a key, then lock — simulates post-restart state
+            w.generate_keypair("main".to_string());
+            w.lock("test-passphrase".to_string());
+            assert!(!w.is_unlocked());
+        }
+
+        let result = generate_jwt("test-audience".to_string(), 9999999999, test_auth_info());
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("Wallet is locked"),
+            "Expected 'Wallet is locked' error, got: {}",
+            err_msg
+        );
+        // Must NOT contain the old misleading message
+        assert!(
+            !err_msg.contains("main key not found"),
+            "Should not contain old misleading error message"
+        );
+
+        // Cleanup: unlock so other tests aren't affected
+        {
+            let mut wallet = wallet_instance.lock().unwrap();
+            let w = wallet.as_mut().unwrap();
+            w.unlock("test-passphrase".to_string()).unwrap();
+        }
+    }
+
+    /// Reproduces the original bug for decode_jwt on a locked wallet.
+    #[test]
+    fn decode_jwt_on_locked_wallet_gives_clear_error() {
+        let wallet_instance = Wallet::instance();
+        {
+            let mut wallet = wallet_instance.lock().unwrap();
+            let w = wallet.as_mut().unwrap();
+            w.generate_keypair("main".to_string());
+            w.lock("test-passphrase".to_string());
+            assert!(!w.is_unlocked());
+        }
+
+        let result = decode_jwt("some.fake.token".to_string());
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("Wallet is locked"),
+            "Expected 'Wallet is locked' error, got: {}",
+            err_msg
+        );
+        assert!(
+            !err_msg.contains("main key not found"),
+            "Should not contain old misleading error message"
+        );
+
+        // Cleanup
+        {
+            let mut wallet = wallet_instance.lock().unwrap();
+            let w = wallet.as_mut().unwrap();
+            w.unlock("test-passphrase".to_string()).unwrap();
+        }
+    }
+
+    /// Verifies generate_jwt succeeds when wallet is unlocked with a "main" key.
+    #[test]
+    fn generate_jwt_succeeds_when_unlocked() {
+        let wallet_instance = Wallet::instance();
+        {
+            let mut wallet = wallet_instance.lock().unwrap();
+            let w = wallet.as_mut().unwrap();
+            w.generate_keypair("main".to_string());
+            assert!(w.is_unlocked());
+        }
+
+        let result = generate_jwt("test-audience".to_string(), 9999999999, test_auth_info());
+        assert!(result.is_ok(), "generate_jwt should succeed when wallet is unlocked: {:?}", result.err());
+
+        let token = result.unwrap();
+        assert!(!token.is_empty());
+
+        // Verify round-trip: decode should also work
+        let decoded = decode_jwt(token);
+        assert!(decoded.is_ok(), "decode_jwt should succeed: {:?}", decoded.err());
+    }
+
+    /// Verifies the error message when wallet is unlocked but "main" key is missing
+    /// (agent never initialized). Should say "not found" not "locked".
+    #[test]
+    fn generate_jwt_without_main_key_gives_not_found_error() {
+        let wallet_instance = Wallet::instance();
+        {
+            let mut wallet = wallet_instance.lock().unwrap();
+            let w = wallet.as_mut().unwrap();
+            // Reset wallet to a fresh state with only a non-"main" key.
+            // Lock first to clear any existing keys from prior tests,
+            // then create a fresh wallet with only "other-key".
+            *w = Wallet::new();
+            w.generate_keypair("other-key".to_string());
+            assert!(w.is_unlocked());
+            assert!(w.get_secret_key(&"main".to_string()).is_none());
+        }
+
+        let result = generate_jwt("test-audience".to_string(), 9999999999, test_auth_info());
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("not found") && err_msg.contains("agentGenerate"),
+            "Expected 'not found' + 'agentGenerate' error, got: {}",
+            err_msg
+        );
+        assert!(
+            !err_msg.contains("Wallet is locked"),
+            "Should not say wallet is locked when it's unlocked"
+        );
+    }
+}

--- a/rust-executor/src/agent/capabilities/token.rs
+++ b/rust-executor/src/agent/capabilities/token.rs
@@ -12,15 +12,20 @@ pub fn generate_jwt(
     let wallet = Wallet::instance();
     let wallet_lock = wallet.lock().expect("wallet lock");
     let wallet_ref = wallet_lock.as_ref().expect("wallet instance");
+
+    if !wallet_ref.is_unlocked() {
+        return Err(anyhow!("Wallet is locked. The agent must be unlocked (agentUnlock) before generating JWTs."));
+    }
+
     let name = "main".to_string();
 
     let secret_key = wallet_ref
         .get_secret_key(&name)
-        .ok_or(anyhow!("main key not found. call createMainKey() first"))?;
+        .ok_or(anyhow!("main signing key not found. Agent may not have been initialized (agentGenerate)."))?;
 
     let did_document = wallet_ref
         .get_did_document(&name)
-        .ok_or(anyhow!("main did not found. call createMainKey() first"))?;
+        .ok_or(anyhow!("main DID document not found. Agent may not have been initialized (agentGenerate)."))?;
 
     let payload = Claims::new(did_document.id, audience, expiration_time, capabilities);
 
@@ -40,9 +45,13 @@ pub fn decode_jwt(token: String) -> Result<Claims, AnyError> {
     let wallet_ref = wallet_lock.as_ref().expect("wallet instance");
     let name = "main".to_string();
 
+    if !wallet_ref.is_unlocked() {
+        return Err(anyhow!("Wallet is locked. The agent must be unlocked (agentUnlock) before decoding JWTs."));
+    }
+
     let secret_key = wallet_ref
         .get_secret_key(&name)
-        .ok_or(anyhow!("main key not found. call createMainKey() first"))?;
+        .ok_or(anyhow!("main signing key not found. Agent may not have been initialized (agentGenerate)."))?;
 
     let result = jsonwebtoken::decode::<Claims>(
         &token,

--- a/rust-executor/src/agent/capabilities/token.rs
+++ b/rust-executor/src/agent/capabilities/token.rs
@@ -3,20 +3,29 @@ use crate::wallet::Wallet;
 use deno_core::{anyhow::anyhow, error::AnyError};
 use jsonwebtoken::{encode, Algorithm, DecodingKey, EncodingKey, Header};
 
+/// Check that the wallet singleton is unlocked, returning a clear error if not.
+fn require_unlocked_wallet() -> Result<(), AnyError> {
+    let wallet = Wallet::instance();
+    let wallet_lock = wallet.lock().expect("wallet lock");
+    let wallet_ref = wallet_lock.as_ref().expect("wallet instance");
+    if !wallet_ref.is_unlocked() {
+        return Err(anyhow!(
+            "Wallet is locked. The agent must be unlocked (agentUnlock) before generating JWTs."
+        ));
+    }
+    Ok(())
+}
+
 pub fn generate_jwt(
     audience: String,
     expiration_time: u64,
     capabilities: AuthInfo,
 ) -> Result<String, AnyError> {
-    // Get the private key
+    require_unlocked_wallet()?;
+
     let wallet = Wallet::instance();
     let wallet_lock = wallet.lock().expect("wallet lock");
     let wallet_ref = wallet_lock.as_ref().expect("wallet instance");
-
-    if !wallet_ref.is_unlocked() {
-        return Err(anyhow!("Wallet is locked. The agent must be unlocked (agentUnlock) before generating JWTs."));
-    }
-
     let name = "main".to_string();
 
     let secret_key = wallet_ref
@@ -39,15 +48,12 @@ pub fn generate_jwt(
 }
 
 pub fn decode_jwt(token: String) -> Result<Claims, AnyError> {
-    //Get the private key
+    require_unlocked_wallet()?;
+
     let wallet = Wallet::instance();
     let wallet_lock = wallet.lock().expect("wallet lock");
     let wallet_ref = wallet_lock.as_ref().expect("wallet instance");
     let name = "main".to_string();
-
-    if !wallet_ref.is_unlocked() {
-        return Err(anyhow!("Wallet is locked. The agent must be unlocked (agentUnlock) before decoding JWTs."));
-    }
 
     let secret_key = wallet_ref
         .get_secret_key(&name)
@@ -66,6 +72,11 @@ pub fn decode_jwt(token: String) -> Result<Claims, AnyError> {
 mod tests {
     use super::*;
     use crate::wallet::Wallet;
+
+    // NOTE: These tests mutate the global Wallet singleton. They MUST run
+    // with --test-threads=1 (which the executor test suite already enforces)
+    // to avoid data races. If this ever changes, add #[serial] from
+    // the serial_test crate.
 
     fn test_auth_info() -> AuthInfo {
         AuthInfo {
@@ -200,5 +211,12 @@ mod tests {
             !err_msg.contains("Wallet is locked"),
             "Should not say wallet is locked when it's unlocked"
         );
+
+        // Cleanup: restore a "main" key so other tests aren't affected
+        {
+            let mut wallet = wallet_instance.lock().unwrap();
+            let w = wallet.as_mut().unwrap();
+            w.generate_keypair("main".to_string());
+        }
     }
 }

--- a/rust-executor/src/mcp/tools/auth.rs
+++ b/rust-executor/src/mcp/tools/auth.rs
@@ -85,6 +85,20 @@ pub struct AuthStatusParams {}
 // ============================================================================
 
 impl Ad4mMcpHandler {
+    /// Check that the agent wallet is unlocked; return Err(json) if locked.
+    fn check_wallet_unlocked() -> Result<(), String> {
+        let wallet = crate::wallet::Wallet::instance();
+        let wallet_lock = wallet.lock().expect("wallet lock");
+        let wallet_ref = wallet_lock.as_ref().expect("wallet instance");
+        if !wallet_ref.is_unlocked() {
+            return Err(serde_json::json!({
+                "success": false,
+                "error": "Agent wallet is locked. Call agentUnlock first (or use login_email for multi-user mode)."
+            }).to_string());
+        }
+        Ok(())
+    }
+
     /// Login with email and password (multi-user mode)
     #[tool(
         description = "Login to a multi-user AD4M executor using email and password. Returns a JWT token on success that will be used for subsequent operations."
@@ -107,17 +121,8 @@ impl Ad4mMcpHandler {
         description = "Request a capability token (step 1/2 of local auth flow). This is the primary way to authenticate with a local/single-user AD4M executor. Returns request_id and code — pass both to generate_jwt to get a JWT token. For multi-user executors, use login_email or signup instead. Note: when using the ad4m-executor CLI, the verification code is logged to stdout."
     )]
     pub async fn request_capability(&self, params: Parameters<RequestCapabilityParams>) -> String {
-        // Check wallet is unlocked before attempting capability flow
-        {
-            let wallet = crate::wallet::Wallet::instance();
-            let wallet_lock = wallet.lock().expect("wallet lock");
-            let wallet_ref = wallet_lock.as_ref().expect("wallet instance");
-            if !wallet_ref.is_unlocked() {
-                return serde_json::json!({
-                    "success": false,
-                    "error": "Agent wallet is locked. Call agentUnlock first (or use login_email for multi-user mode)."
-                }).to_string();
-            }
+        if let Err(msg) = Self::check_wallet_unlocked() {
+            return msg;
         }
 
         let p = &params.0;
@@ -160,17 +165,8 @@ impl Ad4mMcpHandler {
         description = "Generate a JWT token (step 2/2 of local auth flow). Pass the request_id and code from request_capability. The JWT is stored in the session and used for all subsequent operations automatically."
     )]
     pub async fn generate_jwt(&self, params: Parameters<GenerateJwtParams>) -> String {
-        // Check wallet is unlocked before attempting JWT generation
-        {
-            let wallet = crate::wallet::Wallet::instance();
-            let wallet_lock = wallet.lock().expect("wallet lock");
-            let wallet_ref = wallet_lock.as_ref().expect("wallet instance");
-            if !wallet_ref.is_unlocked() {
-                return serde_json::json!({
-                    "success": false,
-                    "error": "Agent wallet is locked. Call agentUnlock first (or use login_email for multi-user mode)."
-                }).to_string();
-            }
+        if let Err(msg) = Self::check_wallet_unlocked() {
+            return msg;
         }
 
         let p = &params.0;

--- a/rust-executor/src/mcp/tools/auth.rs
+++ b/rust-executor/src/mcp/tools/auth.rs
@@ -107,6 +107,19 @@ impl Ad4mMcpHandler {
         description = "Request a capability token (step 1/2 of local auth flow). This is the primary way to authenticate with a local/single-user AD4M executor. Returns request_id and code — pass both to generate_jwt to get a JWT token. For multi-user executors, use login_email or signup instead. Note: when using the ad4m-executor CLI, the verification code is logged to stdout."
     )]
     pub async fn request_capability(&self, params: Parameters<RequestCapabilityParams>) -> String {
+        // Check wallet is unlocked before attempting capability flow
+        {
+            let wallet = crate::wallet::Wallet::instance();
+            let wallet_lock = wallet.lock().expect("wallet lock");
+            let wallet_ref = wallet_lock.as_ref().expect("wallet instance");
+            if !wallet_ref.is_unlocked() {
+                return serde_json::json!({
+                    "success": false,
+                    "error": "Agent wallet is locked. Call agentUnlock first (or use login_email for multi-user mode)."
+                }).to_string();
+            }
+        }
+
         let p = &params.0;
 
         let auth_info = AuthInfo {
@@ -147,6 +160,19 @@ impl Ad4mMcpHandler {
         description = "Generate a JWT token (step 2/2 of local auth flow). Pass the request_id and code from request_capability. The JWT is stored in the session and used for all subsequent operations automatically."
     )]
     pub async fn generate_jwt(&self, params: Parameters<GenerateJwtParams>) -> String {
+        // Check wallet is unlocked before attempting JWT generation
+        {
+            let wallet = crate::wallet::Wallet::instance();
+            let wallet_lock = wallet.lock().expect("wallet lock");
+            let wallet_ref = wallet_lock.as_ref().expect("wallet instance");
+            if !wallet_ref.is_unlocked() {
+                return serde_json::json!({
+                    "success": false,
+                    "error": "Agent wallet is locked. Call agentUnlock first (or use login_email for multi-user mode)."
+                }).to_string();
+            }
+        }
+
         let p = &params.0;
 
         match generate_capability_token(p.request_id.clone(), p.code.clone()).await {

--- a/skills/ad4m/SKILL.md
+++ b/skills/ad4m/SKILL.md
@@ -195,10 +195,10 @@ Without this, `request_capability` and `generate_jwt` return `"Wallet is locked"
 ← { request_id: "...", code: "189217" }
 
 → generate_jwt(request_id: "...", code: "189217")
-← { success: true, token: "eyJ...", message: "JWT generated and stored." }
+← { token: "eyJ..." }
 ```
 
-The JWT is stored in the MCP session automatically — no need to pass it on subsequent calls.
+Include JWT as `Authorization: Bearer <token>` header on subsequent requests.
 
 For multi-user mode, use `signup` → `verify_email_code` → `login_email` instead.
 
@@ -328,4 +328,4 @@ mutation { perspectiveAddLink(
 ```
 
 **Auth header:** `Authorization: <admin-credential>` (single-user) or `Authorization: Bearer <jwt>` (multi-user)
-**Endpoint:** `http://localhost:12100/graphql` (configurable via `--gql-port`)
+**Endpoint:** `http://localhost:12000/graphql` (configurable via `--gql-port`)

--- a/skills/ad4m/SKILL.md
+++ b/skills/ad4m/SKILL.md
@@ -180,7 +180,7 @@ ad4m-executor run --app-data-path ~/.ad4m-server \
 **⚠️ The agent wallet must be unlocked before MCP auth works.** After starting or restarting the executor, unlock via GraphQL first:
 
 ```bash
-curl -s http://localhost:12100/graphql \
+curl -s http://localhost:12000/graphql \
   -H "Content-Type: application/json" \
   -H "Authorization: <admin-credential>" \
   -d '{"query":"mutation { agentUnlock(passphrase: \\"<passphrase>\\", holochain: true) { isUnlocked } }"}'

--- a/skills/ad4m/SKILL.md
+++ b/skills/ad4m/SKILL.md
@@ -25,9 +25,10 @@ AD4M's core bootstrap languages (agent identity, neighbourhood sync, file storag
 ## Quick Start: Join a Neighbourhood and Chat
 
 ```
-1. Connect to MCP      → http://localhost:3001/mcp
-2. Authenticate         → request_capability + generate_jwt (or login_email)
-3. Join neighbourhood   → neighbourhood_join_from_url(url: "neighbourhood://Qm...")
+1. Unlock agent         → agentUnlock via GraphQL (wallet is encrypted at rest)
+2. Connect to MCP       → POST http://localhost:3001/mcp (initialize + notifications/initialized)
+3. Authenticate         → request_capability + generate_jwt (or login_email)
+4. Join neighbourhood   → neighbourhood_join_from_url(url: "neighbourhood://Qm...")
 4. List perspectives    → list_perspectives() → find the joined perspective UUID
 5. Read messages        → message_query(perspective_id: "...", source: "channel-id")
 6. Post a message       → add_child(perspective_id: "...", parent: "channel-id", child: "msg-id")
@@ -148,6 +149,7 @@ ad4m-executor run --app-data-path ~/.ad4m-agent \
 - No multi-user setup — single agent DID
 - Admin credential auth — no email/password needed
 - Local HTTP only — `http://localhost:3001/mcp`
+- **After restart:** unlock the agent via `agentUnlock` mutation before MCP auth works
 
 ### Mode 2: Multi-User Executor
 
@@ -175,15 +177,28 @@ ad4m-executor run --app-data-path ~/.ad4m-server \
 
 ### Authentication
 
+**⚠️ The agent wallet must be unlocked before MCP auth works.** After starting or restarting the executor, unlock via GraphQL first:
+
+```bash
+curl -s http://localhost:12100/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: <admin-credential>" \
+  -d '{"query":"mutation { agentUnlock(passphrase: \\"<passphrase>\\", holochain: true) { isUnlocked } }"}'
 ```
-→ request_capability(app_name: "MyBot", app_desc: "AI agent", app_domain: "*", app_pointers: "*", app_can: "*")
+
+Without this, `request_capability` and `generate_jwt` return `"Wallet is locked"`.
+
+**⚠️ MCP sessions require a two-step handshake.** After the `initialize` request, you **must** send a `notifications/initialized` notification before any tool calls. Without it, the session terminates on the next request. See `skills/ad4m/references/mcp.md` for the full handshake sequence.
+
+```
+→ request_capability(app_name: "MyBot", app_desc: "AI agent", app_url: "http://localhost")
 ← { request_id: "...", code: "189217" }
 
 → generate_jwt(request_id: "...", code: "189217")
-← { token: "eyJ..." }
+← { success: true, token: "eyJ...", message: "JWT generated and stored." }
 ```
 
-Include JWT as `Authorization: Bearer <token>` header on subsequent requests.
+The JWT is stored in the MCP session automatically — no need to pass it on subsequent calls.
 
 For multi-user mode, use `signup` → `verify_email_code` → `login_email` instead.
 
@@ -313,4 +328,4 @@ mutation { perspectiveAddLink(
 ```
 
 **Auth header:** `Authorization: <admin-credential>` (single-user) or `Authorization: Bearer <jwt>` (multi-user)
-**Endpoint:** `http://localhost:12000/graphql` (configurable via `--gql-port`)
+**Endpoint:** `http://localhost:12100/graphql` (configurable via `--gql-port`)

--- a/skills/ad4m/references/mcp.md
+++ b/skills/ad4m/references/mcp.md
@@ -10,88 +10,265 @@ ad4m-executor run --enable-mcp true --mcp-port 3001 ...
 
 ## Transport
 
-HTTP with Server-Sent Events (SSE). Connect at `http://localhost:3001/`.
+**Streamable HTTP** at `POST http://localhost:3001/mcp`. Uses the `rmcp` crate.
 
-**Not stdio** — the MCP server runs alongside the GraphQL server in the same process.
+- **Not SSE-only, not stdio** — the MCP server runs alongside the GraphQL server in the same process.
+- All requests go to the same `/mcp` endpoint as HTTP POST.
+- Responses are delivered as SSE streams (`text/event-stream`) within the HTTP response body.
+- Clients **must** include `Accept: application/json, text/event-stream` on every request.
+
+## Session Lifecycle
+
+MCP uses stateful sessions. Each session is identified by a `Mcp-Session-Id` header returned from the initialize handshake.
+
+### ⚠️ Required handshake (initialize → notifications/initialized)
+
+Every MCP session **must** complete a two-step handshake before tool calls work:
+
+```bash
+# Step 1: Initialize — capture Mcp-Session-Id from response header
+curl -si -X POST http://localhost:3001/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"my-app","version":"1.0"}}}'
+# → Response headers include: Mcp-Session-Id: <uuid>
+
+# Step 2: Send initialized NOTIFICATION (no "id" field = notification, not request)
+curl -s -X POST http://localhost:3001/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: <session-id>" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+```
+
+**Without step 2**, the server expects the `notifications/initialized` message as the next thing after initialize. If it receives a tool call instead, it fails with `"expect initialized notification"` and **terminates the session**. This is the most common cause of "MCP sessions expire immediately."
+
+### Session persistence
+
+- Sessions are tied to the executor process — **restarting the executor invalidates all sessions**.
+- Sessions persist across multiple HTTP requests as long as the `Mcp-Session-Id` header is included.
+- There is no explicit session timeout when `keep_alive` is set to `None` (the default).
 
 ## Authentication
 
-Bearer token in the HTTP `Authorization` header:
+MCP auth is **session-scoped** — authenticate once per session, and the token is stored server-side for all subsequent calls in that session.
 
-```
-Authorization: Bearer <token>
+### ⚠️ Agent must be unlocked first
+
+The wallet is encrypted at rest. After starting or restarting the executor, the agent must be unlocked via GraphQL before MCP auth tools will work:
+
+```bash
+curl -s http://localhost:12100/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: <admin-credential>" \
+  -d '{"query":"mutation { agentUnlock(passphrase: \"<passphrase>\", holochain: true) { did isUnlocked } }"}'
 ```
 
-The token is the `--admin-credential` value passed to the executor. Without an admin credential, empty token has full access.
+Without this, `request_capability` and `generate_jwt` return `"Wallet is locked"`. The agent appears initialized but cannot sign tokens.
+
+### Single-user auth flow (request_capability + generate_jwt)
+
+```bash
+# Step 1: Request capability
+curl -s -X POST http://localhost:3001/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: <session-id>" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"request_capability","arguments":{"app_name":"my-bot","app_desc":"AI agent","app_url":"http://localhost"}}}'
+# → Returns: { request_id: "...", code: "189217", message: "Capability requested and auto-permitted..." }
+# The code is also printed to executor stdout.
+
+# Step 2: Generate JWT
+curl -s -X POST http://localhost:3001/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: <session-id>" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"generate_jwt","arguments":{"request_id":"<id>","code":"<code>"}}}'
+# → Returns: { success: true, token: "eyJ...", message: "JWT generated and stored. You are now authenticated." }
+# Token is stored in the session — no need to pass it on subsequent calls.
+```
+
+### Multi-user auth flow (login_email)
+
+For executors with multi-user mode enabled:
+
+```bash
+# Login with email/password (user must have been created via runtimeCreateUser)
+curl -s -X POST http://localhost:3001/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: <session-id>" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"login_email","arguments":{"email":"user@example.com","password":"pass123"}}}'
+```
+
+### Check auth status
+
+```bash
+curl -s -X POST http://localhost:3001/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: <session-id>" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"auth_status","arguments":{}}}'
+```
 
 ## Core Tools
 
 These are always available regardless of SDNA:
 
+### Auth Tools
 | Tool | Description |
 |------|-------------|
-| `agent_me` | Get current agent DID and status |
-| `agent_generate` | Generate new agent keys (first run only) |
-| `agent_unlock` | Unlock agent with passphrase |
-| `agent_lock` | Lock agent keys |
-| `perspective_create` | Create a new perspective |
-| `perspective_list` | List all perspectives |
-| `add_link` | Add a link to a perspective |
-| `get_links` | Query links in a perspective |
-| `remove_link` | Remove a link from a perspective |
-| `get_models` | List available subject classes (SHACL shapes) |
-| `add_model` | Add SHACL SDNA to a perspective |
+| `request_capability` | Request capability token (step 1/2 of local auth) |
+| `generate_jwt` | Generate JWT from capability request (step 2/2) |
+| `auth_status` | Check current authentication state |
+| `signup` | Create account (multi-user mode) |
+| `login_email` | Login with email/password (multi-user mode) |
+| `request_login_verification` | Request email verification |
+| `verify_email_code` | Verify email with code |
+
+### Perspective & Link Tools
+| Tool | Description |
+|------|-------------|
+| `add_perspective` | Create a new perspective |
+| `list_perspectives` | List all perspectives |
+| `add_link` | Add a raw link (source, predicate, target) |
+| `query_links` | Query links by source/predicate/target |
+| `query_subjects` | Find instances of a subject class |
+| `create_subject` | Create a new subject instance |
+| `get_subject_data` | Get full data for a subject |
+| `set_subject_property` | Set a property on a subject |
+| `delete_subject` | Delete a subject instance |
+
+### Children & Collections
+| Tool | Description |
+|------|-------------|
+| `get_subject_children` | Get children of a subject instance |
+| `get_subject_collection` | Get items in a collection property |
+| `add_to_collection` | Add item to a collection property |
+| `remove_from_collection` | Remove item from a collection |
+
+### Neighbourhood Tools
+| Tool | Description |
+|------|-------------|
+| `neighbourhood_join_from_url` | Join a shared neighbourhood |
+| `neighbourhood_publish_from_perspective` | Publish a perspective as a neighbourhood |
+
+### Agent Tools
+| Tool | Description |
+|------|-------------|
+| `get_agent_profile` | Get agent's DID and profile |
+| `set_agent_profile` | Update agent profile |
+| `set_agent_profile_picture` | Set agent profile picture |
+| `get_agent_public_perspective` | Get agent's public perspective |
+| `set_agent_public_perspective` | Set agent's public perspective |
+
+### AI/Flow Tools
+| Tool | Description |
+|------|-------------|
+| `get_models` | List available AI models |
+| `add_model` | Add an AI model |
+| `infer` | Run inference on a model |
+| `get_flows` | List AI flows |
+| `add_flow` | Add a new flow |
+| `flow_start` | Start a flow |
+| `flow_state` | Get flow state |
+| `flow_actions` | List flow actions |
+| `flow_run_action` | Run a flow action |
+
+### Utility
+| Tool | Description |
+|------|-------------|
+| `execute_commands` | Execute arbitrary commands |
+| `generate_waker_query` | Generate SurrealQL for waker subscription |
 
 ## Dynamic Tools (from SHACL)
 
-When a perspective has SHACL SDNA, tools are generated per class:
+When a perspective has SHACL SDNA (e.g., after joining a Flux neighbourhood), tools are dynamically generated per subject class:
 
 For a class `Channel` with scalar `name`, scalar `description`, and collection `messages`:
 
 | Tool | Description |
 |------|-------------|
-| `channel_create` | Create a Channel instance (required props as params) |
+| `channel_create` | Create a Channel instance |
+| `channel_query` | Find Channel instances |
 | `channel_get` | Get a Channel by URI |
+| `channel_delete` | Delete a Channel |
 | `channel_set_name` | Set the name property |
 | `channel_set_description` | Set the description property |
 | `channel_get_messages` | Get all messages in the collection |
 | `channel_add_messages` | Add a message to the collection |
 | `channel_remove_messages` | Remove a message from the collection |
 
+A Flux neighbourhood typically exposes ~248 tools total (core + dynamic).
+
 ### Naming Convention
 
 Class-first: `{class}_{action}` or `{class}_{action}_{property}`.
 
-Examples:
-- `task_create`, `task_set_title`, `task_get_assignees`
-- `post_create`, `post_set_content`, `post_add_comment`
-
-### Tool Parameters
-
-All dynamic tools include:
-- `perspective_uuid` — which perspective to operate on
-- Property-specific params (type-checked against SHACL datatype)
-
-## Workflow Example
-
-```
-1. agent_me                    → verify identity
-2. perspective_create          → create workspace
-3. add_model                   → add SHACL schema
-4. get_models                  → verify schema loaded
-5. channel_create              → create a Channel
-6. channel_set_name            → set its name
-7. message_create              → create a Message
-8. channel_add_messages        → add message to channel
-```
-
 ## Error Handling
 
-MCP tool calls return JSON-RPC responses:
-- Success: `{ "result": { "content": [{ "type": "text", "text": "..." }] } }`
-- Error: `{ "error": { "code": -32000, "message": "..." } }`
+MCP tool calls return JSON-RPC responses via SSE:
 
-Common errors:
-- `Perspective not found` — invalid UUID
-- `Subject class not found` — SDNA not added to perspective
-- `Unauthorized` — missing or invalid auth token
+```
+data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{...}"}],"isError":false}}
+```
+
+The `text` field contains JSON with the actual result or error. Common errors:
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Wallet is locked` | Agent not unlocked after restart | `agentUnlock` via GraphQL |
+| `main signing key not found` | `agentGenerate` never called | Run `agentGenerate` once |
+| `expect initialized notification` | Missing `notifications/initialized` | Send it after `initialize` |
+| `Session not found` | Executor restarted or session expired | Re-initialize a new session |
+| `Can't find permitted request` | Wrong request_id or code | Re-run `request_capability` |
+| `Perspective not found` | Invalid UUID | Check `list_perspectives` |
+| `Subject class not found` | SDNA not loaded in perspective | Join a neighbourhood with SDNA, or `add_model` |
+| `Not Acceptable` | Missing `Accept` header | Include `Accept: application/json, text/event-stream` |
+
+## Complete Session Example
+
+```bash
+# 1. Ensure agent is unlocked (via GraphQL, not MCP)
+curl -s http://localhost:12100/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: admin-secret" \
+  -d '{"query":"mutation { agentUnlock(passphrase: \"my-passphrase\", holochain: true) { isUnlocked } }"}'
+
+# 2. Initialize MCP session
+curl -si -X POST http://localhost:3001/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -D /tmp/mcp-headers.txt \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"my-bot","version":"1.0"}}}' > /dev/null
+
+MCP_SESSION=$(grep -i 'mcp-session-id' /tmp/mcp-headers.txt | awk '{print $2}' | tr -d '\r')
+
+# 3. Send initialized notification
+curl -s -X POST http://localhost:3001/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: $MCP_SESSION" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+
+# 4. Authenticate
+curl -s -X POST http://localhost:3001/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: $MCP_SESSION" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"request_capability","arguments":{"app_name":"my-bot","app_desc":"AI agent","app_url":"http://localhost"}}}'
+# → Parse request_id and code from response
+
+curl -s -X POST http://localhost:3001/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: $MCP_SESSION" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"generate_jwt","arguments":{"request_id":"<id>","code":"<code>"}}}'
+
+# 5. Use tools (authenticated)
+curl -s -X POST http://localhost:3001/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Mcp-Session-Id: $MCP_SESSION" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_perspectives","arguments":{}}}'
+```

--- a/skills/ad4m/references/mcp.md
+++ b/skills/ad4m/references/mcp.md
@@ -10,265 +10,88 @@ ad4m-executor run --enable-mcp true --mcp-port 3001 ...
 
 ## Transport
 
-**Streamable HTTP** at `POST http://localhost:3001/mcp`. Uses the `rmcp` crate.
+HTTP with Server-Sent Events (SSE). Connect at `http://localhost:3001/`.
 
-- **Not SSE-only, not stdio** — the MCP server runs alongside the GraphQL server in the same process.
-- All requests go to the same `/mcp` endpoint as HTTP POST.
-- Responses are delivered as SSE streams (`text/event-stream`) within the HTTP response body.
-- Clients **must** include `Accept: application/json, text/event-stream` on every request.
-
-## Session Lifecycle
-
-MCP uses stateful sessions. Each session is identified by a `Mcp-Session-Id` header returned from the initialize handshake.
-
-### ⚠️ Required handshake (initialize → notifications/initialized)
-
-Every MCP session **must** complete a two-step handshake before tool calls work:
-
-```bash
-# Step 1: Initialize — capture Mcp-Session-Id from response header
-curl -si -X POST http://localhost:3001/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"my-app","version":"1.0"}}}'
-# → Response headers include: Mcp-Session-Id: <uuid>
-
-# Step 2: Send initialized NOTIFICATION (no "id" field = notification, not request)
-curl -s -X POST http://localhost:3001/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "Mcp-Session-Id: <session-id>" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
-```
-
-**Without step 2**, the server expects the `notifications/initialized` message as the next thing after initialize. If it receives a tool call instead, it fails with `"expect initialized notification"` and **terminates the session**. This is the most common cause of "MCP sessions expire immediately."
-
-### Session persistence
-
-- Sessions are tied to the executor process — **restarting the executor invalidates all sessions**.
-- Sessions persist across multiple HTTP requests as long as the `Mcp-Session-Id` header is included.
-- There is no explicit session timeout when `keep_alive` is set to `None` (the default).
+**Not stdio** — the MCP server runs alongside the GraphQL server in the same process.
 
 ## Authentication
 
-MCP auth is **session-scoped** — authenticate once per session, and the token is stored server-side for all subsequent calls in that session.
+Bearer token in the HTTP `Authorization` header:
 
-### ⚠️ Agent must be unlocked first
-
-The wallet is encrypted at rest. After starting or restarting the executor, the agent must be unlocked via GraphQL before MCP auth tools will work:
-
-```bash
-curl -s http://localhost:12100/graphql \
-  -H "Content-Type: application/json" \
-  -H "Authorization: <admin-credential>" \
-  -d '{"query":"mutation { agentUnlock(passphrase: \"<passphrase>\", holochain: true) { did isUnlocked } }"}'
+```
+Authorization: Bearer <token>
 ```
 
-Without this, `request_capability` and `generate_jwt` return `"Wallet is locked"`. The agent appears initialized but cannot sign tokens.
-
-### Single-user auth flow (request_capability + generate_jwt)
-
-```bash
-# Step 1: Request capability
-curl -s -X POST http://localhost:3001/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "Mcp-Session-Id: <session-id>" \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"request_capability","arguments":{"app_name":"my-bot","app_desc":"AI agent","app_url":"http://localhost"}}}'
-# → Returns: { request_id: "...", code: "189217", message: "Capability requested and auto-permitted..." }
-# The code is also printed to executor stdout.
-
-# Step 2: Generate JWT
-curl -s -X POST http://localhost:3001/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "Mcp-Session-Id: <session-id>" \
-  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"generate_jwt","arguments":{"request_id":"<id>","code":"<code>"}}}'
-# → Returns: { success: true, token: "eyJ...", message: "JWT generated and stored. You are now authenticated." }
-# Token is stored in the session — no need to pass it on subsequent calls.
-```
-
-### Multi-user auth flow (login_email)
-
-For executors with multi-user mode enabled:
-
-```bash
-# Login with email/password (user must have been created via runtimeCreateUser)
-curl -s -X POST http://localhost:3001/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "Mcp-Session-Id: <session-id>" \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"login_email","arguments":{"email":"user@example.com","password":"pass123"}}}'
-```
-
-### Check auth status
-
-```bash
-curl -s -X POST http://localhost:3001/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "Mcp-Session-Id: <session-id>" \
-  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"auth_status","arguments":{}}}'
-```
+The token is the `--admin-credential` value passed to the executor. Without an admin credential, empty token has full access.
 
 ## Core Tools
 
 These are always available regardless of SDNA:
 
-### Auth Tools
 | Tool | Description |
 |------|-------------|
-| `request_capability` | Request capability token (step 1/2 of local auth) |
-| `generate_jwt` | Generate JWT from capability request (step 2/2) |
-| `auth_status` | Check current authentication state |
-| `signup` | Create account (multi-user mode) |
-| `login_email` | Login with email/password (multi-user mode) |
-| `request_login_verification` | Request email verification |
-| `verify_email_code` | Verify email with code |
-
-### Perspective & Link Tools
-| Tool | Description |
-|------|-------------|
-| `add_perspective` | Create a new perspective |
-| `list_perspectives` | List all perspectives |
-| `add_link` | Add a raw link (source, predicate, target) |
-| `query_links` | Query links by source/predicate/target |
-| `query_subjects` | Find instances of a subject class |
-| `create_subject` | Create a new subject instance |
-| `get_subject_data` | Get full data for a subject |
-| `set_subject_property` | Set a property on a subject |
-| `delete_subject` | Delete a subject instance |
-
-### Children & Collections
-| Tool | Description |
-|------|-------------|
-| `get_subject_children` | Get children of a subject instance |
-| `get_subject_collection` | Get items in a collection property |
-| `add_to_collection` | Add item to a collection property |
-| `remove_from_collection` | Remove item from a collection |
-
-### Neighbourhood Tools
-| Tool | Description |
-|------|-------------|
-| `neighbourhood_join_from_url` | Join a shared neighbourhood |
-| `neighbourhood_publish_from_perspective` | Publish a perspective as a neighbourhood |
-
-### Agent Tools
-| Tool | Description |
-|------|-------------|
-| `get_agent_profile` | Get agent's DID and profile |
-| `set_agent_profile` | Update agent profile |
-| `set_agent_profile_picture` | Set agent profile picture |
-| `get_agent_public_perspective` | Get agent's public perspective |
-| `set_agent_public_perspective` | Set agent's public perspective |
-
-### AI/Flow Tools
-| Tool | Description |
-|------|-------------|
-| `get_models` | List available AI models |
-| `add_model` | Add an AI model |
-| `infer` | Run inference on a model |
-| `get_flows` | List AI flows |
-| `add_flow` | Add a new flow |
-| `flow_start` | Start a flow |
-| `flow_state` | Get flow state |
-| `flow_actions` | List flow actions |
-| `flow_run_action` | Run a flow action |
-
-### Utility
-| Tool | Description |
-|------|-------------|
-| `execute_commands` | Execute arbitrary commands |
-| `generate_waker_query` | Generate SurrealQL for waker subscription |
+| `agent_me` | Get current agent DID and status |
+| `agent_generate` | Generate new agent keys (first run only) |
+| `agent_unlock` | Unlock agent with passphrase |
+| `agent_lock` | Lock agent keys |
+| `perspective_create` | Create a new perspective |
+| `perspective_list` | List all perspectives |
+| `add_link` | Add a link to a perspective |
+| `get_links` | Query links in a perspective |
+| `remove_link` | Remove a link from a perspective |
+| `get_models` | List available subject classes (SHACL shapes) |
+| `add_model` | Add SHACL SDNA to a perspective |
 
 ## Dynamic Tools (from SHACL)
 
-When a perspective has SHACL SDNA (e.g., after joining a Flux neighbourhood), tools are dynamically generated per subject class:
+When a perspective has SHACL SDNA, tools are generated per class:
 
 For a class `Channel` with scalar `name`, scalar `description`, and collection `messages`:
 
 | Tool | Description |
 |------|-------------|
-| `channel_create` | Create a Channel instance |
-| `channel_query` | Find Channel instances |
+| `channel_create` | Create a Channel instance (required props as params) |
 | `channel_get` | Get a Channel by URI |
-| `channel_delete` | Delete a Channel |
 | `channel_set_name` | Set the name property |
 | `channel_set_description` | Set the description property |
 | `channel_get_messages` | Get all messages in the collection |
 | `channel_add_messages` | Add a message to the collection |
 | `channel_remove_messages` | Remove a message from the collection |
 
-A Flux neighbourhood typically exposes ~248 tools total (core + dynamic).
-
 ### Naming Convention
 
 Class-first: `{class}_{action}` or `{class}_{action}_{property}`.
 
+Examples:
+- `task_create`, `task_set_title`, `task_get_assignees`
+- `post_create`, `post_set_content`, `post_add_comment`
+
+### Tool Parameters
+
+All dynamic tools include:
+- `perspective_uuid` — which perspective to operate on
+- Property-specific params (type-checked against SHACL datatype)
+
+## Workflow Example
+
+```
+1. agent_me                    → verify identity
+2. perspective_create          → create workspace
+3. add_model                   → add SHACL schema
+4. get_models                  → verify schema loaded
+5. channel_create              → create a Channel
+6. channel_set_name            → set its name
+7. message_create              → create a Message
+8. channel_add_messages        → add message to channel
+```
+
 ## Error Handling
 
-MCP tool calls return JSON-RPC responses via SSE:
+MCP tool calls return JSON-RPC responses:
+- Success: `{ "result": { "content": [{ "type": "text", "text": "..." }] } }`
+- Error: `{ "error": { "code": -32000, "message": "..." } }`
 
-```
-data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{...}"}],"isError":false}}
-```
-
-The `text` field contains JSON with the actual result or error. Common errors:
-
-| Error | Cause | Fix |
-|-------|-------|-----|
-| `Wallet is locked` | Agent not unlocked after restart | `agentUnlock` via GraphQL |
-| `main signing key not found` | `agentGenerate` never called | Run `agentGenerate` once |
-| `expect initialized notification` | Missing `notifications/initialized` | Send it after `initialize` |
-| `Session not found` | Executor restarted or session expired | Re-initialize a new session |
-| `Can't find permitted request` | Wrong request_id or code | Re-run `request_capability` |
-| `Perspective not found` | Invalid UUID | Check `list_perspectives` |
-| `Subject class not found` | SDNA not loaded in perspective | Join a neighbourhood with SDNA, or `add_model` |
-| `Not Acceptable` | Missing `Accept` header | Include `Accept: application/json, text/event-stream` |
-
-## Complete Session Example
-
-```bash
-# 1. Ensure agent is unlocked (via GraphQL, not MCP)
-curl -s http://localhost:12100/graphql \
-  -H "Content-Type: application/json" \
-  -H "Authorization: admin-secret" \
-  -d '{"query":"mutation { agentUnlock(passphrase: \"my-passphrase\", holochain: true) { isUnlocked } }"}'
-
-# 2. Initialize MCP session
-curl -si -X POST http://localhost:3001/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -D /tmp/mcp-headers.txt \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"my-bot","version":"1.0"}}}' > /dev/null
-
-MCP_SESSION=$(grep -i 'mcp-session-id' /tmp/mcp-headers.txt | awk '{print $2}' | tr -d '\r')
-
-# 3. Send initialized notification
-curl -s -X POST http://localhost:3001/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "Mcp-Session-Id: $MCP_SESSION" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
-
-# 4. Authenticate
-curl -s -X POST http://localhost:3001/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "Mcp-Session-Id: $MCP_SESSION" \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"request_capability","arguments":{"app_name":"my-bot","app_desc":"AI agent","app_url":"http://localhost"}}}'
-# → Parse request_id and code from response
-
-curl -s -X POST http://localhost:3001/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "Mcp-Session-Id: $MCP_SESSION" \
-  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"generate_jwt","arguments":{"request_id":"<id>","code":"<code>"}}}'
-
-# 5. Use tools (authenticated)
-curl -s -X POST http://localhost:3001/mcp \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "Mcp-Session-Id: $MCP_SESSION" \
-  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_perspectives","arguments":{}}}'
-```
+Common errors:
+- `Perspective not found` — invalid UUID
+- `Subject class not found` — SDNA not added to perspective
+- `Unauthorized` — missing or invalid auth token


### PR DESCRIPTION
## Summary

Improves MCP authentication error messages and adds early wallet-locked guards.

### Problem

When an MCP client calls `request_capability` or `generate_jwt` before the agent has been unlocked (`agentUnlock`), the error was:

> `main key not found. call createMainKey() first`

This is misleading — the keys exist on disk (encrypted in `agent.json`), they just aren't accessible until the wallet is unlocked. MCP clients (especially AI agents) interpret this as needing to call some `createMainKey` function that doesn't exist in the MCP tool surface.

### Changes

**`rust-executor/src/agent/capabilities/token.rs`**
- Add explicit `wallet.is_unlocked()` check before key access in both `generate_jwt` and `decode_jwt`
- New error: `"Wallet is locked. The agent must be unlocked (agentUnlock) before generating JWTs."`
- Improve fallback error messages to distinguish locked wallet from uninitialized agent

**`rust-executor/src/mcp/tools/auth.rs`**
- Add early wallet-locked guards in `request_capability` and `generate_jwt` MCP tools
- Returns clear JSON error before entering the capability flow, so clients get actionable feedback

### Testing

Tested manually via curl against MCP server:
1. Start executor, don't unlock → `request_capability` returns `"Agent wallet is locked. Call agentUnlock first"`
2. Unlock agent → `request_capability` → `generate_jwt` → JWT issued successfully
3. Session stays alive across multiple tool calls (confirmed `notifications/initialized` is required by MCP spec)

⬡


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JWT generation and decoding now require the wallet to be unlocked; error messages clarified to reference main signing key or DID document and potential agent initialization.

* **New Features**
  * Calls that require auth now short-circuit with a clear "wallet locked" error until the agent is unlocked; successful JWTs are returned and kept for Authorization use.

* **Tests**
  * Added tests for locked-wallet errors, unlocked success, and not-found scenarios.

* **Documentation**
  * Quick Start and MCP Tools docs updated to require unlocking at startup and to include the two-step MCP handshake and example updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->