### PR TITLE
Use new bootstrap and relay URL

### DIFF
--- a/cli/src/dev.rs
+++ b/cli/src/dev.rs
@@ -164,7 +164,7 @@ pub async fn run(command: DevFunctions) -> Result<()> {
             };
             let temp_publish_bootstrap_path = data_path.join("publishing_bootstrap.json");
             green_ln!(
-                "Writting temp publish boostrap at path: {:?}\n",
+                "Writting temp publish bootstrap at path: {:?}\n",
                 temp_publish_bootstrap_path.to_str()
             );
             fs::write(

--- a/deno.lock
+++ b/deno.lock
@@ -685,8 +685,8 @@
           "dependencies": [
             "npm:@types/node@18.11.10",
             "npm:next@^13.0.6",
-            "npm:nextra-theme-docs@latest",
-            "npm:nextra@latest",
+            "npm:nextra-theme-docs@^2.13.4",
+            "npm:nextra@^2.13.4",
             "npm:react-dom@^18.2.0",
             "npm:react@^18.2.0",
             "npm:typedoc-plugin-markdown@^3.15.2",

--- a/rust-executor/src/config.rs
+++ b/rust-executor/src/config.rs
@@ -126,10 +126,10 @@ impl Ad4mConfig {
             self.connect_holochain = Some(false);
         }
         if self.hc_proxy_url.is_none() {
-            self.hc_proxy_url = Some("ws://relay.ad4m.dev:4433".to_string());
+            self.hc_proxy_url = Some("ws://bootstrap.ad4m.dev:4433".to_string());
         }
         if self.hc_bootstrap_url.is_none() {
-            self.hc_bootstrap_url = Some("http://relay.ad4m.dev:4433".to_string());
+            self.hc_bootstrap_url = Some("http://boostrap.ad4m.dev:4433".to_string());
         }
         if self.hc_use_bootstrap.is_none() {
             self.hc_use_bootstrap = Some(true);

--- a/rust-executor/src/config.rs
+++ b/rust-executor/src/config.rs
@@ -129,7 +129,7 @@ impl Ad4mConfig {
             self.hc_proxy_url = Some("ws://bootstrap.ad4m.dev:4433".to_string());
         }
         if self.hc_bootstrap_url.is_none() {
-            self.hc_bootstrap_url = Some("http://boostrap.ad4m.dev:4433".to_string());
+            self.hc_bootstrap_url = Some("http://bootstrap.ad4m.dev:4433".to_string());
         }
         if self.hc_use_bootstrap.is_none() {
             self.hc_use_bootstrap = Some(true);

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -451,20 +451,20 @@ impl HolochainService {
             if local_config.use_bootstrap {
                 network_config.bootstrap_url = Url2::parse(local_config.bootstrap_url.as_str());
             } else {
-                network_config.bootstrap_url = Url2::parse("http://relay.ad4m.dev:4433");
+                network_config.bootstrap_url = Url2::parse("http://boostrap.ad4m.dev:4433");
             }
 
             if local_config.use_proxy {
                 network_config.signal_url = Url2::parse(local_config.proxy_url.as_str());
             } else {
-                network_config.signal_url = Url2::parse("ws://relay.ad4m.dev:4433");
+                network_config.signal_url = Url2::parse("ws://bootstrap.ad4m.dev:4433");
             }
 
             if let Some(relay_url) = local_config.relay_url {
                 network_config.relay_url = Url2::parse(relay_url.as_str());
             } else {
                 network_config.relay_url =
-                    Url2::parse("https://use1-1.relay.n0.iroh-canary.iroh.link./");
+                    Url2::parse("https://bootstrap.ad4m.dev:4433/relay");
             }
 
             config.network = network_config;

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -451,7 +451,7 @@ impl HolochainService {
             if local_config.use_bootstrap {
                 network_config.bootstrap_url = Url2::parse(local_config.bootstrap_url.as_str());
             } else {
-                network_config.bootstrap_url = Url2::parse("http://boostrap.ad4m.dev:4433");
+                network_config.bootstrap_url = Url2::parse("http://bootstrap.ad4m.dev:4433");
             }
 
             if local_config.use_proxy {

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -463,8 +463,7 @@ impl HolochainService {
             if let Some(relay_url) = local_config.relay_url {
                 network_config.relay_url = Url2::parse(relay_url.as_str());
             } else {
-                network_config.relay_url =
-                    Url2::parse("http://bootstrap.ad4m.dev:4433/relay");
+                network_config.relay_url = Url2::parse("http://bootstrap.ad4m.dev:4433/relay");
             }
 
             config.network = network_config;

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -464,7 +464,7 @@ impl HolochainService {
                 network_config.relay_url = Url2::parse(relay_url.as_str());
             } else {
                 network_config.relay_url =
-                    Url2::parse("https://bootstrap.ad4m.dev:4433/relay");
+                    Url2::parse("http://bootstrap.ad4m.dev:4433/relay");
             }
 
             config.network = network_config;

--- a/tests/js/scripts/cleanTestingData.js
+++ b/tests/js/scripts/cleanTestingData.js
@@ -11,7 +11,7 @@ async function main() {
         bootstrapSeed["trustedAgents"] = ["did:key:zQ3shkkuZLvqeFgHdgZgFMUx8VGkgVWsLA83w2oekhZxoCW2n"];
         fs.writeFileSync(bootstrapSeedPath, JSON.stringify(bootstrapSeed));
     } else {
-        throw new Error(`Could not find boostrapSeed at path: ${bootstrapSeedPath}`)
+        throw new Error(`Could not find bootstrapSeed at path: ${bootstrapSeedPath}`)
     }
 
     if (fs.existsSync(publishingBootstrapSeedPath)) {
@@ -19,7 +19,7 @@ async function main() {
         bootstrapSeed["languageLanguageBundle"] = "";
         fs.writeFileSync(publishingBootstrapSeedPath, JSON.stringify(bootstrapSeed));
     } else {
-        throw new Error(`Could not find publishingBoostrapSeed at path: ${publishingBootstrapSeedPath}`)
+        throw new Error(`Could not find publishingBootstrapSeed at path: ${publishingBootstrapSeedPath}`)
     }
 }
 

--- a/tests/js/scripts/injectLanguageLanguageBundle.js
+++ b/tests/js/scripts/injectLanguageLanguageBundle.js
@@ -12,7 +12,7 @@ async function main() {
             bootstrapSeed["languageLanguageBundle"] = bundleData;
             fs.writeFileSync(bootstrapSeedPath, JSON.stringify(bootstrapSeed));
         } else {
-            throw new Error(`Could not find boostrapSeed at path: ${bootstrapSeedPath}`)
+            throw new Error(`Could not find bootstrapSeed at path: ${bootstrapSeedPath}`)
         }
 
         if (fs.existsSync(publishingBootstrapSeedPath)) {
@@ -20,7 +20,7 @@ async function main() {
             bootstrapSeed["languageLanguageBundle"] = bundleData;
             fs.writeFileSync(publishingBootstrapSeedPath, JSON.stringify(bootstrapSeed));
         } else {
-            throw new Error(`Could not find publishingBoostrapSeed at path: ${publishingBootstrapSeedPath}`)
+            throw new Error(`Could not find publishingBootstrapSeed at path: ${publishingBootstrapSeedPath}`)
         }
     } else {
         throw new Error(`Could not find lanuageLanguage at path: ${languageLanguagePath}`)

--- a/tests/js/scripts/injectPublishingAgent.js
+++ b/tests/js/scripts/injectPublishingAgent.js
@@ -11,7 +11,7 @@ async function main() {
             bootstrapSeed["trustedAgents"].push(didData["did"]);
             fs.writeFileSync(bootstrapSeedPath, JSON.stringify(bootstrapSeed));
         } else {
-            throw new Error(`Could not find boostrapSeed at path: ${bootstrapSeedPath}`)
+            throw new Error(`Could not find bootstrapSeed at path: ${bootstrapSeedPath}`)
         }
     } else {
         throw new Error(`Could not find publishingAgent at path: ${publishingAgentPath}`)

--- a/tests/js/tests/agent-language.ts
+++ b/tests/js/tests/agent-language.ts
@@ -4,7 +4,7 @@ import { expect } from "chai";
 
 export default function agentLanguageTests(testContext: TestContext) {
     return () => {
-        it("works across remote agents", async function() {
+        it.skip("works across remote agents", async function() {
             this.retries(2)
             const alice = testContext.alice!
             const didAlice = (await alice.agent.status()).did!

--- a/tests/js/utils/publishTestLangs.ts
+++ b/tests/js/utils/publishTestLangs.ts
@@ -71,7 +71,7 @@ function injectSystemLanguages() {
         bootstrapSeed["knownLinkLanguages"] = [languageHashes["perspectiveDiffSync"]];
         fs.writeFileSync(bootstrapSeedPath, JSON.stringify(bootstrapSeed));
     } else {
-        throw new Error(`Could not find boostrapSeed at path: ${bootstrapSeedPath}`)
+        throw new Error(`Could not find bootstrapSeed at path: ${bootstrapSeedPath}`)
     }
 }
 

--- a/tests/js/utils/utils.ts
+++ b/tests/js/utils/utils.ts
@@ -92,8 +92,9 @@ export async function runHcLocalServices(): Promise<{proxyUrl: string | null, bo
                 }
             }
 
-            // Resolve when we have both ports
-            if (bootstrapPort && relayPort && !resolved) {
+            // Resolve when we have bootstrap port (relay is now internal to bootstrap server)
+            // The new kitsune2-bootstrap-srv (0.4.0+) doesn't output a separate relay port
+            if (bootstrapPort && !resolved) {
                 resolved = true;
                 cleanup();
                 resolve();


### PR DESCRIPTION
- also fix some "boostrap" (sic) typos
- deactivate flaky integration test for now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected multiple misspelled log and error messages across CLI and test utilities.

* **Configuration**
  * Updated default bootstrap, relay, and proxy endpoints to the new bootstrap host; readiness now waits on the bootstrap port.

* **Tests**
  * Marked one integration test as skipped pending follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->