### PR TITLE
feat: add hosting GraphQL contract (HostingUserInfo, PaymentRequestResult)

### DIFF
--- a/core/src/agent/AgentClient.ts
+++ b/core/src/agent/AgentClient.ts
@@ -10,6 +10,7 @@ import {
   EntanglementProofInput,
   UserCreationResult,
 } from "./Agent";
+import { HostingUserInfo, PaymentRequestResult } from "../runtime/RuntimeResolver";
 import { AgentStatus } from "./AgentStatus";
 import { LinkMutations } from "../links/Links";
 import { PerspectiveClient } from "../perspectives/PerspectiveClient";
@@ -587,5 +588,49 @@ export class AgentClient {
       })
     );
     return runtimeVerifyEmailCode;
+  }
+
+  // Hosting methods
+
+  async hostingUserInfo(): Promise<HostingUserInfo> {
+    const { runtimeHostingUserInfo } = unwrapApolloResult(
+      await this.#apolloClient.query({
+        query: gql`query runtimeHostingUserInfo {
+          runtimeHostingUserInfo {
+            email
+            remainingCredits
+            hotWalletAddress
+          }
+        }`,
+      })
+    );
+    return runtimeHostingUserInfo;
+  }
+
+  async setHotWalletAddress(address: string): Promise<boolean> {
+    const { runtimeSetHotWalletAddress } = unwrapApolloResult(
+      await this.#apolloClient.mutate({
+        mutation: gql`mutation runtimeSetHotWalletAddress($address: String!) {
+          runtimeSetHotWalletAddress(address: $address)
+        }`,
+        variables: { address },
+      })
+    );
+    return runtimeSetHotWalletAddress;
+  }
+
+  async requestPayment(amountHOT: number): Promise<PaymentRequestResult> {
+    const { runtimeRequestPayment } = unwrapApolloResult(
+      await this.#apolloClient.mutate({
+        mutation: gql`mutation runtimeRequestPayment($amountHOT: Float!) {
+          runtimeRequestPayment(amountHOT: $amountHOT) {
+            success
+            message
+          }
+        }`,
+        variables: { amountHOT },
+      })
+    );
+    return runtimeRequestPayment;
   }
 }

--- a/core/src/agent/AgentClient.ts
+++ b/core/src/agent/AgentClient.ts
@@ -619,10 +619,10 @@ export class AgentClient {
     return runtimeSetHotWalletAddress;
   }
 
-  async requestPayment(amountHOT: number): Promise<PaymentRequestResult> {
+  async requestPayment(amountHOT: string): Promise<PaymentRequestResult> {
     const { runtimeRequestPayment } = unwrapApolloResult(
       await this.#apolloClient.mutate({
-        mutation: gql`mutation runtimeRequestPayment($amountHOT: Float!) {
+        mutation: gql`mutation runtimeRequestPayment($amountHOT: String!) {
           runtimeRequestPayment(amountHOT: $amountHOT) {
             success
             message

--- a/core/src/runtime/RuntimeResolver.ts
+++ b/core/src/runtime/RuntimeResolver.ts
@@ -223,6 +223,38 @@ export class VerificationRequestResult {
     isExistingUser: boolean;
 }
 
+@ObjectType()
+export class HostingUserInfo {
+    @Field()
+    email: string;
+
+    @Field()
+    remainingCredits: number;
+
+    @Field({ nullable: true })
+    hotWalletAddress?: string;
+
+    constructor(email: string, remainingCredits: number, hotWalletAddress?: string) {
+        this.email = email;
+        this.remainingCredits = remainingCredits;
+        this.hotWalletAddress = hotWalletAddress;
+    }
+}
+
+@ObjectType()
+export class PaymentRequestResult {
+    @Field()
+    success: boolean;
+
+    @Field()
+    message: string;
+
+    constructor(success: boolean, message: string) {
+        this.success = success;
+        this.message = message;
+    }
+}
+
 /**
  * Resolver classes are used here to define the GraphQL schema 
  * (through the type-graphql annotations)
@@ -559,6 +591,27 @@ export default class RuntimeResolver {
     ): boolean {
         // For testing: simulate setting expiry (no-op in mock)
         return true
+    }
+
+    // Hosting mutations & queries
+
+    @Query(returns => HostingUserInfo)
+    runtimeHostingUserInfo(): HostingUserInfo {
+        return new HostingUserInfo("test@example.com", 100.0, null)
+    }
+
+    @Mutation(returns => Boolean)
+    runtimeSetHotWalletAddress(
+        @Arg("address") address: string
+    ): boolean {
+        return true
+    }
+
+    @Mutation(returns => PaymentRequestResult)
+    runtimeRequestPayment(
+        @Arg("amountHOT") amountHOT: number
+    ): PaymentRequestResult {
+        return new PaymentRequestResult(true, "Mock payment of " + amountHOT + " HOT credited")
     }
 }
 

--- a/core/src/runtime/RuntimeResolver.ts
+++ b/core/src/runtime/RuntimeResolver.ts
@@ -229,12 +229,12 @@ export class HostingUserInfo {
     email: string;
 
     @Field()
-    remainingCredits: number;
+    remainingCredits: string;
 
     @Field({ nullable: true })
     hotWalletAddress?: string;
 
-    constructor(email: string, remainingCredits: number, hotWalletAddress?: string) {
+    constructor(email: string, remainingCredits: string, hotWalletAddress?: string) {
         this.email = email;
         this.remainingCredits = remainingCredits;
         this.hotWalletAddress = hotWalletAddress;
@@ -597,7 +597,7 @@ export default class RuntimeResolver {
 
     @Query(returns => HostingUserInfo)
     runtimeHostingUserInfo(): HostingUserInfo {
-        return new HostingUserInfo("test@example.com", 100.0, null)
+        return new HostingUserInfo("test@example.com", "100000000", null)
     }
 
     @Mutation(returns => Boolean)
@@ -609,9 +609,9 @@ export default class RuntimeResolver {
 
     @Mutation(returns => PaymentRequestResult)
     runtimeRequestPayment(
-        @Arg("amountHOT") amountHOT: number
+        @Arg("amountHOT") amountHOT: string
     ): PaymentRequestResult {
-        return new PaymentRequestResult(true, "Mock payment of " + amountHOT + " HOT credited")
+        return new PaymentRequestResult(true, "Mock payment of " + amountHOT + " base units credited")
     }
 }
 

--- a/rust-executor/src/graphql/graphql_types.rs
+++ b/rust-executor/src/graphql/graphql_types.rs
@@ -697,6 +697,21 @@ pub struct VerificationRequestResult {
     pub is_existing_user: bool,
 }
 
+#[derive(GraphQLObject, Default, Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HostingUserInfo {
+    pub email: String,
+    pub remaining_credits: f64,
+    pub hot_wallet_address: Option<String>,
+}
+
+#[derive(GraphQLObject, Default, Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PaymentRequestResult {
+    pub success: bool,
+    pub message: String,
+}
+
 #[derive(Default, Debug, Deserialize, Serialize)]
 pub struct NeighbourhoodSignalFilter {
     pub perspective: PerspectiveHandle,

--- a/rust-executor/src/graphql/graphql_types.rs
+++ b/rust-executor/src/graphql/graphql_types.rs
@@ -701,7 +701,7 @@ pub struct VerificationRequestResult {
 #[serde(rename_all = "camelCase")]
 pub struct HostingUserInfo {
     pub email: String,
-    pub remaining_credits: f64,
+    pub remaining_credits: String,
     pub hot_wallet_address: Option<String>,
 }
 

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -2994,7 +2994,7 @@ impl Mutation {
     async fn runtime_request_payment(
         &self,
         _context: &RequestContext,
-        _amount_hot: f64,
+        _amount_hot: String,
     ) -> FieldResult<PaymentRequestResult> {
         // TODO: implement actual payment request via Unit
         Err(FieldError::new(

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -2982,8 +2982,9 @@ impl Mutation {
     async fn runtime_set_hot_wallet_address(
         &self,
         _context: &RequestContext,
-        _address: String,
+        address: String,
     ) -> FieldResult<bool> {
+        let _ = address;
         // TODO: implement actual hot wallet address storage
         Err(FieldError::new(
             "Set hot wallet address not yet implemented",
@@ -2994,8 +2995,9 @@ impl Mutation {
     async fn runtime_request_payment(
         &self,
         _context: &RequestContext,
-        _amount_hot: String,
+        #[allow(non_snake_case)] amountHOT: String,
     ) -> FieldResult<PaymentRequestResult> {
+        let _ = amountHOT;
         // TODO: implement actual payment request via Unit
         Err(FieldError::new(
             "Request payment not yet implemented",

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -2981,9 +2981,10 @@ impl Mutation {
 
     async fn runtime_set_hot_wallet_address(
         &self,
-        _context: &RequestContext,
+        context: &RequestContext,
         address: String,
     ) -> FieldResult<bool> {
+        check_capability(&context.capabilities, &AGENT_READ_CAPABILITY)?;
         let _ = address;
         // TODO: implement actual hot wallet address storage
         Err(FieldError::new(
@@ -2994,9 +2995,10 @@ impl Mutation {
 
     async fn runtime_request_payment(
         &self,
-        _context: &RequestContext,
+        context: &RequestContext,
         #[allow(non_snake_case)] amountHOT: String,
     ) -> FieldResult<PaymentRequestResult> {
+        check_capability(&context.capabilities, &AGENT_READ_CAPABILITY)?;
         let _ = amountHOT;
         // TODO: implement actual payment request via Unit
         Err(FieldError::new(

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -2978,4 +2978,28 @@ impl Mutation {
 
         Ok(true)
     }
+
+    async fn runtime_set_hot_wallet_address(
+        &self,
+        _context: &RequestContext,
+        _address: String,
+    ) -> FieldResult<bool> {
+        // TODO: implement actual hot wallet address storage
+        Err(FieldError::new(
+            "Set hot wallet address not yet implemented",
+            Value::null(),
+        ))
+    }
+
+    async fn runtime_request_payment(
+        &self,
+        _context: &RequestContext,
+        _amount_hot: f64,
+    ) -> FieldResult<PaymentRequestResult> {
+        // TODO: implement actual payment request via Unit
+        Err(FieldError::new(
+            "Request payment not yet implemented",
+            Value::null(),
+        ))
+    }
 }

--- a/rust-executor/src/graphql/query_resolvers.rs
+++ b/rust-executor/src/graphql/query_resolvers.rs
@@ -940,6 +940,17 @@ impl Query {
         Ok(user_stats)
     }
 
+    async fn runtime_hosting_user_info(
+        &self,
+        _context: &RequestContext,
+    ) -> FieldResult<HostingUserInfo> {
+        // TODO: implement actual hosting user info lookup
+        Err(FieldError::new(
+            "Hosting user info not yet implemented",
+            Value::null(),
+        ))
+    }
+
     async fn ai_get_models(&self, context: &RequestContext) -> FieldResult<Vec<Model>> {
         check_capability(&context.capabilities, &AGENT_READ_CAPABILITY)?;
         let models_result = Ad4mDb::with_global_instance(|db| db.get_models());

--- a/rust-executor/src/graphql/query_resolvers.rs
+++ b/rust-executor/src/graphql/query_resolvers.rs
@@ -942,8 +942,9 @@ impl Query {
 
     async fn runtime_hosting_user_info(
         &self,
-        _context: &RequestContext,
+        context: &RequestContext,
     ) -> FieldResult<HostingUserInfo> {
+        check_capability(&context.capabilities, &AGENT_READ_CAPABILITY)?;
         // TODO: implement actual hosting user info lookup
         Err(FieldError::new(
             "Hosting user info not yet implemented",


### PR DESCRIPTION
# feat: add hosting GraphQL contract (HostingUserInfo, PaymentRequestResult)

## Summary

Adds the GraphQL contract (types, queries, mutations) for the mHOT remote hosting payment flow. Both the TypeScript and Rust sides have stub implementations so that front-end (ad4m-connect UI) and back-end (executor logic) work can proceed in parallel.

## Motivation

Remote hosting lets users run an AD4M executor on a managed server and pay with HOT/mHOT tokens. This PR defines the interface between ad4m-connect (client) and the executor (host) — the three endpoints a hosted user needs:

1. **Check account status** — remaining credits, linked wallet
2. **Link a hot wallet** — so the executor knows where to request payment from
3. **Request a top-up** — trigger a payment flow to add credits

## New Types

### `HostingUserInfo`
| Field | Type | Description |
|-------|------|-------------|
| `email` | `String!` | Authenticated user's email |
| `remainingCredits` | `Float!` | Credit balance (denominated in HOT) |
| `hotWalletAddress` | `String` | User's linked hot wallet address (nullable) |

### `PaymentRequestResult`
| Field | Type | Description |
|-------|------|-------------|
| `success` | `Boolean!` | Whether the payment request was accepted |
| `message` | `String!` | Human-readable status message |

## New Query

```graphql
runtimeHostingUserInfo: HostingUserInfo!
```

Returns the authenticated user's hosting account info (credits, wallet).

## New Mutations

```graphql
runtimeSetHotWalletAddress(address: String!): Boolean!
runtimeRequestPayment(amountHOT: Float!): PaymentRequestResult!
```

- `runtimeSetHotWalletAddress` — persists the user's hot wallet address
- `runtimeRequestPayment` — initiates a payment request for the given HOT amount

## Files Changed

| File | Changes |
|------|---------|
| `core/src/runtime/RuntimeResolver.ts` | `HostingUserInfo` + `PaymentRequestResult` `@ObjectType` classes; 3 resolver stubs for schema generation |
| `core/src/agent/AgentClient.ts` | `hostingUserInfo()`, `setHotWalletAddress()`, `requestPayment()` client methods |
| `rust-executor/src/graphql/graphql_types.rs` | `HostingUserInfo` + `PaymentRequestResult` Rust structs |
| `rust-executor/src/graphql/query_resolvers.rs` | `runtime_hosting_user_info` query stub |
| `rust-executor/src/graphql/mutation_resolvers.rs` | `runtime_set_hot_wallet_address` + `runtime_request_payment` mutation stubs |

## Stub Behavior

- **TypeScript stubs** return mock data (used only for schema generation and client tests)
- **Rust stubs** return `Err("not yet implemented")` — safe to merge, will be filled in when the executor-side hosting logic lands

## How ad4m-connect Will Use These

```ts
const info = await ad4mClient.agent.hostingUserInfo();
await ad4mClient.agent.setHotWalletAddress("holo1abc...");
const result = await ad4mClient.agent.requestPayment(50.0);
```

All calls go through the existing GraphQL WebSocket — no new REST endpoints needed.

## Verification

- `tsc --noEmit` — zero errors
- `cargo check -p ad4m-executor` — compiles cleanly (zero new warnings)
- Generated `schema.gql` includes all new types and operations

## What Comes Next

| Step | Owner | Depends on |
|------|-------|------------|
| ad4m-connect hosting UI views | James | This PR |
| Central index API (`GET /hosts`) | James | Independent |
| Real `runtime_hosting_user_info` (DB-backed) | Nico | This PR |
| Real `runtime_request_payment` (Unit DNA) | Nico | This PR |
| Credit-depleted check in `mod.rs` | Nico | Real hosting user info |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added hosting user information endpoint to view email, remaining credits, and wallet address.
  - Added ability to set a hot wallet address.
  - Added payment request operation to initiate HOT payments (returns success/message).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->