### PR TITLE
fix(connect): add back button on password prompt and remember field values

### DIFF
--- a/connect/src/components/views/ConnectionOptions.ts
+++ b/connect/src/components/views/ConnectionOptions.ts
@@ -16,7 +16,7 @@ export class ConnectionOptions extends LitElement {
   @state() private loading = true;
   @state() private localNodeDetected = false;
   @state() private newPort = 0;
-  @state() private newRemoteUrl = "";
+  @state() private newRemoteUrl = sessionStorage.getItem("ad4m-connect-remote-url") || "";
   @state() private isMobile = false;
 
   static styles = [
@@ -91,7 +91,7 @@ export class ConnectionOptions extends LitElement {
   async connectedCallback() {
     super.connectedCallback();
     this.newPort = this.port;
-    this.newRemoteUrl = this.remoteUrl || "";
+    this.newRemoteUrl = this.remoteUrl || sessionStorage.getItem("ad4m-connect-remote-url") || "";
     this.checkMobile();
     window.addEventListener('resize', this.checkMobile);
     await this.detectLocalNode();
@@ -105,7 +105,7 @@ export class ConnectionOptions extends LitElement {
 
   willUpdate(changedProps: PropertyValues) {
     if (changedProps.has('port')) this.newPort = this.port;
-    if (changedProps.has('remoteUrl')) this.newRemoteUrl = this.remoteUrl || "";
+    if (changedProps.has('remoteUrl')) this.newRemoteUrl = this.remoteUrl || sessionStorage.getItem("ad4m-connect-remote-url") || "";
   }
 
   render() {
@@ -196,6 +196,7 @@ export class ConnectionOptions extends LitElement {
                 @input=${(e: Event) => {
                   const input = e.target as HTMLInputElement;
                   this.newRemoteUrl = input.value;
+                  sessionStorage.setItem("ad4m-connect-remote-url", input.value);
 
                   if (this.remoteNodeError) this.clearRemoteNodeError();
                 }}

--- a/connect/src/components/views/RemoteAuthentication.ts
+++ b/connect/src/components/views/RemoteAuthentication.ts
@@ -12,7 +12,7 @@ export class RemoteAuthentication extends LitElement {
   @property({ type: Boolean }) passwordError: boolean = false;
   @property({ type: Boolean }) accountCreationError: boolean = false;
 
-  @state() private email = "";
+  @state() private email = sessionStorage.getItem("ad4m-connect-email") || "";
   @state() private password = "";
   @state() private emailSecurityCode: string = "";
 
@@ -73,6 +73,14 @@ export class RemoteAuthentication extends LitElement {
     // Clear sensitive fields when navigating back
     this.password = "";
     this.emailSecurityCode = "";
+  }
+
+  private useDifferentAccount() {
+    this.remoteAuthState = null;
+    this.password = "";
+    this.emailSecurityCode = "";
+    this.email = "";
+    sessionStorage.removeItem("ad4m-connect-email");
   }
 
   private emailLogin() {
@@ -141,6 +149,7 @@ export class RemoteAuthentication extends LitElement {
                 @input=${(e: Event) => {
                   const input = e.target as HTMLInputElement;
                   this.email = input.value;
+                  sessionStorage.setItem("ad4m-connect-email", input.value);
                 }}
                 @keydown=${(e: KeyboardEvent) => {
                   if (e.key === 'Enter' && !this.remoteAuthLoading && this.isValidEmail()) {
@@ -250,6 +259,12 @@ export class RemoteAuthentication extends LitElement {
                 `
               : ''
             }
+
+            <div class="login-button">
+              <button class="secondary" @click=${this.useDifferentAccount}>
+                Use Different Account
+              </button>
+            </div>
           `
           : ``
         }
@@ -295,6 +310,12 @@ export class RemoteAuthentication extends LitElement {
                 `
               : ''
             }
+
+            <div class="login-button">
+              <button class="secondary" @click=${this.useDifferentAccount}>
+                Use Different Account
+              </button>
+            </div>
           `
           : ``
         }


### PR DESCRIPTION
## Summary

Fixes two UX issues in the multi-user login flow:

### Back button on password prompt (#724)
When logging in via the multi-user flow, entering the wrong email moved to the password prompt with no way to go back. Added a "Use Different Account" button that resets `remoteAuthState`, clears password/code/email fields, and returns to the email input step. Also appears on the account creation screen.

### Remember field values (#726)
Remote URL and email fields now persist to `sessionStorage` during the session:
- `ad4m-connect-remote-url` — restored when returning to connection options
- `ad4m-connect-email` — restored when returning to the email input step
- Password fields intentionally **not** persisted (security)
- `sessionStorage` clears when the tab closes — no credential persistence across sessions

### Files changed
- `connect/src/components/views/RemoteAuthentication.ts` — back button + email persistence
- `connect/src/components/views/ConnectionOptions.ts` — remote URL persistence

Closes #724, Closes #726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Remote URL persistence: Your remote URL selection now saves during your session
  * Email prefilling: Your email address automatically populates on return visits within the same session
  * "Use Different Account" button: Quickly switch to a different account or email during authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->