### PR TITLE
Feat/credit subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "multibase",
  "multihash",
  "once_cell",
+ "ort",
  "os_info",
  "percent-encoding",
  "portpicker",
@@ -14652,6 +14653,7 @@ checksum = "86d83095ae3c1258738d70ae7a06195c94d966a8e546f0d3609dc90885fb61f5"
 dependencies = [
  "half 2.7.1",
  "js-sys",
+ "libloading 0.8.9",
  "ndarray",
  "ort-sys",
  "thiserror 1.0.69",

--- a/connect/package.json
+++ b/connect/package.json
@@ -48,7 +48,7 @@
     "email": "nicolas@coasys.org"
   },
   "devDependencies": {
-    "@coasys/ad4m": "workspace:0.12.1-dev",
+    "@coasys/ad4m": "workspace:*",
     "@apollo/client": "3.7.10",
     "@types/node": "^16.11.11",
     "esbuild": "^0.15.5",

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -10,7 +10,7 @@ import { fetchUserInfo, requestPayment } from './services/hostIndex';
 
 const DEFAULT_PORT = 12000;
 const DEFAULT_INDEX_URL = "https://hosting.ad4m.dev";
-const CREDIT_POLL_INTERVAL_MS = 30000;
+const CREDIT_POLL_INTERVAL_MS = 60000;
 const DEFAULT_LOW_CREDIT_THRESHOLD = 10;
 
 export default class Ad4mConnect extends EventTarget {
@@ -277,7 +277,41 @@ export default class Ad4mConnect extends EventTarget {
     console.log('[Ad4m Connect] Disconnected successfully');
   }
 
-  // Hosting — credit polling & top-up
+  // Hosting — credit subscription & polling fallback
+
+  /**
+   * Subscribe to real-time credit updates via GraphQL subscription.
+   * Falls back to polling if the subscription is not supported by the executor.
+   */
+  startCreditSubscription(): void {
+    if (!this.ad4mClient) return;
+
+    try {
+      this.ad4mClient.agent.addHostingUserInfoChangedListener((info) => {
+        const userInfo: UserInfo = {
+          email: info.email,
+          remainingCredits: info.remainingCredits === 'unlimited' ? Infinity : (parseFloat(info.remainingCredits) || 0),
+          hotWalletAddress: info.hotWalletAddress || null,
+          freeAccess: info.freeAccess,
+        };
+        this.userInfo = userInfo;
+        this.dispatchEvent(new CustomEvent('userinfochange', { detail: userInfo }));
+
+        if (userInfo.remainingCredits <= 0) {
+          this.dispatchEvent(new CustomEvent('creditdepleted'));
+        }
+        if (userInfo.remainingCredits <= this.lowCreditThreshold) {
+          this.dispatchEvent(new CustomEvent('creditlow'));
+        }
+      });
+      this.ad4mClient.agent.subscribeHostingUserInfoChanged();
+    } catch (e) {
+      console.warn('[Ad4m Connect] Subscription not available, falling back to polling:', e);
+    }
+
+    // Always start polling as a safety-net (at a longer 60s interval)
+    this.startCreditPolling();
+  }
 
   startCreditPolling(): void {
     this.stopCreditPolling();

--- a/connect/src/web.ts
+++ b/connect/src/web.ts
@@ -256,7 +256,7 @@ export class Ad4mConnectElement extends LitElement {
         // If we have a connected host, start credit polling
         if (this.core.connectedHost) {
           this.selectedHost = this.core.connectedHost;
-          this.core.startCreditPolling();
+          this.core.startCreditSubscription();
         }
       }).catch((error) => {
         // Connection failed - show connection options
@@ -370,7 +370,7 @@ export class Ad4mConnectElement extends LitElement {
     // Called after successful remote auth when a host is selected
     if (this.selectedHost) {
       this.core.setConnectedHost(this.selectedHost);
-      this.core.startCreditPolling();
+      this.core.startCreditSubscription();
       this.currentView = "logged-in-dashboard";
     } else {
       this.modalOpen = false;

--- a/core/src/agent/AgentClient.ts
+++ b/core/src/agent/AgentClient.ts
@@ -82,6 +82,7 @@ export interface InitializeArgs {
 export type AgentUpdatedCallback = (agent: Agent) => null;
 export type AgentStatusChangedCallback = (agent: Agent) => null;
 export type AgentAppsUpdatedCallback = () => null;
+export type HostingUserInfoChangedCallback = (info: HostingUserInfo) => void;
 /**
  * Provides access to all functions regarding the local agent,
  * such as generating, locking, unlocking, importing the DID keystore,
@@ -92,12 +93,14 @@ export class AgentClient {
   #appsChangedCallback: AgentAppsUpdatedCallback[];
   #updatedCallbacks: AgentUpdatedCallback[];
   #agentStatusChangedCallbacks: AgentStatusChangedCallback[];
+  #hostingUserInfoChangedCallbacks: HostingUserInfoChangedCallback[];
 
   constructor(client: ApolloClient<any>, subscribe: boolean = true) {
     this.#apolloClient = client;
     this.#updatedCallbacks = [];
     this.#agentStatusChangedCallbacks = [];
     this.#appsChangedCallback = [];
+    this.#hostingUserInfoChangedCallbacks = [];
 
     if (subscribe) {
       this.subscribeAgentUpdated();
@@ -417,6 +420,31 @@ export class AgentClient {
           this.#agentStatusChangedCallbacks.forEach((cb) => {
             cb(agent);
           });
+        },
+        error: (e) => console.error(e),
+      });
+  }
+
+  addHostingUserInfoChangedListener(listener: HostingUserInfoChangedCallback) {
+    this.#hostingUserInfoChangedCallbacks.push(listener);
+  }
+
+  subscribeHostingUserInfoChanged() {
+    this.#apolloClient
+      .subscribe({
+        query: gql`subscription {
+          runtimeHostingUserInfoChanged {
+            email
+            remainingCredits
+            hotWalletAddress
+            freeAccess
+          }
+        }`,
+      })
+      .subscribe({
+        next: (result) => {
+          const info = result.data.runtimeHostingUserInfoChanged;
+          this.#hostingUserInfoChangedCallbacks.forEach((cb) => cb(info));
         },
         error: (e) => console.error(e),
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -605,7 +605,7 @@ importers:
         specifier: 3.7.10
         version: 3.7.10(graphql-ws@5.12.0(graphql@15.7.2(patch_hash=nr4gprddtjag7fz5nm4wirqs4q)))(graphql@15.7.2(patch_hash=nr4gprddtjag7fz5nm4wirqs4q))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@coasys/ad4m':
-        specifier: workspace:0.12.1-dev
+        specifier: workspace:*
         version: link:../core
       '@types/node':
         specifier: ^16.11.11

--- a/rust-executor/src/graphql/graphql_types.rs
+++ b/rust-executor/src/graphql/graphql_types.rs
@@ -1206,6 +1206,20 @@ impl GetFilter for AIModelLoadingStatus {
     }
 }
 
+impl GetValue for HostingUserInfo {
+    type Value = HostingUserInfo;
+
+    fn get_value(&self) -> Self::Value {
+        self.clone()
+    }
+}
+
+impl GetFilter for HostingUserInfo {
+    fn get_filter(&self) -> Option<String> {
+        None
+    }
+}
+
 #[derive(GraphQLInputObject, Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct VoiceActivityParamsInput {

--- a/rust-executor/src/graphql/graphql_types.rs
+++ b/rust-executor/src/graphql/graphql_types.rs
@@ -1216,7 +1216,7 @@ impl GetValue for HostingUserInfo {
 
 impl GetFilter for HostingUserInfo {
     fn get_filter(&self) -> Option<String> {
-        None
+        Some(self.email.clone())
     }
 }
 

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -67,7 +67,7 @@ fn reserve_compute_credits(auth_token: &str, amount: f64) -> FieldResult<()> {
         if !free {
             Ad4mDb::with_global_instance(|db| db.deduct_user_credits_if_available(email, amount))
                 .map_err(|e| FieldError::new(e.to_string(), graphql_value!(null)))?;
-            mark_credits_dirty();
+            mark_credits_dirty(email);
         }
     }
     Ok(())
@@ -3270,7 +3270,7 @@ impl Mutation {
             })
         })?;
 
-        mark_credits_dirty();
+        mark_credits_dirty(&email);
         Ok(true)
     }
 
@@ -3297,7 +3297,7 @@ impl Mutation {
             })
         })?;
 
-        mark_credits_dirty();
+        mark_credits_dirty(&email);
         Ok(true)
     }
 

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -27,7 +27,9 @@ use crate::{
     },
     holochain_service::get_holochain_service,
     languages::LanguageController,
-    pubsub::{get_global_pubsub, AGENT_STATUS_CHANGED_TOPIC, AGENT_UPDATED_TOPIC},
+    pubsub::{
+        get_global_pubsub, mark_credits_dirty, AGENT_STATUS_CHANGED_TOPIC, AGENT_UPDATED_TOPIC,
+    },
 };
 use base64::prelude::*;
 
@@ -65,6 +67,7 @@ fn reserve_compute_credits(auth_token: &str, amount: f64) -> FieldResult<()> {
         if !free {
             Ad4mDb::with_global_instance(|db| db.deduct_user_credits_if_available(email, amount))
                 .map_err(|e| FieldError::new(e.to_string(), graphql_value!(null)))?;
+            mark_credits_dirty();
         }
     }
     Ok(())
@@ -3267,6 +3270,7 @@ impl Mutation {
             })
         })?;
 
+        mark_credits_dirty();
         Ok(true)
     }
 
@@ -3293,6 +3297,7 @@ impl Mutation {
             })
         })?;
 
+        mark_credits_dirty();
         Ok(true)
     }
 

--- a/rust-executor/src/graphql/subscription_resolvers.rs
+++ b/rust-executor/src/graphql/subscription_resolvers.rs
@@ -570,9 +570,10 @@ impl Subscription {
         match check_capability(&context.capabilities, &RUNTIME_HOSTING_READ_CAPABILITY) {
             Err(e) => Box::pin(stream::once(async move { Err(e.into()) })),
             Ok(_) => {
+                let filter = user_email_from_token(context.auth_token.clone());
                 let pubsub = get_global_pubsub().await;
                 let topic = &HOSTING_USER_INFO_CHANGED_TOPIC;
-                subscribe_and_process::<HostingUserInfo>(pubsub, topic.to_string(), None).await
+                subscribe_and_process::<HostingUserInfo>(pubsub, topic.to_string(), filter).await
             }
         }
     }

--- a/rust-executor/src/graphql/subscription_resolvers.rs
+++ b/rust-executor/src/graphql/subscription_resolvers.rs
@@ -8,8 +8,8 @@ use crate::{
     pubsub::{
         get_global_pubsub, subscribe_and_process, AGENT_STATUS_CHANGED_TOPIC, AGENT_UPDATED_TOPIC,
         AI_MODEL_LOADING_STATUS, AI_TRANSCRIPTION_TEXT_TOPIC, APPS_CHANGED,
-        EXCEPTION_OCCURRED_TOPIC, NEIGHBOURHOOD_SIGNAL_TOPIC, PERSPECTIVE_ADDED_TOPIC,
-        PERSPECTIVE_LINK_ADDED_TOPIC, PERSPECTIVE_LINK_REMOVED_TOPIC,
+        EXCEPTION_OCCURRED_TOPIC, HOSTING_USER_INFO_CHANGED_TOPIC, NEIGHBOURHOOD_SIGNAL_TOPIC,
+        PERSPECTIVE_ADDED_TOPIC, PERSPECTIVE_LINK_ADDED_TOPIC, PERSPECTIVE_LINK_REMOVED_TOPIC,
         PERSPECTIVE_LINK_UPDATED_TOPIC, PERSPECTIVE_QUERY_SUBSCRIPTION_TOPIC,
         PERSPECTIVE_REMOVED_TOPIC, PERSPECTIVE_SYNC_STATE_CHANGE_TOPIC, PERSPECTIVE_UPDATED_TOPIC,
         RUNTIME_MESSAGED_RECEIVED_TOPIC, RUNTIME_NOTIFICATION_TRIGGERED_TOPIC,
@@ -559,6 +559,20 @@ impl Subscription {
                     Some(subscription_id),
                 )
                 .await
+            }
+        }
+    }
+
+    async fn runtime_hosting_user_info_changed(
+        &self,
+        context: &RequestContext,
+    ) -> Pin<Box<dyn Stream<Item = FieldResult<HostingUserInfo>> + Send>> {
+        match check_capability(&context.capabilities, &RUNTIME_HOSTING_READ_CAPABILITY) {
+            Err(e) => Box::pin(stream::once(async move { Err(e.into()) })),
+            Ok(_) => {
+                let pubsub = get_global_pubsub().await;
+                let topic = &HOSTING_USER_INFO_CHANGED_TOPIC;
+                subscribe_and_process::<HostingUserInfo>(pubsub, topic.to_string(), None).await
             }
         }
     }

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -505,18 +505,39 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
 
             let pubsub = get_global_pubsub().await;
             for email in &dirty_emails {
-                let free_access = Ad4mDb::with_global_instance(|db| db.get_user_free_access(email))
-                    .unwrap_or(false);
+                let free_access =
+                    match Ad4mDb::with_global_instance(|db| db.get_user_free_access(email)) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            error!(
+                                "Credit flush: get_user_free_access failed for {}: {}",
+                                email, e
+                            );
+                            continue;
+                        }
+                    };
                 let remaining_credits = if free_access {
                     "unlimited".to_string()
                 } else {
-                    let credits = Ad4mDb::with_global_instance(|db| db.get_user_credits(email))
-                        .unwrap_or(0.0);
-                    format!("{}", credits)
+                    match Ad4mDb::with_global_instance(|db| db.get_user_credits(email)) {
+                        Ok(credits) => format!("{}", credits),
+                        Err(e) => {
+                            error!("Credit flush: get_user_credits failed for {}: {}", email, e);
+                            continue;
+                        }
+                    }
                 };
                 let hot_wallet_address =
-                    Ad4mDb::with_global_instance(|db| db.get_user_hot_wallet(email))
-                        .unwrap_or(None);
+                    match Ad4mDb::with_global_instance(|db| db.get_user_hot_wallet(email)) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            error!(
+                                "Credit flush: get_user_hot_wallet failed for {}: {}",
+                                email, e
+                            );
+                            continue;
+                        }
+                    };
 
                 let info = crate::graphql::graphql_types::HostingUserInfo {
                     email: email.clone(),

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -476,31 +476,35 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
     });
 
     // Spawn credit change flush loop (every 2 seconds)
-    // When any credit mutation sets the dirty flag, this publishes
-    // the updated HostingUserInfo to the subscription topic.
+    // When any credit mutation marks a user dirty, this drains the set
+    // and publishes updated HostingUserInfo only for affected users.
     tokio::spawn(async {
         use crate::db::Ad4mDb;
-        use crate::pubsub::{get_global_pubsub, CREDITS_DIRTY, HOSTING_USER_INFO_CHANGED_TOPIC};
-        use std::sync::atomic::Ordering;
+        use crate::pubsub::{
+            get_global_pubsub, DIRTY_CREDIT_USERS, HOSTING_USER_INFO_CHANGED_TOPIC,
+        };
 
         loop {
             tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-            if !CREDITS_DIRTY.swap(false, Ordering::Relaxed) {
+
+            // Drain dirty users
+            let dirty_emails: Vec<String> = {
+                let mut set = match DIRTY_CREDIT_USERS.lock() {
+                    Ok(set) => set,
+                    Err(e) => {
+                        error!("Credit flush: failed to lock dirty set: {}", e);
+                        continue;
+                    }
+                };
+                set.drain().collect()
+            };
+
+            if dirty_emails.is_empty() {
                 continue;
             }
 
-            // Publish updated info for all known users
-            let users = match Ad4mDb::with_global_instance(|db| db.list_users()) {
-                Ok(users) => users,
-                Err(e) => {
-                    error!("Credit flush: failed to list users: {}", e);
-                    continue;
-                }
-            };
-
             let pubsub = get_global_pubsub().await;
-            for user in users {
-                let email = &user.username;
+            for email in &dirty_emails {
                 let free_access = Ad4mDb::with_global_instance(|db| db.get_user_free_access(email))
                     .unwrap_or(false);
                 let remaining_credits = if free_access {

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -475,6 +475,61 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
         }
     });
 
+    // Spawn credit change flush loop (every 2 seconds)
+    // When any credit mutation sets the dirty flag, this publishes
+    // the updated HostingUserInfo to the subscription topic.
+    tokio::spawn(async {
+        use crate::db::Ad4mDb;
+        use crate::pubsub::{get_global_pubsub, CREDITS_DIRTY, HOSTING_USER_INFO_CHANGED_TOPIC};
+        use std::sync::atomic::Ordering;
+
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+            if !CREDITS_DIRTY.swap(false, Ordering::Relaxed) {
+                continue;
+            }
+
+            // Publish updated info for all known users
+            let users = match Ad4mDb::with_global_instance(|db| db.list_users()) {
+                Ok(users) => users,
+                Err(e) => {
+                    error!("Credit flush: failed to list users: {}", e);
+                    continue;
+                }
+            };
+
+            let pubsub = get_global_pubsub().await;
+            for user in users {
+                let email = &user.username;
+                let free_access = Ad4mDb::with_global_instance(|db| db.get_user_free_access(email))
+                    .unwrap_or(false);
+                let remaining_credits = if free_access {
+                    "unlimited".to_string()
+                } else {
+                    let credits = Ad4mDb::with_global_instance(|db| db.get_user_credits(email))
+                        .unwrap_or(0.0);
+                    format!("{}", credits)
+                };
+                let hot_wallet_address =
+                    Ad4mDb::with_global_instance(|db| db.get_user_hot_wallet(email))
+                        .unwrap_or(None);
+
+                let info = crate::graphql::graphql_types::HostingUserInfo {
+                    email: email.clone(),
+                    remaining_credits,
+                    hot_wallet_address,
+                    free_access,
+                };
+
+                if let Ok(json) = serde_json::to_string(&info) {
+                    pubsub
+                        .publish(&HOSTING_USER_INFO_CHANGED_TOPIC, &json)
+                        .await;
+                }
+            }
+        }
+    });
+
     // Check if MCP mode is enabled — run MCP server alongside GraphQL
     if config.enable_mcp == Some(true) {
         info!("Starting MCP server alongside GraphQL...");

--- a/rust-executor/src/pubsub.rs
+++ b/rust-executor/src/pubsub.rs
@@ -6,8 +6,10 @@ use futures::StreamExt;
 use log::error;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use tokio::sync::broadcast;
 use tokio::sync::Mutex;
 use tokio_stream::wrappers::BroadcastStream;
@@ -78,8 +80,8 @@ pub(crate) async fn subscribe_and_process<
                             .expect("Could not get filter on T where we expected to filter");
                         if &data_filter != filter {
                             log::debug!(
-                                "PubSub filter mismatch on topic {}: data_filter={}, subscription_filter={}",
-                                topic, data_filter, filter
+                                "PubSub filter mismatch on topic {}: data_filter and subscription_filter differ",
+                                topic
                             );
                             return futures::future::ready(None);
                         }
@@ -138,9 +140,8 @@ lazy_static::lazy_static! {
 /// When credits are mutated, the affected user's email is inserted.
 /// A background flush loop periodically drains the set and publishes
 /// updated HostingUserInfo only for the affected users.
-pub static DIRTY_CREDIT_USERS: std::sync::LazyLock<
-    std::sync::Mutex<std::collections::HashSet<String>>,
-> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+pub static DIRTY_CREDIT_USERS: LazyLock<std::sync::Mutex<HashSet<String>>> =
+    LazyLock::new(|| std::sync::Mutex::new(HashSet::new()));
 
 pub fn mark_credits_dirty(email: &str) {
     if let Ok(mut set) = DIRTY_CREDIT_USERS.lock() {

--- a/rust-executor/src/pubsub.rs
+++ b/rust-executor/src/pubsub.rs
@@ -131,6 +131,16 @@ lazy_static::lazy_static! {
     pub static ref AI_TRANSCRIPTION_TEXT_TOPIC: String = "ai-transcription-text-topic".to_owned();
     pub static ref AI_MODEL_LOADING_STATUS: String = "ai-model-loading-status".to_owned();
     pub static ref PERSPECTIVE_QUERY_SUBSCRIPTION_TOPIC: String = "perspective-query-subscription-topic".to_owned();
+    pub static ref HOSTING_USER_INFO_CHANGED_TOPIC: String = "hosting-user-info-changed-topic".to_owned();
+}
+
+/// Dirty flag for batched credit change notifications.
+/// Set to `true` whenever credits are mutated; a background flush loop
+/// periodically checks and publishes updated HostingUserInfo.
+pub static CREDITS_DIRTY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+pub fn mark_credits_dirty() {
+    CREDITS_DIRTY.store(true, std::sync::atomic::Ordering::Relaxed);
 }
 
 pub async fn get_global_pubsub() -> Arc<PubSub> {

--- a/rust-executor/src/pubsub.rs
+++ b/rust-executor/src/pubsub.rs
@@ -134,13 +134,18 @@ lazy_static::lazy_static! {
     pub static ref HOSTING_USER_INFO_CHANGED_TOPIC: String = "hosting-user-info-changed-topic".to_owned();
 }
 
-/// Dirty flag for batched credit change notifications.
-/// Set to `true` whenever credits are mutated; a background flush loop
-/// periodically checks and publishes updated HostingUserInfo.
-pub static CREDITS_DIRTY: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+/// Per-user dirty set for batched credit change notifications.
+/// When credits are mutated, the affected user's email is inserted.
+/// A background flush loop periodically drains the set and publishes
+/// updated HostingUserInfo only for the affected users.
+pub static DIRTY_CREDIT_USERS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashSet<String>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
 
-pub fn mark_credits_dirty() {
-    CREDITS_DIRTY.store(true, std::sync::atomic::Ordering::Relaxed);
+pub fn mark_credits_dirty(email: &str) {
+    if let Ok(mut set) = DIRTY_CREDIT_USERS.lock() {
+        set.insert(email.to_owned());
+    }
 }
 
 pub async fn get_global_pubsub() -> Arc<PubSub> {

--- a/rust-executor/src/unyt_service.rs
+++ b/rust-executor/src/unyt_service.rs
@@ -741,7 +741,7 @@ fn credit_and_complete(request: &crate::db::PaymentRequest) {
         return;
     }
 
-    mark_credits_dirty();
+    mark_credits_dirty(&request.user_email);
     info!("Credited user {} with {} HOT", request.user_email, amount);
 
     if let Some(ref action_hash) = request.proposal_action_hash {
@@ -1010,7 +1010,7 @@ pub async fn handle_signal(payload_json: &JsonValue) {
                         email, amount_f64, e
                     );
                 } else {
-                    mark_credits_dirty();
+                    mark_credits_dirty(&email);
                     info!(
                         "Credited user {} with {} HOT from mHOT payment",
                         email, amount_f64

--- a/rust-executor/src/unyt_service.rs
+++ b/rust-executor/src/unyt_service.rs
@@ -18,6 +18,7 @@ use tokio::sync::RwLock;
 use crate::db::Ad4mDb;
 use crate::holochain_service::holochain_service_extension::msgpack_value_to_json;
 use crate::holochain_service::interface::{get_holochain_service, maybe_get_holochain_service};
+use crate::pubsub::mark_credits_dirty;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -740,6 +741,7 @@ fn credit_and_complete(request: &crate::db::PaymentRequest) {
         return;
     }
 
+    mark_credits_dirty();
     info!("Credited user {} with {} HOT", request.user_email, amount);
 
     if let Some(ref action_hash) = request.proposal_action_hash {
@@ -1008,6 +1010,7 @@ pub async fn handle_signal(payload_json: &JsonValue) {
                         email, amount_f64, e
                     );
                 } else {
+                    mark_credits_dirty();
                     info!(
                         "Credited user {} with {} HOT from mHOT payment",
                         email, amount_f64


### PR DESCRIPTION
# PR: Real-time Credit Updates via GraphQL Subscription

## Summary

Replaces the 30-second credit polling mechanism with a GraphQL subscription that pushes credit balance updates to the client in near real-time (~2s latency). Uses a batched dirty-flag pattern to avoid flooding the subscription during high-frequency AI token deductions.

## Architecture

```
Credit mutation (any path)
    │
    ▼
mark_credits_dirty(email)    ← Mutex<HashSet<String>>, per-user
    │
    ▼
Background flush loop (2s)   ← tokio::spawn, drains dirty set
    │
    ▼
Publish HostingUserInfo      ← only for affected user(s)
    │
    ▼
subscribe_and_process filter ← matches on email (GetFilter)
    │
    ▼
GraphQL subscription         ← runtimeHostingUserInfoChanged
    │
    ▼
Core AgentClient callback    ← addHostingUserInfoChangedListener
    │
    ▼
Connect dispatches events    ← userinfochange / creditlow / creditdepleted
```

## Commits

### 1. Server-side subscription (`ae6ee94d`)

**rust-executor/src/pubsub.rs**
- Added `HOSTING_USER_INFO_CHANGED_TOPIC` topic constant
- Added `DIRTY_CREDIT_USERS: LazyLock<Mutex<HashSet<String>>>` for per-user dirty tracking
- Added `mark_credits_dirty(email: &str)` helper that inserts the user's email into the dirty set

**rust-executor/src/graphql/subscription_resolvers.rs**
- Added `runtimeHostingUserInfoChanged` subscription resolver
- Uses `RUNTIME_HOSTING_READ_CAPABILITY` for access control
- Passes authenticated user's email as filter so each subscriber only receives their own updates

**rust-executor/src/graphql/graphql_types.rs**
- Implemented `GetValue` and `GetFilter` traits for `HostingUserInfo`
- `GetFilter` returns `Some(self.email.clone())` for per-user subscription filtering

**rust-executor/src/graphql/mutation_resolvers.rs**
- `reserve_compute_credits()` — marks user dirty after deduction
- `runtime_set_user_credits()` — marks user dirty after admin set
- `runtime_set_user_free_access()` — marks user dirty after toggle

**rust-executor/src/unyt_service.rs**
- `credit_and_complete()` — marks dirty after payment credit
- mHOT payment handler — marks dirty after payment credit

**rust-executor/src/lib.rs**
- Spawns background flush loop (2s interval) that:
  - Drains the per-user dirty set (only affected emails)
  - Fetches fresh `HostingUserInfo` for each dirty user
  - Logs and skips on DB errors instead of fabricating defaults
  - Publishes to the subscription topic

**rust-client/schema.gql**
- Added `runtimeHostingUserInfoChanged: HostingUserInfo` to Subscription type

### 2. Core client subscription (`135c7ce0`)

**core/src/agent/AgentClient.ts**
- Added `HostingUserInfoChangedCallback` type
- Added `#hostingUserInfoChangedCallbacks` private field
- Added `addHostingUserInfoChangedListener()` method
- Added `subscribeHostingUserInfoChanged()` method

### 3. Connect integration (`966443d0`)

**connect/src/core.ts**
- Added `startCreditSubscription()` — sets up subscription listener + starts polling as safety net
- Changed polling interval from 30s to 60s (now just a fallback)

**connect/src/web.ts**
- Switched both call sites from `startCreditPolling()` to `startCreditSubscription()`

**connect/package.json**
- Fixed `@coasys/ad4m` dependency from `workspace:0.12.1-dev` to `workspace:*`

### 4. Per-user scoping (`608f807f`)

- Replaced `AtomicBool` with `Mutex<HashSet<String>>` for per-user dirty tracking
- `mark_credits_dirty()` now takes `&str` email — all 5 call sites updated
- Flush loop drains dirty set — O(dirty users) not O(all users)
- Subscription resolver passes authenticated user's email as filter
- `GetFilter` for `HostingUserInfo` returns email for per-user matching

### 5. DB error handling (`ab82ae9a`)

- Flush loop now logs errors with user email context and skips publishing
- Previously `unwrap_or` would fabricate HostingUserInfo from defaults

## Design Decisions

- **Mutex<HashSet> for per-user dirty tracking**: Supports multi-user mode. Only affected users' info is fetched and published. The lock is held for a single `insert` or `drain` (nanoseconds), so contention is negligible even under concurrent AI streaming.
- **2s flush interval**: Imperceptible for a credit balance display. During idle periods the loop is essentially free (empty set drain).
- **Polling kept as fallback**: 60s safety net catches any missed `mark_dirty()` calls or edge cases. Can be removed once the subscription is battle-tested.
- **All 5 mutation sites covered**: `reserve_compute_credits`, `set_user_credits`, `set_user_free_access`, and both unyt payment paths.
- **Per-user subscription filtering**: `GetFilter` returns the user's email, resolver passes the authenticated email as filter — each subscriber only receives their own credit updates.

## Testing

- `cargo check` passes for rust-executor
- `tsc --noEmit` passes for core
- `pnpm build` passes for connect


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Real-time credit and user information updates now delivered immediately when credit balance or access status changes, with automatic fallback to periodic checks if real-time delivery becomes unavailable. Users receive instant notifications for credit depletion and low-credit warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->