### PR TITLE
feat(plugin): auto-download ad4m-executor binary when not in PATH

### DIFF
--- a/plugins/ad4m/README.md
+++ b/plugins/ad4m/README.md
@@ -1,70 +1,113 @@
 # AD4M Plugin for OpenClaw
 
-Connect your AI agent to **AD4M** — join P2P neighbourhoods, message humans and other AI agents, watch for changes in real-time, and collaborate via shared semantic knowledge graphs.
+Connect your AI agent to **AD4M** — a peer-to-peer application framework built on holochain and based on semantic knowledge graphs. With this plugin your agent can join P2P neighbourhoods, message humans and other AI agents, watch for activity in real-time, and collaborate through shared data.
 
-## What this plugin provides
+## What can your agent do with AD4M?
 
-- **Native agent tools** — AD4M's MCP tools (perspectives, channels, messages, subject classes, neighbourhoods, profiles, etc.) are registered as native OpenClaw tools, available directly in the LLM's context
-- **Dynamic tool discovery** — as SHACL schemas sync in perspectives, new tools (e.g. `ad4m_channel_create`, `ad4m_message_set_body`) are automatically discovered and registered
-- **Embedded waker** — subscribe to mentions or channel activity with one tool call; the plugin watches via GraphQL WS and wakes your agent automatically
-- **Skill** with instructions on how to use AD4M effectively (data model, auth, waker setup, SHACL schemas)
+Once set up, you can ask your agent to:
+
+- **Join a neighbourhood** — connect to a shared P2P space by its URL
+- **Publish a neighbourhood** — create and share a new neighbourhood for others to join
+- **Read and send messages** — participate in channels and conversations
+- **Subscribe to mentions** — get notified when someone mentions your agent
+- **Watch channels** — subscribe to new messages in specific channels and wake up automatically
+- **Manage perspectives** — create, list, and query local or shared knowledge graphs
+- **Work with subject classes** — interact with structured data defined by SHACL schemas
+- **Set your profile** — update your agent's name, profile picture, and other details
+- **Install languages** — add new AD4M languages (expression types) to your agent
 
 ## Installation
-
-### Via npm
 
 ```bash
 openclaw plugins install @coasys/openclaw-ad4m
 ```
 
-### Local development
+For local development:
 
 ```bash
 openclaw plugins install -l plugins/ad4m
 ```
 
-## Configuration
+## Setup
 
-Configure the plugin in your OpenClaw config:
+After installation, run the interactive setup command:
+
+```bash
+openclaw ad4m-setup
+```
+
+This command handles everything automatically:
+
+1. **Finds or downloads the executor** — looks for an `ad4m-executor` binary on your system. If none is found, it downloads the correct version for your platform automatically.
+2. **Starts the executor** — launches `ad4m-executor` with MCP enabled.
+3. **Generates an agent** — creates a new AD4M agent identity with a secure passphrase (or detects your existing one).
+4. **Prints a config snippet** — outputs the JSON config block you need to add to your `openclaw.json`.
+
+### Adding the config
+
+At the end of setup, you'll see a config snippet like this:
+
+```json
+{
+  "mode": "managed",
+  "ad4mBinaryPath": "/path/to/ad4m-executor",
+  "agentPassphrase": "your-generated-passphrase"
+}
+```
+
+Copy it into your `openclaw.json` under the plugin entry:
 
 ```json5
 {
   plugins: {
     entries: {
-      ad4m: {
+      "ad4m-openclaw-plugin": {
         enabled: true,
         config: {
-          // Managed mode (default): no config needed — credentials and hooks
-          // token are auto-generated. Just install and go.
-        },
-      },
-    },
-  },
+          // paste the snippet here
+          "mode": "managed",
+          "ad4mBinaryPath": "/path/to/ad4m-executor",
+          "agentPassphrase": "your-generated-passphrase"
+        }
+      }
+    }
+  }
 }
 ```
 
-All fields are optional. In managed mode the plugin auto-generates credentials and reads the hooks token from OpenClaw's global config. On first install, `configureInteractive` will generate a secure hooks token if one isn't set.
+Then restart OpenClaw. The plugin will start the executor, unlock your agent, and register all AD4M tools automatically.
 
-| Field                   | Required | Default                             | Description                                                                 |
-| ----------------------- | -------- | ----------------------------------- | --------------------------------------------------------------------------- |
-| `mode`                  | No       | `managed`                           | `managed` = auto-manages executor + agent, `external` = connect to existing |
-| `adminCredential`       | No       | auto-generated                      | Admin credential for the ad4m-executor                                      |
-| `mcpEndpoint`           | No       | `http://localhost:3001/mcp`         | AD4M executor MCP endpoint URL                                              |
-| `toolRefreshIntervalMs` | No       | `30000`                             | How often to poll for new dynamic SHACL tools (ms)                          |
-| `executorWsUrl`         | No       | `ws://localhost:12000/graphql`      | AD4M executor GraphQL WebSocket URL (for waker)                             |
-| `wakeUrl`               | No       | `http://localhost:18789/hooks/wake` | OpenClaw wake endpoint URL                                                  |
-| `wakeToken`             | No       | auto from `hooks.token`             | Override for the hooks token (read from OpenClaw global config if omitted)  |
-| `debounceMs`            | No       | `2000`                              | Debounce interval for wake events (ms)                                      |
+### Setup modes
 
-## Prerequisites
+The setup detects your environment and picks the right path:
 
-An **ad4m-executor** must be running with MCP enabled:
+| Scenario | What happens |
+|----------|-------------|
+| No executor binary found | Downloads it automatically, then runs managed setup |
+| Binary found, no running executor | Starts executor, generates agent, prints managed config |
+| Executor already running | Connects to it, requests capabilities via JWT, prints external config |
+| Existing agent data in `~/.ad4m` | Asks you to provide your existing passphrase in the config |
 
-```bash
-ad4m-executor run --enable-mcp true --admin-credential <your-credential>
-```
+### External mode
 
-See `skills/ad4m/references/setup.md` for full setup instructions.
+If you already run your own `ad4m-executor`, the setup will connect to it and request a JWT token. You'll see a verification code — confirm it in your executor UI. The resulting config uses `"mode": "external"` with a `token` field instead of a passphrase.
+
+## Configuration reference
+
+All fields are optional. In managed mode, credentials are auto-generated during setup.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `mode` | `managed` | `managed` = plugin manages executor lifecycle; `external` = connect to existing |
+| `ad4mBinaryPath` | auto-detected | Path to the `ad4m-executor` binary |
+| `agentPassphrase` | generated during setup | Passphrase to unlock the agent |
+| `mcpEndpoint` | `http://localhost:3001/mcp` | AD4M executor MCP endpoint URL |
+| `token` | — | JWT token for external mode authentication |
+| `toolRefreshIntervalMs` | `30000` | How often to poll for new dynamic tools (ms) |
+| `executorWsUrl` | `ws://localhost:12000/graphql` | GraphQL WebSocket URL for the waker |
+| `wakeUrl` | `http://localhost:18789/hooks/wake` | OpenClaw wake endpoint URL |
+| `wakeToken` | auto from `hooks.token` | Override for the hooks authentication token |
+| `debounceMs` | `2000` | Debounce interval for wake events (ms) |
 
 ## How it works
 
@@ -72,45 +115,41 @@ The plugin runs two background services:
 
 ### `ad4m-mcp` — MCP tool bridge
 
-1. **Connects** to the AD4M executor's MCP endpoint (Streamable HTTP transport)
-2. **Initializes** an MCP session (JSON-RPC handshake with SSE responses)
-3. **Discovers** all available tools via `tools/list`
-4. **Registers** each tool as a native OpenClaw agent tool via `api.registerTool()`
-5. **Polls** periodically for new dynamic tools as perspectives sync SHACL schemas
+Connects to the AD4M executor's MCP endpoint, discovers all available tools, and registers them as native OpenClaw agent tools. As perspectives sync SHACL schemas, new tools (e.g. `ad4m_channel_create`, `ad4m_message_set_body`) are automatically discovered and added.
 
-### `ad4m-waker` — embedded waker
+### `ad4m-waker` — real-time subscriptions
 
-1. **Connects** to the AD4M executor's GraphQL WebSocket endpoint
-2. When the agent calls `ad4m_subscribe_to_mentions` or `ad4m_subscribe_to_children`, creates live SurrealDB subscriptions via `QuerySubscriptionProxy`
-3. **Debounces** change events and POSTs to OpenClaw's `/hooks/wake` to wake the agent
+Connects to the executor's GraphQL WebSocket. When your agent subscribes to mentions or channel activity, the waker watches for changes and POSTs to OpenClaw's wake endpoint to bring your agent back into action.
 
 ## Plugin-provided tools
 
-In addition to all AD4M MCP tools (discovered dynamically), the plugin registers:
+In addition to all dynamically discovered AD4M MCP tools, the plugin registers:
 
-| Tool                                                                 | Description                                                   |
-| -------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `ad4m_refresh_ad4m_tools()`                                          | Re-fetch the MCP tool list and register new tools immediately |
-| `ad4m_subscribe_to_mentions(perspective_id)`                         | Watch for messages mentioning your name/DID                   |
-| `ad4m_subscribe_to_children(perspective_id, expression_address)`     | Watch for new children under a parent                         |
-| `ad4m_unsubscribe_from_mentions(perspective_id)`                     | Stop watching mentions                                        |
-| `ad4m_unsubscribe_from_children(perspective_id, expression_address)` | Stop watching a channel                                       |
-| `ad4m_list_waker_subscriptions()`                                    | List all active waker subscriptions                           |
+| Tool | Description |
+|------|-------------|
+| `ad4m_refresh_ad4m_tools()` | Re-fetch the MCP tool list immediately |
+| `ad4m_subscribe_to_mentions(perspective_id)` | Watch for messages mentioning your agent |
+| `ad4m_subscribe_to_children(perspective_id, expression_address)` | Watch for new messages in a channel |
+| `ad4m_unsubscribe_from_mentions(perspective_id)` | Stop watching mentions |
+| `ad4m_unsubscribe_from_children(perspective_id, expression_address)` | Stop watching a channel |
+| `ad4m_list_waker_subscriptions()` | List all active subscriptions |
+| `ad4m_set_profile_picture_from_file(file_path)` | Set your agent's profile picture |
 
 ## Plugin structure
 
 ```
 plugins/ad4m/
-├── openclaw.plugin.json        # OpenClaw plugin manifest
+├── openclaw.plugin.json        # Plugin manifest
 ├── index.ts                    # Plugin entry point (MCP bridge + waker)
-├── package.json                # NPM package for distribution
+├── setup.ts                    # Interactive setup flow
+├── executor.ts                 # Binary discovery, process management, auto-download
+├── agent.ts                    # Agent initialization
+├── config.ts                   # Config and state management
+├── mcpClient.ts                # MCP transport and tool listing
+├── package.json                # NPM package
 ├── skills/
 │   └── ad4m/
 │       ├── SKILL.md            # Agent instructions
 │       └── references/         # Detailed reference docs
-│           ├── mcp.md
-│           ├── architecture.md
-│           ├── setup.md
-│           └── waker.md
 └── README.md
 ```

--- a/plugins/ad4m/README.md
+++ b/plugins/ad4m/README.md
@@ -61,7 +61,7 @@ Copy it into your `openclaw.json` under the plugin entry:
 {
   plugins: {
     entries: {
-      "ad4m-openclaw-plugin": {
+      "ad4m": {
         enabled: true,
         config: {
           // paste the snippet here

--- a/plugins/ad4m/executor.ts
+++ b/plugins/ad4m/executor.ts
@@ -1,5 +1,7 @@
 import path from "path";
 import fs from "fs";
+import https from "https";
+import http from "http";
 import { spawn, execFileSync } from "child_process";
 
 import type { PluginConfig } from "./types";
@@ -27,6 +29,7 @@ export function findExecutorBinary(): string | null {
   // 2. Check common locations not always in PATH
   const home = process.env.HOME || process.env.USERPROFILE || "";
   const commonPaths = [
+    path.join(home, ".ad4m-plugin", "bin"),
     "/usr/local/bin",
     "/usr/bin",
     "/opt/homebrew/bin",
@@ -46,6 +49,222 @@ export function findExecutorBinary(): string | null {
   }
 
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Auto-download of ad4m-executor and ad4m CLI binaries
+// ---------------------------------------------------------------------------
+
+// Hardcoded version for auto-download.
+// TODO: Update this with each release or make it configurable via plugin config.
+const EXECUTOR_VERSION = "0.12.0-rc1";
+
+/** Directory where downloaded binaries are stored */
+function getPluginBinDir(): string {
+  const home = process.env.HOME || process.env.USERPROFILE || "/tmp";
+  return path.join(home, ".ad4m-plugin", "bin");
+}
+
+interface DownloadAsset {
+  /** Display name for logging */
+  label: string;
+  /** GitHub release asset filename */
+  assetName: string;
+  /** Local filename to save as */
+  localName: string;
+}
+
+/**
+ * Get the list of assets to download for the current platform.
+ * Returns null with a logged error if the platform is unsupported.
+ */
+function getDownloadAssets(logger: any): DownloadAsset[] | null {
+  const platform = process.platform;
+  const arch = process.arch;
+
+  // Map Node.js platform/arch to asset naming convention.
+  // Linux x64 binaries are available now; macOS and Windows binaries will be
+  // published in a future release (Nico will handle the CI for those).
+  // If the asset doesn't exist for the current release version, the download
+  // will fail with a clear HTTP 404 / "binary not found" message.
+
+  let osName: string;
+  let archName: string;
+  let ext = ""; // Windows binaries need .exe
+
+  switch (platform) {
+    case "linux":
+      osName = "linux";
+      break;
+    case "darwin":
+      osName = "macos";
+      break;
+    case "win32":
+      osName = "windows";
+      ext = ".exe";
+      break;
+    default:
+      logger.error(
+        `[ad4m] Auto-download is not supported on ${platform}/${arch}. ` +
+          `Please install ad4m-executor manually.`,
+      );
+      return null;
+  }
+
+  switch (arch) {
+    case "x64":
+      archName = "x64";
+      break;
+    case "arm64":
+      archName = "aarch64";
+      break;
+    default:
+      logger.error(
+        `[ad4m] Auto-download is not supported for architecture ${arch} on ${platform}. ` +
+          `Please install ad4m-executor manually.`,
+      );
+      return null;
+  }
+
+  const exeSuffix = ext; // .exe on Windows, empty otherwise
+  const localExeSuffix = platform === "win32" ? ".exe" : "";
+
+  return [
+    {
+      label: "ad4m-executor",
+      assetName: `ad4m-cli-executor-${osName}-${EXECUTOR_VERSION}-${archName}${exeSuffix}`,
+      localName: `ad4m-executor${localExeSuffix}`,
+    },
+    {
+      label: "ad4m CLI client",
+      assetName: `ad4m-cli-client-${osName}-${EXECUTOR_VERSION}-${archName}${exeSuffix}`,
+      localName: `ad4m${localExeSuffix}`,
+    },
+  ];
+}
+
+/**
+ * Download a file from a URL, following redirects (GitHub releases -> S3).
+ * Returns a promise that resolves when the file is fully written.
+ */
+function downloadFile(
+  url: string,
+  destPath: string,
+  label: string,
+  logger: any,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proto = url.startsWith("https") ? https : http;
+
+    proto
+      .get(url, { headers: { "User-Agent": "openclaw-ad4m-plugin" } }, (res) => {
+        // Follow redirects (301, 302, 307, 308)
+        if (
+          res.statusCode &&
+          res.statusCode >= 300 &&
+          res.statusCode < 400 &&
+          res.headers.location
+        ) {
+          downloadFile(res.headers.location, destPath, label, logger)
+            .then(resolve)
+            .catch(reject);
+          res.resume(); // consume response to free memory
+          return;
+        }
+
+        if (!res.statusCode || res.statusCode !== 200) {
+          res.resume();
+          reject(
+            new Error(
+              `Failed to download ${label}: HTTP ${res.statusCode ?? "unknown"}`,
+            ),
+          );
+          return;
+        }
+
+        const totalBytes = parseInt(res.headers["content-length"] || "0", 10);
+        let downloadedBytes = 0;
+        let lastLogPercent = -10; // log every 10%
+
+        const fileStream = fs.createWriteStream(destPath);
+
+        res.on("data", (chunk: Buffer) => {
+          downloadedBytes += chunk.length;
+          if (totalBytes > 0) {
+            const percent = Math.floor((downloadedBytes / totalBytes) * 100);
+            if (percent - lastLogPercent >= 10) {
+              const mb = (downloadedBytes / 1024 / 1024).toFixed(1);
+              const totalMb = (totalBytes / 1024 / 1024).toFixed(1);
+              logger.info(
+                `[ad4m] Downloading ${label}: ${mb}MB / ${totalMb}MB (${percent}%)`,
+              );
+              lastLogPercent = percent;
+            }
+          }
+        });
+
+        res.pipe(fileStream);
+
+        fileStream.on("finish", () => {
+          fileStream.close();
+          const mb = (downloadedBytes / 1024 / 1024).toFixed(1);
+          logger.info(`[ad4m] Downloaded ${label}: ${mb}MB`);
+          resolve();
+        });
+
+        fileStream.on("error", (err) => {
+          fs.unlink(destPath, () => {}); // clean up partial file
+          reject(new Error(`Failed to write ${label}: ${err.message}`));
+        });
+      })
+      .on("error", (err) => {
+        reject(new Error(`Network error downloading ${label}: ${err.message}`));
+      });
+  });
+}
+
+/**
+ * Download ad4m-executor and ad4m CLI client binaries for the current platform.
+ * Binaries are saved to ~/.ad4m-plugin/bin/ and made executable.
+ *
+ * Returns true if the executor binary was successfully downloaded.
+ */
+export async function downloadExecutor(logger: any): Promise<boolean> {
+  const assets = getDownloadAssets(logger);
+  if (!assets) return false;
+
+  const binDir = getPluginBinDir();
+
+  // Create bin directory
+  try {
+    fs.mkdirSync(binDir, { recursive: true });
+  } catch (err: any) {
+    logger.error(
+      `[ad4m] Failed to create directory ${binDir}: ${err.message}`,
+    );
+    return false;
+  }
+
+  const baseUrl = `https://github.com/coasys/ad4m/releases/download/v${EXECUTOR_VERSION}`;
+
+  for (const asset of assets) {
+    const url = `${baseUrl}/${asset.assetName}`;
+    const destPath = path.join(binDir, asset.localName);
+
+    logger.info(`[ad4m] Downloading ${asset.label} from ${url}`);
+
+    try {
+      await downloadFile(url, destPath, asset.label, logger);
+      fs.chmodSync(destPath, 0o755);
+      logger.info(`[ad4m] Installed ${asset.label} at ${destPath}`);
+    } catch (err: any) {
+      logger.error(`[ad4m] Failed to download ${asset.label}: ${err.message}`);
+      // If executor download fails, return false. Client failure is non-fatal.
+      if (asset.localName === "ad4m-executor") return false;
+    }
+  }
+
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/ad4m/executor.ts
+++ b/plugins/ad4m/executor.ts
@@ -11,18 +11,25 @@ import type { PluginConfig } from "./types";
  * Returns the absolute path if found, null otherwise.
  */
 export function findExecutorBinary(): string | null {
-  const name = "ad4m-executor";
+  const isWindows = process.platform === "win32";
+  const candidateNames = isWindows
+    ? ["ad4m-executor.exe", "ad4m-executor"]
+    : ["ad4m-executor"];
+  // Windows doesn't use the executable permission bit
+  const accessFlag = isWindows ? fs.constants.F_OK : fs.constants.X_OK;
 
   // 1. Check PATH entries
   const envPath = process.env.PATH ?? "";
   for (const dir of envPath.split(path.delimiter)) {
     if (!dir) continue;
-    const candidate = path.join(dir, name);
-    try {
-      fs.accessSync(candidate, fs.constants.X_OK);
-      return candidate;
-    } catch {
-      // not found or not executable
+    for (const name of candidateNames) {
+      const candidate = path.join(dir, name);
+      try {
+        fs.accessSync(candidate, accessFlag);
+        return candidate;
+      } catch {
+        // not found or not executable
+      }
     }
   }
 
@@ -39,12 +46,14 @@ export function findExecutorBinary(): string | null {
   ];
 
   for (const dir of commonPaths) {
-    const candidate = path.join(dir, name);
-    try {
-      fs.accessSync(candidate, fs.constants.X_OK);
-      return candidate;
-    } catch {
-      // not found
+    for (const name of candidateNames) {
+      const candidate = path.join(dir, name);
+      try {
+        fs.accessSync(candidate, accessFlag);
+        return candidate;
+      } catch {
+        // not found
+      }
     }
   }
 
@@ -143,6 +152,9 @@ function getDownloadAssets(logger: any): DownloadAsset[] | null {
   ];
 }
 
+const MAX_REDIRECTS = 5;
+const REQUEST_TIMEOUT_MS = 300_000; // 5 minutes — executor binaries are ~364MB
+
 /**
  * Download a file from a URL, following redirects (GitHub releases -> S3).
  * Returns a promise that resolves when the file is fully written.
@@ -152,12 +164,13 @@ function downloadFile(
   destPath: string,
   label: string,
   logger: any,
+  redirectCount: number = 0,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const proto = url.startsWith("https") ? https : http;
 
-    proto
-      .get(url, { headers: { "User-Agent": "openclaw-ad4m-plugin" } }, (res) => {
+    const req = proto
+      .get(url, { headers: { "User-Agent": "openclaw-ad4m-plugin" }, timeout: REQUEST_TIMEOUT_MS }, (res) => {
         // Follow redirects (301, 302, 307, 308)
         if (
           res.statusCode &&
@@ -165,7 +178,13 @@ function downloadFile(
           res.statusCode < 400 &&
           res.headers.location
         ) {
-          downloadFile(res.headers.location, destPath, label, logger)
+          if (redirectCount >= MAX_REDIRECTS) {
+            res.resume();
+            reject(new Error(`Too many redirects (${MAX_REDIRECTS}) downloading ${label}`));
+            return;
+          }
+          const redirectUrl = new URL(res.headers.location, url).toString();
+          downloadFile(redirectUrl, destPath, label, logger, redirectCount + 1)
             .then(resolve)
             .catch(reject);
           res.resume(); // consume response to free memory
@@ -216,10 +235,16 @@ function downloadFile(
           fs.unlink(destPath, () => {}); // clean up partial file
           reject(new Error(`Failed to write ${label}: ${err.message}`));
         });
-      })
-      .on("error", (err) => {
-        reject(new Error(`Network error downloading ${label}: ${err.message}`));
       });
+
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error(`Download of ${label} timed out after ${REQUEST_TIMEOUT_MS / 1000}s`));
+    });
+
+    req.on("error", (err) => {
+      reject(new Error(`Network error downloading ${label}: ${err.message}`));
+    });
   });
 }
 
@@ -255,12 +280,21 @@ export async function downloadExecutor(logger: any): Promise<boolean> {
 
     try {
       await downloadFile(url, destPath, asset.label, logger);
+
+      // TODO: Add SHA-256 checksum verification when release manifests are available
+      // Basic integrity check: reject zero-byte files
+      const fileSize = fs.statSync(destPath).size;
+      if (fileSize === 0) {
+        fs.unlinkSync(destPath);
+        throw new Error(`Downloaded file is empty (0 bytes)`);
+      }
+
       fs.chmodSync(destPath, 0o755);
       logger.info(`[ad4m] Installed ${asset.label} at ${destPath}`);
     } catch (err: any) {
       logger.error(`[ad4m] Failed to download ${asset.label}: ${err.message}`);
       // If executor download fails, return false. Client failure is non-fatal.
-      if (asset.localName === "ad4m-executor") return false;
+      if (asset.label === "ad4m-executor") return false;
     }
   }
 

--- a/plugins/ad4m/executor.ts
+++ b/plugins/ad4m/executor.ts
@@ -1,10 +1,18 @@
 import path from "path";
 import fs from "fs";
+import os from "os";
 import https from "https";
 import http from "http";
 import { spawn, execFileSync } from "child_process";
 
 import type { PluginConfig } from "./types";
+
+/** Canonical home directory — used by both discovery and download. */
+const PLUGIN_BIN_DIR = path.join(
+  process.env.HOME || process.env.USERPROFILE || os.tmpdir(),
+  ".ad4m-plugin",
+  "bin",
+);
 
 /**
  * Search for ad4m-executor binary in PATH and common locations.
@@ -36,7 +44,7 @@ export function findExecutorBinary(): string | null {
   // 2. Check common locations not always in PATH
   const home = process.env.HOME || process.env.USERPROFILE || "";
   const commonPaths = [
-    path.join(home, ".ad4m-plugin", "bin"),
+    PLUGIN_BIN_DIR,
     "/usr/local/bin",
     "/usr/bin",
     "/opt/homebrew/bin",
@@ -70,8 +78,7 @@ const EXECUTOR_VERSION = "0.12.0-rc2";
 
 /** Directory where downloaded binaries are stored */
 function getPluginBinDir(): string {
-  const home = process.env.HOME || process.env.USERPROFILE || "/tmp";
-  return path.join(home, ".ad4m-plugin", "bin");
+  return PLUGIN_BIN_DIR;
 }
 
 interface DownloadAsset {
@@ -205,7 +212,8 @@ function downloadFile(
         let downloadedBytes = 0;
         let lastLogPercent = -10; // log every 10%
 
-        const fileStream = fs.createWriteStream(destPath);
+        const tempPath = destPath + ".part";
+        const fileStream = fs.createWriteStream(tempPath);
 
         res.on("data", (chunk: Buffer) => {
           downloadedBytes += chunk.length;
@@ -228,21 +236,30 @@ function downloadFile(
           fileStream.close();
           const mb = (downloadedBytes / 1024 / 1024).toFixed(1);
           logger.info(`[ad4m] Downloaded ${label}: ${mb}MB`);
+          try {
+            fs.renameSync(tempPath, destPath);
+          } catch (renameErr: any) {
+            fs.unlink(tempPath, () => {});
+            reject(new Error(`Failed to finalize ${label}: ${renameErr.message}`));
+            return;
+          }
           resolve();
         });
 
         fileStream.on("error", (err) => {
-          fs.unlink(destPath, () => {}); // clean up partial file
+          fs.unlink(tempPath, () => {}); // clean up partial file
           reject(new Error(`Failed to write ${label}: ${err.message}`));
         });
       });
 
     req.on("timeout", () => {
       req.destroy();
+      fs.unlink(destPath + ".part", () => {});
       reject(new Error(`Download of ${label} timed out after ${REQUEST_TIMEOUT_MS / 1000}s`));
     });
 
     req.on("error", (err) => {
+      fs.unlink(destPath + ".part", () => {});
       reject(new Error(`Network error downloading ${label}: ${err.message}`));
     });
   });

--- a/plugins/ad4m/executor.ts
+++ b/plugins/ad4m/executor.ts
@@ -66,7 +66,7 @@ export function findExecutorBinary(): string | null {
 
 // Hardcoded version for auto-download.
 // TODO: Update this with each release or make it configurable via plugin config.
-const EXECUTOR_VERSION = "0.12.0-rc1";
+const EXECUTOR_VERSION = "0.12.0-rc2";
 
 /** Directory where downloaded binaries are stored */
 function getPluginBinDir(): string {

--- a/plugins/ad4m/index.test.ts
+++ b/plugins/ad4m/index.test.ts
@@ -1668,7 +1668,7 @@ describe("ad4mPlugin", () => {
     }, 50);
 
     const mockApi = {
-      id: "ad4m-openclaw-plugin",
+      id: "ad4m",
       pluginConfig: {
         mode: "managed",
       },
@@ -2002,7 +2002,7 @@ describe("ad4mPlugin", () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("No executor"));
 
     const mockApi = {
-      id: "ad4m-openclaw-plugin",
+      id: "ad4m",
       pluginConfig: {
         mode: "external",
         mcpEndpoint: "http://localhost:3001/mcp",
@@ -2033,7 +2033,7 @@ describe("ad4mPlugin", () => {
 
   it("logs setup hint when mode is not configured", async () => {
     const mockApi: any = {
-      id: "ad4m-openclaw-plugin",
+      id: "ad4m",
       pluginConfig: {},
       logger: makeMockLogger(),
       registerTool: vi.fn(),
@@ -2058,7 +2058,7 @@ describe("ad4mPlugin", () => {
 
   it("registers ad4m-setup CLI command", () => {
     const mockApi: any = {
-      id: "ad4m-openclaw-plugin",
+      id: "ad4m",
       pluginConfig: {},
       logger: makeMockLogger(),
       registerTool: vi.fn(),

--- a/plugins/ad4m/index.ts
+++ b/plugins/ad4m/index.ts
@@ -868,22 +868,10 @@ Notes:
             logger.info(`[ad4m] Found ad4m-executor at: ${discovered}`);
             binaryPath = discovered;
           } else {
-            logger.info(
-              `[ad4m] ad4m-executor not found in PATH or common locations. Attempting auto-download...`,
+            logger.warn(
+              `[ad4m] ad4m-executor not found in PATH or common locations. ` +
+              `Run 'openclaw ad4m-setup' to download and configure it automatically.`,
             );
-            const downloaded = await downloadExecutor(logger);
-            if (downloaded) {
-              const retryPath = findExecutorBinary();
-              if (retryPath) {
-                logger.info(`[ad4m] Using downloaded executor at: ${retryPath}`);
-                binaryPath = retryPath;
-              }
-            }
-            if (!binaryPath) {
-              logger.warn(
-                `[ad4m] Auto-download failed or unsupported platform. Will try bare name.`,
-              );
-            }
           }
         } else {
           logger.info(`[ad4m] Using executor binary: ${binaryPath}`);

--- a/plugins/ad4m/index.ts
+++ b/plugins/ad4m/index.ts
@@ -29,6 +29,7 @@ import {
   findExecutorBinary,
   isExecutorRunning,
   stopExecutor,
+  downloadExecutor,
 } from "./executor";
 import { ensureAgentReady } from "./agent";
 import {
@@ -61,6 +62,7 @@ export {
   isExecutorRunning,
   ensureExecutorRunning,
   stopExecutor,
+  downloadExecutor,
 } from "./executor";
 export type { ExecutorStartResult } from "./executor";
 export { ensureAgentReady } from "./agent";
@@ -857,7 +859,7 @@ Notes:
         const adminCredential = generateRandomPassphrase(24);
         authToken = adminCredential;
 
-        // Resolve executor binary path: config > discover > bare name
+        // Resolve executor binary path: config > discover > auto-download
         let binaryPath = providedConfig.ad4mBinaryPath;
         if (!binaryPath) {
           logger.info(`[ad4m] Searching for ad4m-executor binary...`);
@@ -866,9 +868,22 @@ Notes:
             logger.info(`[ad4m] Found ad4m-executor at: ${discovered}`);
             binaryPath = discovered;
           } else {
-            logger.warn(
-              `[ad4m] ad4m-executor not found in PATH or common locations. Will try bare name.`,
+            logger.info(
+              `[ad4m] ad4m-executor not found in PATH or common locations. Attempting auto-download...`,
             );
+            const downloaded = await downloadExecutor(logger);
+            if (downloaded) {
+              const retryPath = findExecutorBinary();
+              if (retryPath) {
+                logger.info(`[ad4m] Using downloaded executor at: ${retryPath}`);
+                binaryPath = retryPath;
+              }
+            }
+            if (!binaryPath) {
+              logger.warn(
+                `[ad4m] Auto-download failed or unsupported platform. Will try bare name.`,
+              );
+            }
           }
         } else {
           logger.info(`[ad4m] Using executor binary: ${binaryPath}`);

--- a/plugins/ad4m/openclaw.plugin.json
+++ b/plugins/ad4m/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "ad4m-openclaw-plugin",
+  "id": "ad4m",
   "name": "AD4M",
   "description": "Connect to AD4M — join P2P neighbourhoods, message humans and other AI agents, watch for changes in real-time. Bridges AD4M's MCP server into OpenClaw as native agent tools.",
   "version": "0.1.0",

--- a/plugins/ad4m/package-lock.json
+++ b/plugins/ad4m/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@coasys/ad4m-openclaw-plugin",
+  "name": "@coasys/openclaw-ad4m",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@coasys/ad4m-openclaw-plugin",
+      "name": "@coasys/openclaw-ad4m",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/plugins/ad4m/package.json
+++ b/plugins/ad4m/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@coasys/ad4m-openclaw-plugin",
+  "name": "@coasys/openclaw-ad4m",
   "version": "0.0.1",
   "description": "OpenClaw plugin for AD4M — bridges AD4M's MCP tools as native agent tools and turns subscriptions into waker events",
   "license": "MIT",

--- a/plugins/ad4m/setup.ts
+++ b/plugins/ad4m/setup.ts
@@ -6,6 +6,7 @@ import {
   isExecutorRunning,
   ensureExecutorRunning,
   stopExecutor,
+  downloadExecutor,
 } from "./executor";
 import { ensureAgentReady } from "./agent";
 import {
@@ -75,8 +76,8 @@ export async function runSetup(
     // Branch A: No running executor, binary found
     await setupManagedMode(logger, binaryPath, endpoint, executorWsUrl, wakeToken);
   } else {
-    // Branch C: No binary, no executor
-    setupNoExecutor(logger, wakeToken);
+    // Branch C: No binary, no executor — try to download, then set up managed mode
+    await setupWithDownload(logger, endpoint, executorWsUrl, wakeToken);
   }
 }
 
@@ -263,31 +264,52 @@ async function setupExternalMode(
 }
 
 // ---------------------------------------------------------------------------
-// Branch C: No executor, no binary
+// Branch C: No executor, no binary — auto-download then managed mode
 // ---------------------------------------------------------------------------
 
-function setupNoExecutor(logger: any, wakeToken?: string): void {
+async function setupWithDownload(
+  logger: any,
+  endpoint: string,
+  executorWsUrl: string,
+  wakeToken?: string,
+): Promise<void> {
   logger.info(
     "[ad4m-setup] No ad4m-executor binary found and no running executor detected.",
   );
   logger.info(
-    "[ad4m-setup] To use this plugin, either:",
-  );
-  logger.info(
-    "[ad4m-setup]   1. Install ad4m-executor and restart OpenClaw (managed mode)",
-  );
-  logger.info(
-    "[ad4m-setup]   2. Start an executor manually and configure external mode",
-  );
-  logger.info(
-    "[ad4m-setup]   3. Set ad4mBinaryPath in plugin config to the full path",
+    "[ad4m-setup] Attempting to download ad4m-executor for your platform...",
   );
 
-  printConfigSnippet(logger, "managed", {
-    ad4mBinaryPath: "<path-to-ad4m-executor>",
-    agentPassphrase: "<will-be-shown-after-setup>",
-    wakeToken,
-  });
+  const downloaded = await downloadExecutor(logger);
+
+  if (!downloaded) {
+    logger.error(
+      "[ad4m-setup] Auto-download failed. Please install ad4m-executor manually:",
+    );
+    logger.info(
+      "[ad4m-setup]   https://github.com/coasys/ad4m/releases",
+    );
+    printConfigSnippet(logger, "managed", {
+      ad4mBinaryPath: "<path-to-ad4m-executor>",
+      agentPassphrase: "<will-be-shown-after-setup>",
+      wakeToken,
+    });
+    return;
+  }
+
+  // After download, find the binary in the plugin bin dir
+  const binaryPath = findExecutorBinary();
+  if (!binaryPath) {
+    logger.error(
+      "[ad4m-setup] Download succeeded but binary not found. This should not happen.",
+    );
+    return;
+  }
+
+  logger.info(`[ad4m-setup] Downloaded ad4m-executor to: ${binaryPath}`);
+
+  // Continue with managed mode setup using the downloaded binary
+  await setupManagedMode(logger, binaryPath, endpoint, executorWsUrl, wakeToken);
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/ad4m/setup.ts
+++ b/plugins/ad4m/setup.ts
@@ -341,7 +341,7 @@ function printConfigSnippet(
   logger.info(`[ad4m-setup] ${SEPARATOR}`);
   logger.info(`[ad4m-setup] ${title}`);
   logger.info(
-    `[ad4m-setup] Add this to your openclaw.json under plugins.entries["ad4m-openclaw-plugin"].config:`,
+    `[ad4m-setup] Add this to your openclaw.json under plugins.entries["ad4m"].config:`,
   );
   logger.info(`[ad4m-setup]`);
 

--- a/plugins/ad4m/skills/ad4m/SKILL.md
+++ b/plugins/ad4m/skills/ad4m/SKILL.md
@@ -41,7 +41,7 @@ After adding the config snippet and restarting OpenClaw, the plugin auto-manages
 
 The AD4M OpenClaw plugin bridges AD4M's MCP server into your tool list automatically. Tools like `ad4m_list_perspectives`, `ad4m_add_perspective`, `ad4m_channel_create`, `ad4m_message_get`, etc. are available as **native agent tools** — call them directly, no shell commands or HTTP requests needed.
 
-The plugin is configured in OpenClaw's config under `plugins.entries.ad4m-openclaw-plugin.config`. Run `openclaw ad4m-setup` to generate the config — key fields:
+The plugin is configured in OpenClaw's config under `plugins.entries.ad4m.config`. Run `openclaw ad4m-setup` to generate the config — key fields:
 
 - `mode` — `"managed"` or `"external"`. Managed = plugin starts/manages the executor process.
 - `mcpEndpoint` — MCP endpoint (default: `http://localhost:3001/mcp`)


### PR DESCRIPTION
## What

Adds auto-download of `ad4m-executor` and `ad4m` CLI client binaries when they're not found in PATH or common locations. This makes the OpenClaw AD4M plugin a one-step setup — just add the plugin config and it handles the rest.

## How it works

1. **On startup** (managed mode): if `findExecutorBinary()` returns null, calls `downloadExecutor()`
2. **Detects platform**: Linux x64, macOS x64/aarch64, Windows x64
3. **Downloads from GitHub releases**: follows redirects (GitHub → S3), logs progress with percentages
4. **Saves to** `~/.ad4m-plugin/bin/` with `chmod +x`
5. **Downloads both binaries**: `ad4m-executor` and `ad4m` CLI client

## Platform support

| Platform | Status |
|----------|--------|
| Linux x64 | ✅ Available now |
| macOS aarch64 | 🔜 Asset names ready, binaries in next release |
| macOS x64 | 🔜 Asset names ready, binaries in next release |
| Windows x64 | 🔜 Asset names ready (.exe), binaries in next release |

If a binary doesn't exist for the current release, the download fails gracefully with a clear error message.

## Details

- Version hardcoded to `0.12.0-rc1` — should be updated each release or made configurable
- `findExecutorBinary()` now also checks `~/.ad4m-plugin/bin/`
- No new dependencies — uses Node.js built-in `https`/`http` modules
- Handles network errors, disk write errors, and missing assets gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic local installation of the required native executable into a plugin bin location, with platform-aware executable naming, permission setup, and re-check before falling back. Updated messaging directs users to run the setup command to install/configure.

* **Bug Fixes / Reliability**
  * More robust download/installation: follows redirects, enforces timeouts, logs progress, rejects zero-byte assets, and surfaces install failures while treating auxiliary client fetches as non-fatal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->