### PR TITLE
feat: add iroh-ice module for WebRTC ICE candidate extraction

### DIFF
--- a/core/src/runtime/RuntimeClient.ts
+++ b/core/src/runtime/RuntimeClient.ts
@@ -1,7 +1,7 @@
 import { ApolloClient, gql } from "@apollo/client/core"
 import { Perspective, PerspectiveExpression } from "../perspectives/Perspective"
 import unwrapApolloResult from "../unwrapApolloResult"
-import { RuntimeInfo, ExceptionInfo, SentMessage, NotificationInput, Notification, TriggeredNotification, ImportResult, UserStatistics } from "./RuntimeResolver"
+import { RuntimeInfo, IceCandidateInfo, ExceptionInfo, SentMessage, NotificationInput, Notification, TriggeredNotification, ImportResult, UserStatistics } from "./RuntimeResolver"
 
 const PERSPECTIVE_EXPRESSION_FIELDS = `
 author
@@ -76,6 +76,21 @@ export class RuntimeClient {
             }`,
         }));
         return runtimeInfo
+    }
+
+    async iceCandidates(): Promise<IceCandidateInfo[]> {
+        const { runtimeIceCandidates } = unwrapApolloResult(await this.#apolloClient.query({
+            query: gql`query runtimeIceCandidates {
+                runtimeIceCandidates {
+                    candidate
+                    candidateType
+                    address
+                    port
+                }
+            }`,
+            fetchPolicy: 'no-cache',
+        }))
+        return runtimeIceCandidates
     }
 
     async quit(): Promise<Boolean> {

--- a/core/src/runtime/RuntimeResolver.ts
+++ b/core/src/runtime/RuntimeResolver.ts
@@ -43,6 +43,19 @@ export class RuntimeInfo {
     isUnlocked: Boolean;
 }
 
+
+@ObjectType()
+export class IceCandidateInfo {
+    @Field()
+    candidate: string;
+    @Field()
+    candidateType: string;
+    @Field()
+    address: string;
+    @Field(() => Int)
+    port: number;
+}
+
 @ObjectType()
 export class ExceptionInfo {
     @Field()
@@ -239,6 +252,11 @@ export default class RuntimeResolver {
     @Mutation(returns => Boolean)
     runtimeOpenLink(@Arg('url') url: string): Boolean {
         return true
+    }
+
+    @Query(returns => [IceCandidateInfo])
+    runtimeIceCandidates(): IceCandidateInfo[] {
+        return []
     }
 
     @Query(returns => RuntimeInfo)

--- a/rust-executor/src/graphql/graphql_types.rs
+++ b/rust-executor/src/graphql/graphql_types.rs
@@ -625,6 +625,21 @@ pub struct ResourceInput {
     pub pointers: Vec<String>,
 }
 
+
+/// ICE candidate information derived from the Iroh transport layer.
+#[derive(GraphQLObject, Default, Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct IceCandidateInfo {
+    /// ICE candidate string in SDP format (RFC 8445).
+    pub candidate: String,
+    /// Candidate type: "host" or "srflx".
+    pub candidate_type: String,
+    /// The IP address.
+    pub address: String,
+    /// The port number.
+    pub port: i32,
+}
+
 #[derive(GraphQLObject, Default, Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RuntimeInfo {

--- a/rust-executor/src/graphql/query_resolvers.rs
+++ b/rust-executor/src/graphql/query_resolvers.rs
@@ -6,6 +6,7 @@ use crate::languages::LanguageController;
 use crate::types::{AITask, DecoratedExpressionProof, ModelType};
 use crate::{agent::AgentService, entanglement_service::get_entanglement_proofs};
 use crate::{
+    iroh_ice::IrohIce,
     db::Ad4mDb,
     globals::AD4M_VERSION,
     holochain_service::get_holochain_service,
@@ -789,6 +790,39 @@ impl Query {
         let metrics = interface.get_network_metrics().await?;
 
         Ok(metrics)
+    }
+
+    /// Get ICE candidates derived from the Iroh transport layer.
+    /// These can be used as WebRTC ICE candidates, replacing external STUN servers.
+    async fn runtime_ice_candidates(&self, context: &RequestContext) -> FieldResult<Vec<IceCandidateInfo>> {
+        check_capability(
+            &context.capabilities,
+            &RUNTIME_HC_AGENT_INFO_READ_CAPABILITY,
+        )?;
+
+        let service = get_holochain_service().await;
+        let addrs = service
+            .conductor
+            .holochain_p2p()
+            .local_socket_addrs()
+            .await
+            .map_err(|e| FieldError::new(format!("Failed to get socket addresses: {}", e), Value::null()))?;
+
+        let ice = IrohIce::new(addrs);
+        let candidates = ice.local_candidates();
+
+        Ok(candidates
+            .into_iter()
+            .map(|c| IceCandidateInfo {
+                candidate: c.candidate,
+                candidate_type: match c.typ {
+                    crate::iroh_ice::IceCandidateType::Host => "host".to_string(),
+                    crate::iroh_ice::IceCandidateType::ServerReflexive => "srflx".to_string(),
+                },
+                address: c.addr.ip().to_string(),
+                port: c.addr.port() as i32,
+            })
+            .collect())
     }
 
     async fn runtime_info(&self, _context: &RequestContext) -> FieldResult<RuntimeInfo> {

--- a/rust-executor/src/iroh_ice/mod.rs
+++ b/rust-executor/src/iroh_ice/mod.rs
@@ -56,12 +56,13 @@ impl IrohIce {
 
     /// Get ICE candidates for the local endpoint.
     ///
-    /// Classifies addresses as:
-    /// - `host` — private/LAN addresses (RFC 1918, link-local, loopback)
-    /// - `srflx` — public/server-reflexive addresses (everything else)
+    /// All addresses are classified as `host` since Iroh does not distinguish
+    /// between directly-bound and STUN-discovered addresses.
+    /// Unspecified/wildcard addresses (0.0.0.0, ::) are filtered out.
     pub fn local_candidates(&self) -> Vec<IceCandidate> {
         self.local_addrs
             .iter()
+            .filter(|addr| !addr.ip().is_unspecified())
             .enumerate()
             .map(|(i, addr)| {
                 let typ = classify_addr(addr);
@@ -92,13 +93,14 @@ impl IrohIce {
     }
 }
 
-/// Classify a socket address as host (private) or server-reflexive (public).
-fn classify_addr(addr: &SocketAddr) -> IceCandidateType {
-    if is_private(addr) {
-        IceCandidateType::Host
-    } else {
-        IceCandidateType::ServerReflexive
-    }
+/// Classify a socket address.
+///
+/// Since Iroh's EndpointAddr does not distinguish between directly-bound and
+/// STUN-discovered addresses (all come from `local_socket_addrs()`), every
+/// address is reported as `host`.  Only a real STUN response should produce
+/// `srflx`, which we do not have here.
+fn classify_addr(_addr: &SocketAddr) -> IceCandidateType {
+    IceCandidateType::Host
 }
 
 /// Check if a socket address is private/LAN.
@@ -106,10 +108,13 @@ fn is_private(addr: &SocketAddr) -> bool {
     match addr {
         SocketAddr::V4(v4) => {
             let ip = v4.ip();
+            let octets = ip.octets();
             ip.is_private()
                 || ip.is_loopback()
                 || ip.is_link_local()
                 || ip.is_unspecified()
+                // CGNAT/shared address space (100.64.0.0/10) per RFC 6598
+                || (octets[0] == 100 && (octets[1] & 0xC0) == 64)
         }
         SocketAddr::V6(v6) => {
             let ip = v6.ip();
@@ -179,8 +184,8 @@ mod tests {
             ("172.16.0.1:8080", IceCandidateType::Host),
             ("127.0.0.1:3000", IceCandidateType::Host),
             ("169.254.1.1:4000", IceCandidateType::Host),
-            ("8.8.8.8:443", IceCandidateType::ServerReflexive),
-            ("203.0.113.5:12345", IceCandidateType::ServerReflexive),
+            ("8.8.8.8:443", IceCandidateType::Host),
+            ("203.0.113.5:12345", IceCandidateType::Host),
         ];
         for (addr_str, expected) in cases {
             let addr: SocketAddr = addr_str.parse().unwrap();
@@ -201,7 +206,7 @@ mod tests {
         assert_eq!(classify_addr(&ula), IceCandidateType::Host);
 
         let public: SocketAddr = "[2001:db8::1]:1234".parse().unwrap();
-        assert_eq!(classify_addr(&public), IceCandidateType::ServerReflexive);
+        assert_eq!(classify_addr(&public), IceCandidateType::Host);
     }
 
     #[test]
@@ -255,9 +260,9 @@ mod tests {
 
         assert_eq!(candidates.len(), 2);
         assert_eq!(candidates[0].typ, IceCandidateType::Host);
-        assert_eq!(candidates[1].typ, IceCandidateType::ServerReflexive);
+        assert_eq!(candidates[1].typ, IceCandidateType::Host);
         assert!(candidates[0].candidate.contains("typ host"));
-        assert!(candidates[1].candidate.contains("typ srflx"));
+        assert!(candidates[1].candidate.contains("typ host"));
     }
 
     #[test]

--- a/rust-executor/src/iroh_ice/mod.rs
+++ b/rust-executor/src/iroh_ice/mod.rs
@@ -1,0 +1,291 @@
+//! Generic Iroh-to-ICE bridge for AD4M WebRTC connections.
+//!
+//! Provides ICE candidates derived from the Holochain/Iroh transport layer,
+//! replacing the need for external STUN/TURN servers.
+//!
+//! This module is transport-agnostic — it works with socket addresses from
+//! any source. It has no knowledge of whether the consumer is a P2P mesh
+//! call, an SFU connection, or a pipe transport.
+//!
+//! See: <https://github.com/coasys/ad4m/issues/719>
+
+use std::net::SocketAddr;
+
+/// A WebRTC ICE candidate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IceCandidate {
+    /// The ICE candidate string in SDP format (RFC 8445).
+    /// e.g. "candidate:1 1 udp 2130706431 192.168.1.5 12345 typ host"
+    pub candidate: String,
+    /// The candidate type.
+    pub typ: IceCandidateType,
+    /// The underlying socket address.
+    pub addr: SocketAddr,
+}
+
+/// ICE candidate types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IceCandidateType {
+    /// Local/LAN address.
+    Host,
+    /// Server-reflexive (public/NAT-mapped) address, replaces STUN.
+    ServerReflexive,
+}
+
+/// Generic Iroh-to-ICE bridge.
+///
+/// Takes socket addresses from the Holochain/kitsune2 transport layer
+/// and converts them to WebRTC ICE candidate format.
+pub struct IrohIce {
+    /// Cached local addresses.
+    local_addrs: Vec<SocketAddr>,
+}
+
+impl IrohIce {
+    /// Create a new IrohIce instance with the given local socket addresses.
+    ///
+    /// In practice, these come from `conductor.holochain_p2p().local_socket_addrs().await`.
+    pub fn new(local_addrs: Vec<SocketAddr>) -> Self {
+        Self { local_addrs }
+    }
+
+    /// Update the local addresses (e.g. when the transport discovers new addresses).
+    pub fn update_addrs(&mut self, addrs: Vec<SocketAddr>) {
+        self.local_addrs = addrs;
+    }
+
+    /// Get ICE candidates for the local endpoint.
+    ///
+    /// Classifies addresses as:
+    /// - `host` — private/LAN addresses (RFC 1918, link-local, loopback)
+    /// - `srflx` — public/server-reflexive addresses (everything else)
+    pub fn local_candidates(&self) -> Vec<IceCandidate> {
+        self.local_addrs
+            .iter()
+            .enumerate()
+            .map(|(i, addr)| {
+                let typ = classify_addr(addr);
+                let priority = compute_priority(&typ, i);
+                IceCandidate {
+                    candidate: format_ice_candidate(i + 1, addr, &typ, priority),
+                    typ,
+                    addr: *addr,
+                }
+            })
+            .collect()
+    }
+
+    /// Get ICE candidates formatted for use in an SDP answer/offer.
+    ///
+    /// Returns the candidate strings ready for `RTCPeerConnection.addIceCandidate()`.
+    pub fn candidate_strings(&self) -> Vec<String> {
+        self.local_candidates()
+            .into_iter()
+            .map(|c| c.candidate)
+            .collect()
+    }
+
+    /// Check if any public (server-reflexive) addresses are available.
+    /// If false, connections will only work on the local network.
+    pub fn has_public_addr(&self) -> bool {
+        self.local_addrs.iter().any(|a| !is_private(a))
+    }
+}
+
+/// Classify a socket address as host (private) or server-reflexive (public).
+fn classify_addr(addr: &SocketAddr) -> IceCandidateType {
+    if is_private(addr) {
+        IceCandidateType::Host
+    } else {
+        IceCandidateType::ServerReflexive
+    }
+}
+
+/// Check if a socket address is private/LAN.
+fn is_private(addr: &SocketAddr) -> bool {
+    match addr {
+        SocketAddr::V4(v4) => {
+            let ip = v4.ip();
+            ip.is_private()
+                || ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_unspecified()
+        }
+        SocketAddr::V6(v6) => {
+            let ip = v6.ip();
+            ip.is_loopback() || ip.is_unspecified()
+            // Note: is_unique_local() (fc00::/7) is nightly-only,
+            // so we check the first byte manually.
+                || {
+                    let octets = ip.octets();
+                    octets[0] == 0xfc || octets[0] == 0xfd // ULA
+                    || (octets[0] == 0xfe && (octets[1] & 0xc0) == 0x80) // link-local
+                }
+        }
+    }
+}
+
+/// Compute ICE candidate priority per RFC 8445 Section 5.1.2.1.
+///
+/// priority = (2^24) * type_preference + (2^8) * local_preference + (256 - component_id)
+///
+/// type_preference: host=126, srflx=100
+/// component_id: always 1 (RTP)
+fn compute_priority(typ: &IceCandidateType, index: usize) -> u32 {
+    let type_pref: u32 = match typ {
+        IceCandidateType::Host => 126,
+        IceCandidateType::ServerReflexive => 100,
+    };
+    // local_preference: prefer lower-index addresses (first discovered)
+    let local_pref: u32 = 65535u32.saturating_sub(index as u32);
+    let component_id: u32 = 1;
+
+    (type_pref << 24) + (local_pref << 8) + (256 - component_id)
+}
+
+/// Format an ICE candidate string per RFC 8445.
+///
+/// Format: candidate:{foundation} {component} udp {priority} {ip} {port} typ {type}
+fn format_ice_candidate(
+    foundation: usize,
+    addr: &SocketAddr,
+    typ: &IceCandidateType,
+    priority: u32,
+) -> String {
+    let type_str = match typ {
+        IceCandidateType::Host => "host",
+        IceCandidateType::ServerReflexive => "srflx",
+    };
+    format!(
+        "candidate:{foundation} 1 udp {priority} {ip} {port} typ {type_str}",
+        foundation = foundation,
+        priority = priority,
+        ip = addr.ip(),
+        port = addr.port(),
+        type_str = type_str,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn test_classify_private_v4() {
+        let cases = vec![
+            ("192.168.1.5:1234", IceCandidateType::Host),
+            ("10.0.0.1:5000", IceCandidateType::Host),
+            ("172.16.0.1:8080", IceCandidateType::Host),
+            ("127.0.0.1:3000", IceCandidateType::Host),
+            ("169.254.1.1:4000", IceCandidateType::Host),
+            ("8.8.8.8:443", IceCandidateType::ServerReflexive),
+            ("203.0.113.5:12345", IceCandidateType::ServerReflexive),
+        ];
+        for (addr_str, expected) in cases {
+            let addr: SocketAddr = addr_str.parse().unwrap();
+            assert_eq!(
+                classify_addr(&addr),
+                expected,
+                "wrong classification for {addr_str}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_classify_private_v6() {
+        let loopback: SocketAddr = "[::1]:1234".parse().unwrap();
+        assert_eq!(classify_addr(&loopback), IceCandidateType::Host);
+
+        let ula: SocketAddr = "[fd12::1]:1234".parse().unwrap();
+        assert_eq!(classify_addr(&ula), IceCandidateType::Host);
+
+        let public: SocketAddr = "[2001:db8::1]:1234".parse().unwrap();
+        assert_eq!(classify_addr(&public), IceCandidateType::ServerReflexive);
+    }
+
+    #[test]
+    fn test_format_ice_candidate() {
+        let addr: SocketAddr = "192.168.1.5:12345".parse().unwrap();
+        let candidate = format_ice_candidate(1, &addr, &IceCandidateType::Host, 2130706431);
+        assert_eq!(
+            candidate,
+            "candidate:1 1 udp 2130706431 192.168.1.5 12345 typ host"
+        );
+    }
+
+    #[test]
+    fn test_format_srflx_candidate() {
+        let addr: SocketAddr = "203.0.113.5:54321".parse().unwrap();
+        let candidate =
+            format_ice_candidate(2, &addr, &IceCandidateType::ServerReflexive, 1694498815);
+        assert_eq!(
+            candidate,
+            "candidate:2 1 udp 1694498815 203.0.113.5 54321 typ srflx"
+        );
+    }
+
+    #[test]
+    fn test_priority_ordering() {
+        // Host candidates should have higher priority than srflx
+        let host_priority = compute_priority(&IceCandidateType::Host, 0);
+        let srflx_priority = compute_priority(&IceCandidateType::ServerReflexive, 0);
+        assert!(
+            host_priority > srflx_priority,
+            "host ({host_priority}) should have higher priority than srflx ({srflx_priority})"
+        );
+
+        // Earlier candidates should have higher priority than later ones
+        let first = compute_priority(&IceCandidateType::Host, 0);
+        let second = compute_priority(&IceCandidateType::Host, 1);
+        assert!(
+            first > second,
+            "first ({first}) should have higher priority than second ({second})"
+        );
+    }
+
+    #[test]
+    fn test_iroh_ice_local_candidates() {
+        let addrs = vec![
+            "192.168.1.5:12345".parse().unwrap(),
+            "203.0.113.5:54321".parse().unwrap(),
+        ];
+        let ice = IrohIce::new(addrs);
+        let candidates = ice.local_candidates();
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].typ, IceCandidateType::Host);
+        assert_eq!(candidates[1].typ, IceCandidateType::ServerReflexive);
+        assert!(candidates[0].candidate.contains("typ host"));
+        assert!(candidates[1].candidate.contains("typ srflx"));
+    }
+
+    #[test]
+    fn test_has_public_addr() {
+        let private_only = IrohIce::new(vec!["192.168.1.5:1234".parse().unwrap()]);
+        assert!(!private_only.has_public_addr());
+
+        let with_public = IrohIce::new(vec![
+            "192.168.1.5:1234".parse().unwrap(),
+            "8.8.8.8:5678".parse().unwrap(),
+        ]);
+        assert!(with_public.has_public_addr());
+    }
+
+    #[test]
+    fn test_empty_addrs() {
+        let ice = IrohIce::new(vec![]);
+        assert!(ice.local_candidates().is_empty());
+        assert!(ice.candidate_strings().is_empty());
+        assert!(!ice.has_public_addr());
+    }
+
+    #[test]
+    fn test_update_addrs() {
+        let mut ice = IrohIce::new(vec![]);
+        assert!(ice.local_candidates().is_empty());
+
+        ice.update_addrs(vec!["10.0.0.1:5000".parse().unwrap()]);
+        assert_eq!(ice.local_candidates().len(), 1);
+    }
+}

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -7,6 +7,7 @@ pub mod entanglement_service;
 mod globals;
 pub mod graphql;
 pub mod holochain_service;
+pub mod iroh_ice;
 pub mod js_core;
 pub mod mcp;
 mod prolog_service;


### PR DESCRIPTION
## Summary

Adds a complete Iroh-to-ICE bridge that exposes Holochain's transport-discovered socket addresses as WebRTC ICE candidates, replacing the need for external STUN servers. Provides both the low-level module and the full GraphQL API + TypeScript client integration.

### Changes

#### `rust-executor/src/iroh_ice/mod.rs` — Core Module
- `IrohIce` struct: takes socket addresses, produces RFC 8445 compliant ICE candidates
- Classifies addresses as `host` (private/LAN) or `srflx` (public/reflexive)
- Computes priorities per RFC 8445 Section 5.1.2.1
- Formats candidate strings for `RTCPeerConnection.addIceCandidate()`
- Zero external dependencies (pure `std::net`)
- 9 unit tests

#### `rust-executor/src/graphql/` — GraphQL API
- `IceCandidateInfo` GraphQL type with `candidate`, `candidateType`, `address`, `port`
- `runtimeIceCandidates` query: fetches socket addresses from `conductor.holochain_p2p().local_socket_addrs()` and converts them via `IrohIce`

#### `core/src/runtime/` — TypeScript Client
- `IceCandidateInfo` class in `RuntimeResolver.ts`
- `runtime.iceCandidates()` client method in `RuntimeClient.ts`

### Usage

```typescript
// In Flux or any AD4M client
const candidates = await ad4mClient.runtime.iceCandidates()
// Returns: [{ candidate: 'candidate:1 1 udp 2130706431 192.168.1.5 12345 typ host', candidateType: 'host', address: '192.168.1.5', port: 12345 }, ...]
```

### Flux Integration (separate PR)

The `packages/webrtc/src/WebRTCManager.ts` in Flux currently uses hardcoded STUN servers (`stun:relay.ad4m.dev:3478`, `stun:stun.l.google.com:19302`, etc.). The integration path:

1. On `WebRTCManager.init()`, call `ad4mClient.runtime.iceCandidates()` to fetch Iroh-derived candidates
2. After each `RTCPeerConnection` is created (in `AD4MPeer.createPeer()`), inject the Iroh candidates via `pc.addIceCandidate()`
3. Optionally fall back to STUN servers if no Iroh candidates are available (graceful degradation)

This works for both the existing P2P mesh calls and the future SFU system (#700), since `iroh-ice` is transport-agnostic — it provides candidates that any WebRTC consumer can use.

### SFU Considerations

The `iroh-ice` module is deliberately generic — no knowledge of mesh vs SFU vs pipe transport. When the str0m SFU (#700) lands:
- SFU server: uses `IrohIce` to get its own ICE candidates to share with clients
- SFU clients: use the same `runtimeIceCandidates` API to get their local candidates
- The SFU negotiation adds its own signaling on top, but the ICE candidate source is shared

### Dependencies

- [holochain/kitsune2#476](https://github.com/holochain/kitsune2/pull/476) — `local_socket_addrs()` on Transport trait
- [coasys/holochain#1](https://github.com/coasys/holochain/pull/1) — surface through HcP2p trait

### Note

The `ad4m-client` crate has 327 pre-existing compile errors (GraphQL codegen issue) unrelated to this PR. The `ad4m-executor` crate and the `iroh-ice` module compile and test successfully.

See: #719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API and GraphQL query to fetch ICE candidate details (candidate, type, address, port).
  * Local ICE candidate generation exposed so clients can discover formatted candidate info and detect public vs private addresses for connectivity diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->