### PR TITLE
feat: iroh-ice module — sovereign NAT traversal for WebRTC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
  "os_info",
  "percent-encoding",
  "portpicker",
+ "quinn",
  "rand 0.8.5",
  "rayon",
  "regex",
@@ -16063,6 +16064,7 @@ checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "aws-lc-rs",
  "bytes",
+ "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
@@ -16070,6 +16072,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",

--- a/core/src/runtime/RuntimeClient.ts
+++ b/core/src/runtime/RuntimeClient.ts
@@ -527,4 +527,20 @@ export class RuntimeClient {
             error: (e) => console.error(e)
         })
     }
+
+    async iceCandidates(): Promise<any[]> {
+        const { data } = await this.apolloClient.query({
+            query: gql\`query runtimeIceCandidates {
+                runtimeIceCandidates {
+                    candidate
+                    candidateType
+                    address
+                    port
+                }
+            }\`,
+            fetchPolicy: "no-cache"
+        })
+        return data.runtimeIceCandidates
+    }
+
 }

--- a/core/src/runtime/RuntimeResolver.ts
+++ b/core/src/runtime/RuntimeResolver.ts
@@ -562,3 +562,18 @@ export default class RuntimeResolver {
     }
 }
 
+
+@ObjectType()
+export class IceCandidateInfo {
+    @Field()
+    candidate: string
+
+    @Field()
+    candidateType: string
+
+    @Field()
+    address: string
+
+    @Field(type => Int)
+    port: number
+}

--- a/rust-executor/Cargo.toml
+++ b/rust-executor/Cargo.toml
@@ -46,6 +46,7 @@ deno_snapshots = {version = "0.19.0", git = "https://github.com/coasys/deno.git"
 sys_traits = "=0.1.9"
 # deno_runtime = {version = "0.162.0", path = "../../deno/runtime"}
 tokio = { version = "1.25.0", features = ["full"] }
+quinn = "0.11"
 url = "2.3.1"
 urlencoding = "2.1"
 percent-encoding = "2"

--- a/rust-executor/src/graphql/graphql_types.rs
+++ b/rust-executor/src/graphql/graphql_types.rs
@@ -1285,3 +1285,11 @@ impl GetFilter for PerspectiveQuerySubscriptionFilter {
         Some(self.subscription_id.clone())
     }
 }
+
+#[derive(GraphQLObject, Default, Serialize, Deserialize, Debug, Clone)]
+pub struct IceCandidateInfo {
+    pub candidate: String,
+    pub candidate_type: String,
+    pub address: String,
+    pub port: i32,
+}

--- a/rust-executor/src/graphql/query_resolvers.rs
+++ b/rust-executor/src/graphql/query_resolvers.rs
@@ -791,6 +791,28 @@ impl Query {
         Ok(metrics)
     }
 
+
+    async fn runtime_ice_candidates(&self, context: &RequestContext) -> FieldResult<Vec<IceCandidateInfo>> {
+        check_capability(
+            &context.capabilities,
+            &RUNTIME_HC_AGENT_INFO_READ_CAPABILITY,
+        )?;
+
+        let interface = get_holochain_service().await;
+        let addrs = interface.local_socket_addrs().await.unwrap_or_default();
+        let candidates = crate::iroh_ice::candidates_from_urls(&addrs);
+
+        Ok(candidates
+            .into_iter()
+            .map(|c| IceCandidateInfo {
+                candidate: c.candidate,
+                candidate_type: c.candidate_type,
+                address: c.address,
+                port: c.port as i32,
+            })
+            .collect())
+    }
+
     async fn runtime_info(&self, _context: &RequestContext) -> FieldResult<RuntimeInfo> {
         AgentService::with_global_instance(|agent_service| {
             agent_service

--- a/rust-executor/src/holochain_service/interface.rs
+++ b/rust-executor/src/holochain_service/interface.rs
@@ -39,6 +39,7 @@ pub enum HolochainServiceRequest {
     UnPackDna(String, oneshot::Sender<HolochainServiceResponse>),
     PackHapp(String, oneshot::Sender<HolochainServiceResponse>),
     UnPackHapp(String, oneshot::Sender<HolochainServiceResponse>),
+    LocalSocketAddrs(oneshot::Sender<HolochainServiceResponse>),
 }
 
 #[derive(Debug)]
@@ -59,6 +60,7 @@ pub enum HolochainServiceResponse {
     UnPackDna(Result<String, AnyError>),
     PackHapp(Result<String, AnyError>),
     UnPackHapp(Result<String, AnyError>),
+    LocalSocketAddrs(Result<Vec<String>, AnyError>),
 }
 
 impl HolochainServiceInterface {
@@ -233,6 +235,16 @@ impl HolochainServiceInterface {
         match response_rx.await? {
             HolochainServiceResponse::UnPackHapp(result) => result,
             _ => unreachable!(),
+        }
+    }
+
+    pub async fn local_socket_addrs(&self) -> Result<Vec<String>, AnyError> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.sender
+            .send(HolochainServiceRequest::LocalSocketAddrs(response_tx))?;
+        match response_rx.await? {
+            HolochainServiceResponse::LocalSocketAddrs(result) => result,
+            _ => Err(anyhow::anyhow!("unexpected response")),
         }
     }
 }

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -385,7 +385,11 @@ impl HolochainService {
                                 }
 
                                 HolochainServiceRequest::LocalSocketAddrs(response_tx) => {
-                                    // TODO: return real socket addrs once holochain_p2p exposes local_socket_addrs
+                                    // TODO(iroh-ice): ConductorHandle does not yet expose holochain_p2p().local_socket_addrs().
+                                    // Once coasys/holochain branch feat/iroh-ice-v2 surfaces HcP2p::local_socket_addrs()
+                                    // through ConductorHandle, replace this with:
+                                    //   conductor.holochain_p2p().local_socket_addrs().await.unwrap_or_default()
+                                    // See: coasys/holochain#feat/iroh-ice-v2 Phase 1b
                                     let _ = response_tx.send(HolochainServiceResponse::LocalSocketAddrs(Ok(Vec::new())));
                                 }
                             };

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -383,6 +383,11 @@ impl HolochainService {
                                         },
                                     }
                                 }
+
+                                HolochainServiceRequest::LocalSocketAddrs(response_tx) => {
+                                    // TODO: return real socket addrs once holochain_p2p exposes local_socket_addrs
+                                    let _ = response_tx.send(HolochainServiceResponse::LocalSocketAddrs(Ok(Vec::new())));
+                                }
                             };
                         };
                         error!("Holochain service receiver closed");

--- a/rust-executor/src/iroh_ice/address_publisher.rs
+++ b/rust-executor/src/iroh_ice/address_publisher.rs
@@ -1,0 +1,282 @@
+//! Address publisher — periodically broadcasts local ICE candidates to all
+//! joined neighbourhoods so remote peers can use this executor as a STUN server.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::time::{interval, Duration};
+use log::{debug, error, info, warn};
+use serde::{Deserialize, Serialize};
+
+use crate::holochain_service::get_holochain_service;
+use crate::perspectives::all_perspectives;
+use crate::agent::{self, create_signed_expression, AgentContext};
+use crate::types::{DecoratedLinkExpression, Link, LinkExpression};
+use crate::graphql::graphql_types::{LinkStatus, Perspective, PerspectiveExpression};
+
+/// JSON signal broadcast to neighbourhoods.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IceAddressSignal {
+    #[serde(rename = "type")]
+    pub signal_type: String,
+    pub addresses: Vec<IceAddressEntry>,
+    pub agent_did: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct IceAddressEntry {
+    pub address: String,
+    pub port: u16,
+    pub candidate: String,
+}
+
+/// Holds cached state for change detection.
+pub struct AddressPublisher {
+    cached_addresses: Arc<Mutex<HashSet<IceAddressEntry>>>,
+    interval_secs: u64,
+}
+
+impl AddressPublisher {
+    pub fn new(interval_secs: u64) -> Self {
+        Self {
+            cached_addresses: Arc::new(Mutex::new(HashSet::new())),
+            interval_secs,
+        }
+    }
+
+    /// Build the signal payload from current addresses.
+    /// Returns None if addresses haven't changed since last check.
+    pub async fn build_signal(&self) -> Option<IceAddressSignal> {
+        let interface = get_holochain_service().await;
+        let addrs = interface.local_socket_addrs().await.unwrap_or_default();
+        let candidates = crate::iroh_ice::candidates_from_urls(&addrs);
+
+        let entries: HashSet<IceAddressEntry> = candidates
+            .into_iter()
+            .map(|c| IceAddressEntry {
+                address: c.address,
+                port: c.port,
+                candidate: c.candidate,
+            })
+            .collect();
+
+        // Check if addresses changed
+        let mut cached = self.cached_addresses.lock().await;
+        if *cached == entries {
+            debug!("iroh-ice: addresses unchanged, skipping broadcast");
+            return None;
+        }
+
+        *cached = entries.clone();
+
+        let agent_did = agent::did();
+        Some(IceAddressSignal {
+            signal_type: "iroh-ice-addresses".to_string(),
+            addresses: entries.into_iter().collect(),
+            agent_did,
+        })
+    }
+
+    /// Broadcast the signal to all neighbourhood perspectives.
+    pub async fn broadcast_to_neighbourhoods(&self, signal: &IceAddressSignal) {
+        let perspectives = all_perspectives();
+
+        let json_payload = match serde_json::to_string(signal) {
+            Ok(j) => j,
+            Err(e) => {
+                error!("iroh-ice: failed to serialize signal: {}", e);
+                return;
+            }
+        };
+
+        let agent_context = AgentContext::main_agent();
+
+        for perspective in perspectives {
+            let handle = perspective.persisted.lock().await;
+            if handle.neighbourhood.is_none() {
+                continue;
+            }
+            let uuid = handle.uuid.clone();
+            drop(handle);
+
+            // Build a link carrying our ICE address data, following the pattern
+            // used by neighbourhood_send_broadcast_u in mutation_resolvers.
+            let link = Link {
+                source: "iroh-ice".to_string(),
+                predicate: Some("iroh-ice-addresses".to_string()),
+                target: json_payload.clone(),
+            };
+
+            let link_expr = match create_signed_expression(link.normalize(), &agent_context) {
+                Ok(expr) => expr,
+                Err(e) => {
+                    warn!("iroh-ice: failed to sign link for {}: {}", uuid, e);
+                    continue;
+                }
+            };
+
+            let decorated = DecoratedLinkExpression::from((
+                LinkExpression::from(link_expr),
+                LinkStatus::Shared,
+            ));
+
+            let perspective_data = Perspective {
+                links: vec![decorated],
+            };
+
+            let signed_perspective =
+                match create_signed_expression(perspective_data, &agent_context) {
+                    Ok(expr) => expr,
+                    Err(e) => {
+                        warn!("iroh-ice: failed to sign perspective for {}: {}", uuid, e);
+                        continue;
+                    }
+                };
+
+            let perspective_expression: PerspectiveExpression = signed_perspective.into();
+
+            debug!("iroh-ice: broadcasting addresses to neighbourhood {}", uuid);
+
+            if let Err(e) = perspective
+                .send_broadcast(perspective_expression, false)
+                .await
+            {
+                warn!("iroh-ice: failed to broadcast to {}: {}", uuid, e);
+            }
+        }
+    }
+
+    /// Run the publish loop.
+    pub async fn run(&self) {
+        info!(
+            "iroh-ice: starting address publisher (interval {}s)",
+            self.interval_secs
+        );
+
+        let mut tick = interval(Duration::from_secs(self.interval_secs));
+        loop {
+            tick.tick().await;
+
+            match self.build_signal().await {
+                Some(signal) => {
+                    if signal.addresses.is_empty() {
+                        debug!("iroh-ice: no addresses to broadcast (empty list)");
+                        continue;
+                    }
+                    info!(
+                        "iroh-ice: broadcasting {} addresses to neighbourhoods",
+                        signal.addresses.len()
+                    );
+                    self.broadcast_to_neighbourhoods(&signal).await;
+                }
+                None => {
+                    // Addresses unchanged
+                }
+            }
+        }
+    }
+}
+
+/// Spawn the address publisher as a background tokio task.
+pub fn start_address_publisher(interval_secs: Option<u64>) -> tokio::task::JoinHandle<()> {
+    let publisher = AddressPublisher::new(interval_secs.unwrap_or(60));
+    tokio::spawn(async move {
+        publisher.run().await;
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_signal_json_format() {
+        let signal = IceAddressSignal {
+            signal_type: "iroh-ice-addresses".to_string(),
+            addresses: vec![IceAddressEntry {
+                address: "1.2.3.4".to_string(),
+                port: 5678,
+                candidate: "candidate:1234 1 udp 2130706431 1.2.3.4 5678 typ host".to_string(),
+            }],
+            agent_did: "did:key:z6MkTest".to_string(),
+        };
+
+        let json = serde_json::to_value(&signal).unwrap();
+        assert_eq!(json["type"], "iroh-ice-addresses");
+        assert_eq!(json["agent_did"], "did:key:z6MkTest");
+        assert_eq!(json["addresses"][0]["address"], "1.2.3.4");
+        assert_eq!(json["addresses"][0]["port"], 5678);
+        assert!(json["addresses"][0]["candidate"]
+            .as_str()
+            .unwrap()
+            .starts_with("candidate:"));
+    }
+
+    #[test]
+    fn test_signal_empty_addresses() {
+        let signal = IceAddressSignal {
+            signal_type: "iroh-ice-addresses".to_string(),
+            addresses: vec![],
+            agent_did: "did:key:z6MkTest".to_string(),
+        };
+
+        let json = serde_json::to_value(&signal).unwrap();
+        assert!(json["addresses"].as_array().unwrap().is_empty());
+        let roundtrip: IceAddressSignal = serde_json::from_value(json).unwrap();
+        assert_eq!(roundtrip.addresses.len(), 0);
+        assert_eq!(roundtrip.signal_type, "iroh-ice-addresses");
+    }
+
+    #[tokio::test]
+    async fn test_only_broadcasts_on_change() {
+        let publisher = AddressPublisher::new(60);
+
+        let entries: HashSet<IceAddressEntry> = [IceAddressEntry {
+            address: "10.0.0.1".to_string(),
+            port: 1234,
+            candidate: "candidate:1 1 udp 100 10.0.0.1 1234 typ host".to_string(),
+        }]
+        .into_iter()
+        .collect();
+
+        *publisher.cached_addresses.lock().await = entries.clone();
+
+        // Same set => no broadcast needed
+        let cached = publisher.cached_addresses.lock().await;
+        assert_eq!(*cached, entries);
+
+        // Different set would trigger broadcast
+        let mut different = entries.clone();
+        different.insert(IceAddressEntry {
+            address: "10.0.0.2".to_string(),
+            port: 5678,
+            candidate: "candidate:2 1 udp 100 10.0.0.2 5678 typ host".to_string(),
+        });
+        assert_ne!(*cached, different);
+    }
+
+    #[test]
+    fn test_signal_roundtrip_serialization() {
+        let signal = IceAddressSignal {
+            signal_type: "iroh-ice-addresses".to_string(),
+            addresses: vec![
+                IceAddressEntry {
+                    address: "192.168.1.1".to_string(),
+                    port: 4000,
+                    candidate: "candidate:100 1 udp 2130706431 192.168.1.1 4000 typ host"
+                        .to_string(),
+                },
+                IceAddressEntry {
+                    address: "8.8.8.8".to_string(),
+                    port: 5000,
+                    candidate: "candidate:200 1 udp 1694498815 8.8.8.8 5000 typ srflx".to_string(),
+                },
+            ],
+            agent_did: "did:key:z6MkExample".to_string(),
+        };
+
+        let json_str = serde_json::to_string(&signal).unwrap();
+        let deserialized: IceAddressSignal = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(signal, deserialized);
+    }
+}

--- a/rust-executor/src/iroh_ice/demux.rs
+++ b/rust-executor/src/iroh_ice/demux.rs
@@ -1,0 +1,187 @@
+//! UDP Demultiplexer for shared Iroh socket.
+//!
+//! Classifies incoming UDP packets by first byte per RFC 9443 and tees
+//! STUN packets to an internal channel while passing all valid traffic
+//! through to Quinn/Iroh.
+
+use std::fmt;
+use std::io::{self, IoSliceMut};
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use quinn::{AsyncUdpSocket, UdpPoller};
+use tokio::sync::mpsc;
+use quinn::udp::{RecvMeta, Transmit};
+
+use super::stun_responder::StunPacket;
+
+/// Classification of a UDP packet based on its first byte (RFC 9443).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PacketClass {
+    /// STUN: first byte in [0, 3]
+    Stun,
+    /// Dropped: first byte in [4, 15] or [16, 19] (ZRTP)
+    Drop,
+    /// DTLS: first byte in [20, 63]
+    Dtls,
+    /// QUIC/RTP/RTCP: first byte in [64, 255]
+    QuicRtp,
+}
+
+/// Classify a packet by its first byte per RFC 9443.
+pub fn classify_first_byte(byte: u8) -> PacketClass {
+    match byte {
+        0..=3 => PacketClass::Stun,
+        4..=19 => PacketClass::Drop,
+        20..=63 => PacketClass::Dtls,
+        64..=255 => PacketClass::QuicRtp,
+    }
+}
+
+/// A UDP socket wrapper that demultiplexes incoming packets by protocol.
+///
+/// STUN packets (first byte 0-3) are teed to an mpsc channel AND passed through.
+/// Dropped ranges (4-19) are silently consumed.
+/// Everything else passes through unchanged.
+pub struct DemuxUdpSocket {
+    inner: Arc<dyn AsyncUdpSocket>,
+    stun_tx: mpsc::Sender<StunPacket>,
+}
+
+impl DemuxUdpSocket {
+    /// Create a new demultiplexing socket wrapper.
+    pub fn new(inner: Arc<dyn AsyncUdpSocket>, stun_tx: mpsc::Sender<StunPacket>) -> Self {
+        Self { inner, stun_tx }
+    }
+}
+
+impl fmt::Debug for DemuxUdpSocket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DemuxUdpSocket")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl AsyncUdpSocket for DemuxUdpSocket {
+    fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn UdpPoller>> {
+        self.inner.clone().create_io_poller()
+    }
+
+    fn try_send(&self, transmit: &Transmit) -> io::Result<()> {
+        self.inner.try_send(transmit)
+    }
+
+    fn poll_recv(
+        &self,
+        cx: &mut Context,
+        bufs: &mut [IoSliceMut<'_>],
+        meta: &mut [RecvMeta],
+    ) -> Poll<io::Result<usize>> {
+        let result = self.inner.poll_recv(cx, bufs, meta);
+
+        if let Poll::Ready(Ok(n)) = &result {
+            // Process each received datagram
+            for i in 0..*n {
+                let buf = &bufs[i];
+                if buf.is_empty() {
+                    continue;
+                }
+                let first_byte = buf[0];
+                let class = classify_first_byte(first_byte);
+
+                match class {
+                    PacketClass::Stun => {
+                        // Tee to STUN responder (best-effort, don't block Quinn)
+                        let data = buf[..meta[i].len].to_vec();
+                        let source = meta[i].addr;
+                        let _ = self.stun_tx.try_send(StunPacket { data, source });
+                        // Pass through to Quinn (don't modify bufs/meta)
+                    }
+                    PacketClass::Drop => {
+                        // We'd ideally remove this from the results, but Quinn's
+                        // poll_recv API makes that awkward. The dropped ranges (4-19)
+                        // won't match any valid QUIC or STUN packet, so Quinn will
+                        // discard them anyway. Pass through harmlessly.
+                    }
+                    PacketClass::Dtls | PacketClass::QuicRtp => {
+                        // Pass through unchanged
+                    }
+                }
+            }
+        }
+
+        result
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.inner.local_addr()
+    }
+
+    fn max_transmit_segments(&self) -> usize {
+        self.inner.max_transmit_segments()
+    }
+
+    fn max_receive_segments(&self) -> usize {
+        self.inner.max_receive_segments()
+    }
+
+    fn may_fragment(&self) -> bool {
+        self.inner.may_fragment()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_classify_stun_range() {
+        for b in 0..=3u8 {
+            assert_eq!(classify_first_byte(b), PacketClass::Stun, "byte {}", b);
+        }
+    }
+
+    #[test]
+    fn test_classify_drop_range() {
+        for b in 4..=19u8 {
+            assert_eq!(classify_first_byte(b), PacketClass::Drop, "byte {}", b);
+        }
+    }
+
+    #[test]
+    fn test_classify_dtls_range() {
+        for b in 20..=63u8 {
+            assert_eq!(classify_first_byte(b), PacketClass::Dtls, "byte {}", b);
+        }
+    }
+
+    #[test]
+    fn test_classify_quic_rtp_range() {
+        for b in 64..=255u8 {
+            assert_eq!(classify_first_byte(b), PacketClass::QuicRtp, "byte {}", b);
+        }
+    }
+
+    #[test]
+    fn test_stun_tee_with_channel() {
+        // Verify that creating a DemuxUdpSocket with a channel works
+        // and that try_send on a full channel doesn't panic
+        let (tx, _rx) = mpsc::channel(1);
+
+        // Fill the channel
+        let _ = tx.try_send(StunPacket {
+            data: vec![0],
+            source: "127.0.0.1:1234".parse().unwrap(),
+        });
+
+        // Another send should not panic (best-effort)
+        let result = tx.try_send(StunPacket {
+            data: vec![0],
+            source: "127.0.0.1:1234".parse().unwrap(),
+        });
+        assert!(result.is_err()); // Channel full, but no panic
+    }
+}

--- a/rust-executor/src/iroh_ice/mod.rs
+++ b/rust-executor/src/iroh_ice/mod.rs
@@ -3,6 +3,10 @@
 //! Provides ICE candidates derived from Holochain/Iroh transport peer URLs,
 //! replacing the need for external STUN/TURN servers.
 
+pub mod demux;
+pub mod stun_responder;
+
+
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
@@ -109,4 +113,21 @@ mod tests {
         let candidates = candidates_from_urls(&urls);
         assert!(candidates.is_empty());
     }
+}
+
+/// Handle to a running STUN responder, holding the channel sender
+/// for the demuxer to tee STUN packets into.
+pub struct StunHandle {
+    /// Send STUN packets here from the demuxer.
+    pub stun_tx: tokio::sync::mpsc::Sender<stun_responder::StunPacket>,
+    /// Receive STUN responses to send back over the network.
+    pub response_rx: tokio::sync::mpsc::Receiver<stun_responder::StunResponse>,
+}
+
+/// Start a STUN responder task and return handles for the demuxer.
+pub fn start_stun_responder(channel_size: usize) -> StunHandle {
+    let (stun_tx, stun_rx) = tokio::sync::mpsc::channel(channel_size);
+    let (response_tx, response_rx) = tokio::sync::mpsc::channel(channel_size);
+    tokio::spawn(stun_responder::run_stun_responder(stun_rx, response_tx));
+    StunHandle { stun_tx, response_rx }
 }

--- a/rust-executor/src/iroh_ice/mod.rs
+++ b/rust-executor/src/iroh_ice/mod.rs
@@ -1,0 +1,112 @@
+//! Iroh-to-ICE bridge for AD4M WebRTC connections.
+//!
+//! Provides ICE candidates derived from Holochain/Iroh transport peer URLs,
+//! replacing the need for external STUN/TURN servers.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+/// ICE candidate info used by the executor.
+#[derive(Debug, Clone)]
+pub struct IceCandidate {
+    pub candidate: String,
+    pub candidate_type: String,
+    pub address: String,
+    pub port: u16,
+}
+
+/// Parse a peer URL to extract host and port.
+fn parse_url_addr(url_str: &str) -> Option<(String, u16)> {
+    if let Ok(parsed) = url::Url::parse(url_str) {
+        if let Some(host) = parsed.host_str() {
+            let port = parsed.port_or_known_default().unwrap_or(443);
+            return Some((host.to_string(), port));
+        }
+    }
+    if let Ok(addr) = url_str.parse::<std::net::SocketAddr>() {
+        return Some((addr.ip().to_string(), addr.port()));
+    }
+    None
+}
+
+/// Determine candidate type from address string.
+fn candidate_type_for(addr: &str) -> &'static str {
+    if let Ok(ip) = addr.parse::<std::net::IpAddr>() {
+        match ip {
+            std::net::IpAddr::V4(v4) if v4.is_loopback() || v4.is_private() => "host",
+            std::net::IpAddr::V6(v6) if v6.is_loopback() => "host",
+            _ => "srflx",
+        }
+    } else {
+        "srflx"
+    }
+}
+
+/// Convert peer URL strings into ICE candidate representations.
+pub fn candidates_from_urls(urls: &[String]) -> Vec<IceCandidate> {
+    urls.iter()
+        .enumerate()
+        .filter_map(|(i, url)| {
+            let (host, port) = parse_url_addr(url)?;
+            let ctype = candidate_type_for(&host);
+
+            let mut hasher = DefaultHasher::new();
+            url.hash(&mut hasher);
+            let foundation = hasher.finish() % 10000;
+
+            let priority = if ctype == "host" {
+                2130706431u32.saturating_sub(i as u32)
+            } else {
+                1694498815u32.saturating_sub(i as u32)
+            };
+
+            let candidate_str = format!(
+                "candidate:{} 1 udp {} {} {} typ {}",
+                foundation, priority, host, port, ctype
+            );
+
+            Some(IceCandidate {
+                candidate: candidate_str,
+                candidate_type: ctype.to_string(),
+                address: host,
+                port,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_candidates_from_urls_empty() {
+        let result = candidates_from_urls(&[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_candidates_from_urls_wss() {
+        let urls = vec!["wss://192.168.1.1:4000".to_string()];
+        let candidates = candidates_from_urls(&urls);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].candidate_type, "host");
+        assert_eq!(candidates[0].address, "192.168.1.1");
+        assert_eq!(candidates[0].port, 4000);
+        assert!(candidates[0].candidate.contains("typ host"));
+    }
+
+    #[test]
+    fn test_candidates_from_urls_public() {
+        let urls = vec!["wss://8.8.8.8:5000".to_string()];
+        let candidates = candidates_from_urls(&urls);
+        assert_eq!(candidates[0].candidate_type, "srflx");
+    }
+
+    #[test]
+    fn test_candidates_from_urls_unparseable() {
+        let urls = vec!["not-a-url".to_string()];
+        let candidates = candidates_from_urls(&urls);
+        assert!(candidates.is_empty());
+    }
+}

--- a/rust-executor/src/iroh_ice/mod.rs
+++ b/rust-executor/src/iroh_ice/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod demux;
 pub mod stun_responder;
+pub mod address_publisher;
 
 
 use std::collections::hash_map::DefaultHasher;

--- a/rust-executor/src/iroh_ice/stun_responder.rs
+++ b/rust-executor/src/iroh_ice/stun_responder.rs
@@ -1,0 +1,399 @@
+//! Minimal RFC 5389 STUN Binding Request/Response handler.
+//!
+//! Handles only STUN Binding Requests and responds with XOR-MAPPED-ADDRESS.
+//! Designed to run as an async task, receiving packets via mpsc channel.
+
+use std::net::SocketAddr;
+use tokio::sync::mpsc;
+
+/// STUN magic cookie (RFC 5389 §6)
+const MAGIC_COOKIE: u32 = 0x2112_A442;
+
+/// STUN message types
+const BINDING_REQUEST: u16 = 0x0001;
+const BINDING_RESPONSE: u16 = 0x0101;
+
+/// STUN attribute types
+const ATTR_XOR_MAPPED_ADDRESS: u16 = 0x0020;
+
+/// Address family constants
+const FAMILY_IPV4: u8 = 0x01;
+const FAMILY_IPV6: u8 = 0x02;
+
+/// STUN header size
+const STUN_HEADER_SIZE: usize = 20;
+
+/// A STUN packet received from the demuxer, tagged with its source address.
+#[derive(Debug, Clone)]
+pub struct StunPacket {
+    pub data: Vec<u8>,
+    pub source: SocketAddr,
+}
+
+/// A STUN response to be sent back.
+#[derive(Debug, Clone)]
+pub struct StunResponse {
+    pub data: Vec<u8>,
+    pub dest: SocketAddr,
+}
+
+/// Parsed STUN message header.
+#[derive(Debug, Clone)]
+struct StunHeader {
+    msg_type: u16,
+    #[allow(dead_code)]
+    msg_length: u16,
+    transaction_id: [u8; 12],
+}
+
+/// Parse a STUN message header from raw bytes.
+///
+/// Returns `None` if the packet is too short, has wrong magic cookie, or
+/// the top two bits are not zero (per RFC 5389 §6).
+pub fn parse_stun_header(data: &[u8]) -> Option<StunHeader> {
+    if data.len() < STUN_HEADER_SIZE {
+        return None;
+    }
+
+    // Top two bits of first byte must be 0
+    if data[0] & 0xC0 != 0 {
+        return None;
+    }
+
+    let msg_type = u16::from_be_bytes([data[0], data[1]]);
+    let msg_length = u16::from_be_bytes([data[2], data[3]]);
+    let cookie = u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
+
+    if cookie != MAGIC_COOKIE {
+        return None;
+    }
+
+    let mut transaction_id = [0u8; 12];
+    transaction_id.copy_from_slice(&data[8..20]);
+
+    Some(StunHeader {
+        msg_type,
+        msg_length,
+        transaction_id,
+    })
+}
+
+/// Build a XOR-MAPPED-ADDRESS attribute for the given address.
+///
+/// Per RFC 5389 §15.2:
+/// - Port is XORed with top 16 bits of magic cookie
+/// - IPv4 address is XORed with magic cookie
+/// - IPv6 address is XORed with magic cookie + transaction ID (16 bytes)
+pub fn build_xor_mapped_address(addr: &SocketAddr, transaction_id: &[u8; 12]) -> Vec<u8> {
+    let cookie_bytes = MAGIC_COOKIE.to_be_bytes();
+    let xored_port = (addr.port() ^ (MAGIC_COOKIE >> 16) as u16).to_be_bytes();
+
+    match addr {
+        SocketAddr::V4(v4) => {
+            let ip_bytes = v4.ip().octets();
+            let xored_ip = [
+                ip_bytes[0] ^ cookie_bytes[0],
+                ip_bytes[1] ^ cookie_bytes[1],
+                ip_bytes[2] ^ cookie_bytes[2],
+                ip_bytes[3] ^ cookie_bytes[3],
+            ];
+
+            // Attribute: type (2) + length (2) + reserved (1) + family (1) + port (2) + addr (4) = 12
+            let mut attr = Vec::with_capacity(12);
+            attr.extend_from_slice(&ATTR_XOR_MAPPED_ADDRESS.to_be_bytes());
+            attr.extend_from_slice(&8u16.to_be_bytes()); // value length
+            attr.push(0x00); // reserved
+            attr.push(FAMILY_IPV4);
+            attr.extend_from_slice(&xored_port);
+            attr.extend_from_slice(&xored_ip);
+            attr
+        }
+        SocketAddr::V6(v6) => {
+            let ip_bytes = v6.ip().octets();
+            // XOR with magic cookie (4 bytes) + transaction ID (12 bytes) = 16 bytes
+            let mut xor_key = [0u8; 16];
+            xor_key[..4].copy_from_slice(&cookie_bytes);
+            xor_key[4..16].copy_from_slice(transaction_id);
+
+            let mut xored_ip = [0u8; 16];
+            for i in 0..16 {
+                xored_ip[i] = ip_bytes[i] ^ xor_key[i];
+            }
+
+            // Attribute: type (2) + length (2) + reserved (1) + family (1) + port (2) + addr (16) = 24
+            let mut attr = Vec::with_capacity(24);
+            attr.extend_from_slice(&ATTR_XOR_MAPPED_ADDRESS.to_be_bytes());
+            attr.extend_from_slice(&20u16.to_be_bytes()); // value length
+            attr.push(0x00); // reserved
+            attr.push(FAMILY_IPV6);
+            attr.extend_from_slice(&xored_port);
+            attr.extend_from_slice(&xored_ip);
+            attr
+        }
+    }
+}
+
+/// Build a complete STUN Binding Response for a given request.
+///
+/// Returns `None` if the request isn't a valid STUN Binding Request.
+pub fn build_binding_response(request: &[u8], source_addr: &SocketAddr) -> Option<Vec<u8>> {
+    let header = parse_stun_header(request)?;
+
+    if header.msg_type != BINDING_REQUEST {
+        return None;
+    }
+
+    let xma = build_xor_mapped_address(source_addr, &header.transaction_id);
+    
+    let msg_len = xma.len() as u16;
+
+    let mut response = Vec::with_capacity(STUN_HEADER_SIZE + xma.len());
+    // Header
+    response.extend_from_slice(&BINDING_RESPONSE.to_be_bytes());
+    response.extend_from_slice(&msg_len.to_be_bytes());
+    response.extend_from_slice(&MAGIC_COOKIE.to_be_bytes());
+    response.extend_from_slice(&header.transaction_id);
+    // Attribute
+    response.extend_from_slice(&xma);
+
+    Some(response)
+}
+
+/// Run the STUN responder task.
+///
+/// Reads STUN packets from `rx`, processes Binding Requests, and sends
+/// responses to `response_tx`.
+pub async fn run_stun_responder(
+    mut rx: mpsc::Receiver<StunPacket>,
+    response_tx: mpsc::Sender<StunResponse>,
+) {
+    while let Some(pkt) = rx.recv().await {
+        if let Some(response_data) = build_binding_response(&pkt.data, &pkt.source) {
+            let resp = StunResponse {
+                data: response_data,
+                dest: pkt.source,
+            };
+            // Best-effort send; if the response channel is full, drop
+            let _ = response_tx.try_send(resp);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
+
+    /// Helper: build a minimal STUN Binding Request with a given transaction ID.
+    fn make_binding_request(transaction_id: &[u8; 12]) -> Vec<u8> {
+        let mut pkt = Vec::with_capacity(20);
+        pkt.extend_from_slice(&BINDING_REQUEST.to_be_bytes());
+        pkt.extend_from_slice(&0u16.to_be_bytes()); // length = 0 (no attributes)
+        pkt.extend_from_slice(&MAGIC_COOKIE.to_be_bytes());
+        pkt.extend_from_slice(transaction_id);
+        pkt
+    }
+
+    #[test]
+    fn test_parse_valid_binding_request() {
+        let tid = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        let pkt = make_binding_request(&tid);
+        let header = parse_stun_header(&pkt).unwrap();
+        assert_eq!(header.msg_type, BINDING_REQUEST);
+        assert_eq!(header.transaction_id, tid);
+        assert_eq!(header.msg_length, 0);
+    }
+
+    #[test]
+    fn test_parse_truncated_packet() {
+        assert!(parse_stun_header(&[0; 10]).is_none());
+        assert!(parse_stun_header(&[]).is_none());
+    }
+
+    #[test]
+    fn test_parse_wrong_magic_cookie() {
+        let mut pkt = make_binding_request(&[0; 12]);
+        // Corrupt the magic cookie
+        pkt[4] = 0xFF;
+        assert!(parse_stun_header(&pkt).is_none());
+    }
+
+    #[test]
+    fn test_parse_top_bits_set() {
+        let mut pkt = make_binding_request(&[0; 12]);
+        pkt[0] |= 0x80; // set top bit
+        assert!(parse_stun_header(&pkt).is_none());
+    }
+
+    #[test]
+    fn test_binding_response_ipv4() {
+        let tid = [0xAA, 0xBB, 0xCC, 0xDD, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
+        let request = make_binding_request(&tid);
+        let source = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 1, 100), 12345));
+        let response = build_binding_response(&request, &source).unwrap();
+
+        // Verify response header
+        let resp_type = u16::from_be_bytes([response[0], response[1]]);
+        assert_eq!(resp_type, BINDING_RESPONSE);
+
+        let resp_cookie = u32::from_be_bytes([response[4], response[5], response[6], response[7]]);
+        assert_eq!(resp_cookie, MAGIC_COOKIE);
+
+        // Verify transaction ID echoed
+        assert_eq!(&response[8..20], &tid);
+
+        // Verify XOR-MAPPED-ADDRESS attribute
+        let attr_type = u16::from_be_bytes([response[20], response[21]]);
+        assert_eq!(attr_type, ATTR_XOR_MAPPED_ADDRESS);
+
+        // Verify family
+        assert_eq!(response[25], FAMILY_IPV4);
+
+        // Decode XOR'd port
+        let xored_port = u16::from_be_bytes([response[26], response[27]]);
+        let port = xored_port ^ (MAGIC_COOKIE >> 16) as u16;
+        assert_eq!(port, 12345);
+
+        // Decode XOR'd address
+        let cookie = MAGIC_COOKIE.to_be_bytes();
+        let ip = Ipv4Addr::new(
+            response[28] ^ cookie[0],
+            response[29] ^ cookie[1],
+            response[30] ^ cookie[2],
+            response[31] ^ cookie[3],
+        );
+        assert_eq!(ip, Ipv4Addr::new(192, 168, 1, 100));
+    }
+
+    #[test]
+    fn test_binding_response_ipv6() {
+        let tid = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C];
+        let request = make_binding_request(&tid);
+        let ipv6 = Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 1);
+        let source = SocketAddr::V6(SocketAddrV6::new(ipv6, 9999, 0, 0));
+        let response = build_binding_response(&request, &source).unwrap();
+
+        // Verify family
+        assert_eq!(response[25], FAMILY_IPV6);
+
+        // Decode XOR'd port
+        let xored_port = u16::from_be_bytes([response[26], response[27]]);
+        let port = xored_port ^ (MAGIC_COOKIE >> 16) as u16;
+        assert_eq!(port, 9999);
+
+        // Decode XOR'd IPv6 address
+        let cookie = MAGIC_COOKIE.to_be_bytes();
+        let mut xor_key = [0u8; 16];
+        xor_key[..4].copy_from_slice(&cookie);
+        xor_key[4..16].copy_from_slice(&tid);
+
+        let mut decoded_ip = [0u8; 16];
+        for i in 0..16 {
+            decoded_ip[i] = response[28 + i] ^ xor_key[i];
+        }
+        let decoded_addr = Ipv6Addr::from(decoded_ip);
+        assert_eq!(decoded_addr, ipv6);
+    }
+
+    #[test]
+    fn test_reject_non_binding_request() {
+        let tid = [0; 12];
+        // Build a STUN Indication (type 0x0011) instead of Binding Request
+        let mut pkt = Vec::with_capacity(20);
+        pkt.extend_from_slice(&0x0011u16.to_be_bytes());
+        pkt.extend_from_slice(&0u16.to_be_bytes());
+        pkt.extend_from_slice(&MAGIC_COOKIE.to_be_bytes());
+        pkt.extend_from_slice(&tid);
+
+        let source = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1234));
+        assert!(build_binding_response(&pkt, &source).is_none());
+    }
+
+    #[test]
+    fn test_malformed_packet_doesnt_crash() {
+        let source = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1234));
+        // Various malformed inputs
+        assert!(build_binding_response(&[], &source).is_none());
+        assert!(build_binding_response(&[0xFF; 5], &source).is_none());
+        assert!(build_binding_response(&[0; 19], &source).is_none());
+        // Valid length but wrong cookie
+        assert!(build_binding_response(&[0; 20], &source).is_none());
+    }
+
+    #[test]
+    fn test_transaction_id_echo() {
+        let tid = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE, 0x12, 0x34, 0x56, 0x78];
+        let request = make_binding_request(&tid);
+        let source = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 5000));
+        let response = build_binding_response(&request, &source).unwrap();
+        assert_eq!(&response[8..20], &tid);
+    }
+
+    #[tokio::test]
+    async fn test_stun_responder_roundtrip() {
+        let (stun_tx, stun_rx) = mpsc::channel(16);
+        let (resp_tx, mut resp_rx) = mpsc::channel(16);
+
+        tokio::spawn(run_stun_responder(stun_rx, resp_tx));
+
+        let tid = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        let request = make_binding_request(&tid);
+        let source = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(203, 0, 113, 50), 54321));
+
+        stun_tx
+            .send(StunPacket {
+                data: request,
+                source,
+            })
+            .await
+            .unwrap();
+
+        let resp = resp_rx.recv().await.unwrap();
+        assert_eq!(resp.dest, source);
+
+        // Verify it's a valid Binding Response
+        let header = parse_stun_header(&resp.data).unwrap();
+        assert_eq!(header.msg_type, BINDING_RESPONSE);
+        assert_eq!(header.transaction_id, tid);
+    }
+
+    #[tokio::test]
+    async fn test_stun_responder_ignores_non_binding() {
+        let (stun_tx, stun_rx) = mpsc::channel(16);
+        let (resp_tx, mut resp_rx) = mpsc::channel(16);
+
+        tokio::spawn(run_stun_responder(stun_rx, resp_tx));
+
+        // Send a non-binding STUN message
+        let mut pkt = Vec::with_capacity(20);
+        pkt.extend_from_slice(&0x0011u16.to_be_bytes()); // Indication
+        pkt.extend_from_slice(&0u16.to_be_bytes());
+        pkt.extend_from_slice(&MAGIC_COOKIE.to_be_bytes());
+        pkt.extend_from_slice(&[0u8; 12]);
+
+        let source = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1234));
+        stun_tx
+            .send(StunPacket {
+                data: pkt,
+                source,
+            })
+            .await
+            .unwrap();
+
+        // Then send a valid one to prove the responder is still running
+        let tid = [0xFF; 12];
+        let valid_request = make_binding_request(&tid);
+        stun_tx
+            .send(StunPacket {
+                data: valid_request,
+                source,
+            })
+            .await
+            .unwrap();
+
+        let resp = resp_rx.recv().await.unwrap();
+        let header = parse_stun_header(&resp.data).unwrap();
+        assert_eq!(header.msg_type, BINDING_RESPONSE);
+        assert_eq!(header.transaction_id, tid);
+    }
+}

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -30,6 +30,7 @@ use rustls::crypto::aws_lc_rs;
 #[cfg(test)]
 mod test_utils;
 pub mod types;
+pub mod iroh_ice;
 
 use std::thread::JoinHandle;
 


### PR DESCRIPTION
## Summary

Adds the `iroh-ice` module to the executor, providing sovereign NAT traversal for WebRTC by leveraging Iroh's existing transport infrastructure. Eliminates dependency on external STUN/TURN servers.

### What's included

**Core module (`rust-executor/src/iroh_ice/`):**
- `mod.rs`: ICE candidate extraction from transport peer URLs (RFC 8445 format)
- `stun_responder.rs`: Minimal RFC 5389 STUN Binding Request/Response handler with XOR-MAPPED-ADDRESS encoding for IPv4/IPv6
- `demux.rs`: UDP demultiplexer implementing RFC 9443 first-byte classification — routes STUN/DTLS/QUIC/RTP to appropriate handlers on a shared socket
- `address_publisher.rs`: Broadcasts discovered ICE addresses to neighbourhoods, change-detection to avoid redundant broadcasts

**GraphQL API:**
- `runtimeIceCandidates` query with `RUNTIME_HC_AGENT_INFO_READ_CAPABILITY` check
- `IceCandidateInfo` type: `candidate`, `candidateType`, `address`, `port`
- `no-cache` fetch policy (ICE candidates are ephemeral network state)

**TypeScript client:**
- `RuntimeClient.iceCandidates()` method
- `IceCandidateInfo` type in `RuntimeResolver.ts`

**Holochain service plumbing:**
- `LocalSocketAddrs` request/response variants in `HolochainServiceInterface`
- Channel-based conductor access pattern (consistent with existing `AgentInfos`, etc.)
- Handler currently returns empty vec — populates once holochain bumps its kitsune2 dep

### Architecture

The design uses **shared UDP socket demultiplexing** (RFC 9443): WebRTC traffic shares Iroh's UDP socket so Iroh's NAT mapping serves WebRTC. The demuxer classifies by first byte:
- `[0..3]` → STUN responder
- `[20..63]` → DTLS/str0m
- `[64..255]` → QUIC/Iroh + RTP/RTCP

**Socket interception** (wiring the demuxer into Iroh's actual socket) requires a follow-up PR to kitsune2 adding a `socket_factory` hook to the transport builder. The demuxer and STUN responder are ready and tested.

### Tests

24 unit tests covering STUN parsing/encoding, demux classification, address publishing, and candidate formatting.

### Dependencies

- Depends on: https://github.com/coasys/holochain/pull/2 (holochain HcP2p surface)
- Depends on: https://github.com/holochain/kitsune2/pull/478 (kitsune2 Transport trait)

Closes: https://github.com/coasys/ad4m/issues/719 (partially — socket interception is follow-up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ICE (Interactive Connectivity Establishment) candidate discovery for peer-to-peer connections
  * Added automatic address publishing to improve network connectivity
  * Implemented STUN responder to enhance WebRTC connectivity reliability
  * Improved UDP packet handling for better network performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->