### PR TITLE
feat: Hosting UI cleanup, free/paid toggle, and launcher improvements

### DIFF
--- a/connect/src/components/views/HostBrowser.ts
+++ b/connect/src/components/views/HostBrowser.ts
@@ -182,6 +182,24 @@ export class HostBrowser extends LitElement {
         flex-shrink: 0;
       }
 
+      .trust-notice {
+        display: flex;
+        gap: 10px;
+        padding: 12px 14px;
+        border-radius: 8px;
+        background: rgba(255, 200, 50, 0.08);
+        border: 1px solid rgba(255, 200, 50, 0.25);
+        margin-bottom: 12px;
+        font-size: 13px;
+        line-height: 1.45;
+        color: rgba(255, 255, 255, 0.75);
+      }
+
+      .trust-notice svg {
+        flex-shrink: 0;
+        margin-top: 1px;
+      }
+
       .pinned-label {
         font-size: 11px;
         color: var(--ac-primary-color);
@@ -276,6 +294,15 @@ export class HostBrowser extends LitElement {
         <div class="header">
           <h1>Remote Node</h1>
           <h3>Choose a host or enter a URL</h3>
+        </div>
+
+        <div class="trust-notice">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="rgba(255, 200, 50, 0.9)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+            <line x1="12" y1="9" x2="12" y2="13"/>
+            <line x1="12" y1="17" x2="12.01" y2="17"/>
+          </svg>
+          <span>By connecting to a remote host, you are trusting them to run AD4M on your behalf. Your data will be stored on their machine and they will have access to your agent's operations. Only connect to hosts you trust.</span>
         </div>
 
         ${this.loading ? html`

--- a/connect/src/components/views/HostBrowser.ts
+++ b/connect/src/components/views/HostBrowser.ts
@@ -276,7 +276,7 @@ export class HostBrowser extends LitElement {
   }
 
   private getAvgTokenPrice(rates: RemoteHost["rates"]): number | null {
-    const tokenRates = rates.filter(r => r.description.trim().toLowerCase().endsWith("per token"));
+    const tokenRates = rates.filter(r => r.description.trim().toLowerCase() !== "link write");
     if (tokenRates.length === 0) return null;
     return tokenRates.reduce((sum, r) => sum + r.priceInHOT, 0) / tokenRates.length;
   }

--- a/connect/src/components/views/HostBrowser.ts
+++ b/connect/src/components/views/HostBrowser.ts
@@ -311,7 +311,7 @@ export class HostBrowser extends LitElement {
                     const avgTokenPrice = this.getAvgTokenPrice(host.rates);
                     return html`
                     <p class="rates-preview">
-                      ${linkPrice != null ? html`Link: ${this.formatPrice(linkPrice)} HOT` : ''}${linkPrice != null && avgTokenPrice != null ? ' · ' : ''}${avgTokenPrice != null ? html`Token: ~${this.formatPrice(avgTokenPrice)} HOT` : ''}
+                      ${linkPrice != null ? html`Link: ${this.formatPrice(linkPrice)} wHOT` : ''}${linkPrice != null && avgTokenPrice != null ? ' · ' : ''}${avgTokenPrice != null ? html`Token: ~${this.formatPrice(avgTokenPrice)} wHOT` : ''}
                     </p>
                   `; })() : ''}
                 </div>

--- a/connect/src/components/views/HostDetail.ts
+++ b/connect/src/components/views/HostDetail.ts
@@ -188,7 +188,7 @@ export class HostDetail extends LitElement {
                 ${this.host.rates.filter(r => this.isOperationRate(r)).map(rate => html`
                   <tr>
                     <td>${this.rateLabel(rate.description)}</td>
-                    <td>${this.formatPrice(rate.priceInHOT)} HOT</td>
+                    <td>${this.formatPrice(rate.priceInHOT)} wHOT</td>
                   </tr>
                 `)}
                 ${this.host.rates.filter(r => !this.isOperationRate(r)).length > 0 ? html`
@@ -196,7 +196,7 @@ export class HostDetail extends LitElement {
                   ${this.host.rates.filter(r => !this.isOperationRate(r)).map(rate => html`
                     <tr>
                       <td>${rate.description}</td>
-                      <td>${this.formatPrice(rate.priceInHOT)} HOT</td>
+                      <td>${this.formatPrice(rate.priceInHOT)} wHOT</td>
                     </tr>
                   `)}
                 ` : ''}

--- a/connect/src/components/views/LoggedInDashboard.ts
+++ b/connect/src/components/views/LoggedInDashboard.ts
@@ -373,7 +373,7 @@ export class LoggedInDashboard extends LitElement {
 
           <!-- Wallet address -->
           <div class="wallet-section">
-            <label>${WalletIcon()} mHOT Wallet Address</label>
+            <label>${WalletIcon()} wHOT Wallet Address</label>
             ${this.hasWallet && !this.editingWallet ? html`
               <div class="wallet-row">
                 <div class="wallet-display" title=${this.userInfo!.hotWalletAddress}>${this.truncateMiddle(this.userInfo!.hotWalletAddress || '')}</div>
@@ -390,7 +390,7 @@ export class LoggedInDashboard extends LitElement {
               <div class="wallet-row">
                 <input
                   type="text"
-                  placeholder="Enter your mHOT wallet address"
+                  placeholder="Enter your wHOT wallet address"
                   .value=${this.walletInput}
                   @input=${(e: Event) => { this.walletInput = (e.target as HTMLInputElement).value; }}
                   @keydown=${(e: KeyboardEvent) => { if (e.key === 'Enter') this.setWalletAddress(); }}
@@ -414,7 +414,7 @@ export class LoggedInDashboard extends LitElement {
               <input
                 type="number"
                 min="1"
-                placeholder="Amount in HOT"
+                placeholder="Amount in wHOT"
                 .value=${this.topUpAmount}
                 @input=${(e: Event) => { this.topUpAmount = (e.target as HTMLInputElement).value; }}
                 @keydown=${(e: KeyboardEvent) => { if (e.key === 'Enter' && this.topUpAmount && Number(this.topUpAmount) > 0) this.requestTopUp(Number(this.topUpAmount)); }}
@@ -435,7 +435,7 @@ export class LoggedInDashboard extends LitElement {
                   ?disabled=${this.topUpDisabled}
                   @click=${() => { this.topUpAmount = String(amount); this.requestTopUp(amount); }}
                 >
-                  ${amount} HOT
+                  ${amount} wHOT
                 </button>
               `)}
             </div>

--- a/connect/src/components/views/LoggedInDashboard.ts
+++ b/connect/src/components/views/LoggedInDashboard.ts
@@ -358,7 +358,7 @@ export class LoggedInDashboard extends LitElement {
           <div class="credit-display">
             ${CreditIcon()}
             <span class="credit-amount">${credits.toFixed(2)}</span>
-            <span class="credit-label">HOT</span>
+            <span class="credit-label">wHOT</span>
           </div>
 
           ${this.isDepleted ? html`

--- a/connect/src/types.ts
+++ b/connect/src/types.ts
@@ -54,7 +54,7 @@ export type PricingItem = {
 /** User account data returned by the host after auth */
 export type UserInfo = {
   email: string;
-  remainingCredits: number;  // in HOT equivalent
-  hotWalletAddress: string | null;  // user's mHOT public address (null until set)
+  remainingCredits: number;  // in wHOT equivalent
+  hotWalletAddress: string | null;  // user's wHOT public address (null until set)
   freeAccess: boolean;
 };

--- a/connect/src/web.ts
+++ b/connect/src/web.ts
@@ -634,7 +634,7 @@ export class Ad4mConnectElement extends LitElement {
         <div class="settings-bar">
           ${credits != null ? html`
             <span class="credit-badge ${this.lowCredit ? 'low-credit' : ''}">
-              ${CreditIcon()} ${credits.toFixed(2)} HOT
+              ${CreditIcon()} ${credits.toFixed(2)} wHOT
             </span>
           ` : ''}
           <button

--- a/core/src/runtime/RuntimeClient.ts
+++ b/core/src/runtime/RuntimeClient.ts
@@ -414,6 +414,25 @@ export class RuntimeClient {
         return runtimeSetMultiUserEnabled
     }
 
+    async freeHostingEnabled(): Promise<boolean> {
+        const { runtimeFreeHostingEnabled } = unwrapApolloResult(await this.#apolloClient.query({
+            query: gql`query runtimeFreeHostingEnabled {
+                runtimeFreeHostingEnabled
+            }`
+        }))
+        return runtimeFreeHostingEnabled
+    }
+
+    async setFreeHostingEnabled(enabled: boolean): Promise<boolean> {
+        const { runtimeSetFreeHostingEnabled } = unwrapApolloResult(await this.#apolloClient.mutate({
+            mutation: gql`mutation runtimeSetFreeHostingEnabled($enabled: Boolean!) {
+                runtimeSetFreeHostingEnabled(enabled: $enabled)
+            }`,
+            variables: { enabled }
+        }))
+        return runtimeSetFreeHostingEnabled
+    }
+
     async listUsers(): Promise<UserStatistics[]> {
         const { runtimeListUsers } = unwrapApolloResult(await this.#apolloClient.query({
             query: gql`query runtimeListUsers {

--- a/core/src/runtime/RuntimeResolver.ts
+++ b/core/src/runtime/RuntimeResolver.ts
@@ -515,7 +515,7 @@ export default class RuntimeResolver {
 
     @Query(returns => Boolean)
     runtimeFreeHostingEnabled(): boolean {
-        return false
+        return true
     }
 
     @Mutation(returns => Boolean)

--- a/core/src/runtime/RuntimeResolver.ts
+++ b/core/src/runtime/RuntimeResolver.ts
@@ -513,6 +513,16 @@ export default class RuntimeResolver {
         return enabled
     }
 
+    @Query(returns => Boolean)
+    runtimeFreeHostingEnabled(): boolean {
+        return false
+    }
+
+    @Mutation(returns => Boolean)
+    runtimeSetFreeHostingEnabled(@Arg("enabled") enabled: boolean): boolean {
+        return enabled
+    }
+
     @Query(returns => [UserStatistics])
     runtimeListUsers(): UserStatistics[] {
         return [{

--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -3385,6 +3385,20 @@ impl Ad4mDb {
         self.set_setting("multi_user_enabled", if enabled { "true" } else { "false" })
     }
 
+    pub fn get_free_hosting_enabled(&self) -> Ad4mDbResult<bool> {
+        match self.get_setting("free_hosting_enabled")? {
+            Some(value) => Ok(value == "true"),
+            None => Ok(true), // Default to free hosting
+        }
+    }
+
+    pub fn set_free_hosting_enabled(&self, enabled: bool) -> Ad4mDbResult<()> {
+        self.set_setting(
+            "free_hosting_enabled",
+            if enabled { "true" } else { "false" },
+        )
+    }
+
     // Email verification functions
 
     /// Generates a 6-digit verification code, stores its SHA-256 hash, and returns the plaintext code

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -63,7 +63,7 @@ fn get_rate(description: &str, default: f64) -> FieldResult<f64> {
 fn reserve_compute_credits(auth_token: &str, amount: f64) -> FieldResult<()> {
     if let Some(ref email) = user_email_from_token(auth_token.to_string()) {
         let global_free =
-            Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled()).unwrap_or(false);
+            Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled()).unwrap_or(true);
         if global_free {
             return Ok(());
         }
@@ -84,7 +84,7 @@ fn reserve_compute_credits(auth_token: &str, amount: f64) -> FieldResult<()> {
 fn check_compute_credits(auth_token: &str) -> FieldResult<()> {
     if let Some(ref email) = user_email_from_token(auth_token.to_string()) {
         let global_free =
-            Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled()).unwrap_or(false);
+            Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled()).unwrap_or(true);
         if global_free {
             return Ok(());
         }
@@ -2604,6 +2604,13 @@ impl Mutation {
         Ad4mDb::with_global_instance(|db| {
             db.set_free_hosting_enabled(enabled)
                 .map_err(|e| FieldError::new(e.to_string(), Value::null()))?;
+            // Mark all users dirty so the credit flush loop pushes updated
+            // HostingUserInfo (with the new freeAccess value) to clients.
+            if let Ok(users) = db.list_users() {
+                for u in users {
+                    mark_credits_dirty(&u.email);
+                }
+            }
             Ok(enabled)
         })
     }
@@ -3191,7 +3198,7 @@ impl Mutation {
 
         // When free hosting is enabled, payments are not applicable
         let global_free =
-            Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled()).unwrap_or(false);
+            Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled()).unwrap_or(true);
         if global_free {
             return Ok(PaymentRequestResult {
                 success: false,

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -2608,7 +2608,7 @@ impl Mutation {
             // HostingUserInfo (with the new freeAccess value) to clients.
             if let Ok(users) = db.list_users() {
                 for u in users {
-                    mark_credits_dirty(&u.email);
+                    mark_credits_dirty(&u.username);
                 }
             }
             Ok(enabled)

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -3208,7 +3208,7 @@ impl Mutation {
             ));
         }
 
-        // Look up user's mHOT wallet address (= Holochain AgentPubKey)
+        // Look up user's wHOT wallet address (= Holochain AgentPubKey)
         let wallet_address = Ad4mDb::with_global_instance(|db| db.get_user_hot_wallet(&user_email))
             .map_err(|e| FieldError::new(format!("DB error: {}", e), Value::null()))?;
 
@@ -3217,13 +3217,13 @@ impl Mutation {
             _ => {
                 return Ok(PaymentRequestResult {
                     success: false,
-                    message: "User has not set their mHOT wallet address. Call setHotWalletAddress first.".to_string(),
+                    message: "User has not set their wHOT wallet address. Call setHotWalletAddress first.".to_string(),
                 });
             }
         };
 
         // Create payment proposal via Unyt alliance DNA
-        let note = format!("AD4M hosting top-up: {} HOT for {}", amountHOT, user_email);
+        let note = format!("AD4M hosting top-up: {} wHOT for {}", amountHOT, user_email);
         match crate::unyt_service::create_proposal(&amountHOT, &wallet_address, Some(&note)).await {
             Ok(proposal_hash) => {
                 // Record the payment request in the DB — fail the whole operation if this doesn't persist
@@ -3238,7 +3238,7 @@ impl Mutation {
                 }
 
                 log::info!(
-                    "Created mHOT payment proposal {} for user={} amount={}",
+                    "Created wHOT payment proposal {} for user={} amount={}",
                     proposal_hash,
                     user_email,
                     amountHOT
@@ -3247,7 +3247,7 @@ impl Mutation {
                 Ok(PaymentRequestResult {
                     success: true,
                     message: format!(
-                        "Payment proposal created (hash: {}). Awaiting approval in user's mHOT wallet.",
+                        "Payment proposal created (hash: {}). Awaiting approval in user's wHOT wallet.",
                         proposal_hash
                     ),
                 })
@@ -3255,7 +3255,7 @@ impl Mutation {
             Err(e) => {
                 let err_str = e.to_string();
                 log::error!(
-                    "Failed to create mHOT payment proposal for user={}: {}",
+                    "Failed to create wHOT payment proposal for user={}: {}",
                     user_email,
                     err_str
                 );
@@ -3358,7 +3358,7 @@ impl Mutation {
         }
     }
 
-    /// Send mHOT from the host's wallet to an external address.
+    /// Send wHOT from the host's wallet to an external address.
     async fn runtime_send_hot(
         &self,
         context: &RequestContext,
@@ -3368,7 +3368,7 @@ impl Mutation {
         // Admin-only: only the host operator can send from the wallet
         if !context.is_admin_credential {
             return Err(FieldError::new(
-                "Only the admin (launcher) can send mHOT",
+                "Only the admin (launcher) can send wHOT",
                 Value::null(),
             ));
         }
@@ -3399,13 +3399,13 @@ impl Mutation {
             Ok(commitment_hash) => Ok(PaymentRequestResult {
                 success: true,
                 message: format!(
-                    "Sent {} HOT to {} (commitment: {})",
+                    "Sent {} wHOT to {} (commitment: {})",
                     amount, recipient, commitment_hash
                 ),
             }),
             Err(e) => Ok(PaymentRequestResult {
                 success: false,
-                message: format!("Failed to send mHOT: {}", e),
+                message: format!("Failed to send wHOT: {}", e),
             }),
         }
     }

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -2598,7 +2598,9 @@ impl Mutation {
         context: &RequestContext,
         enabled: bool,
     ) -> FieldResult<bool> {
-        check_capability(&context.capabilities, &AGENT_UPDATE_CAPABILITY)?;
+        if !context.is_admin_credential {
+            return Err(FieldError::new("Admin credentials required", Value::null()));
+        }
         Ad4mDb::with_global_instance(|db| {
             db.set_free_hosting_enabled(enabled)
                 .map_err(|e| FieldError::new(e.to_string(), Value::null()))?;
@@ -3186,6 +3188,17 @@ impl Mutation {
         #[allow(non_snake_case)] amountHOT: String,
     ) -> FieldResult<PaymentRequestResult> {
         check_capability(&context.capabilities, &RUNTIME_HOSTING_UPDATE_CAPABILITY)?;
+
+        // When free hosting is enabled, payments are not applicable
+        let global_free =
+            Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled()).unwrap_or(false);
+        if global_free {
+            return Ok(PaymentRequestResult {
+                success: false,
+                message: "Payments are disabled — this host is configured for free access."
+                    .to_string(),
+            });
+        }
 
         let user_email = user_email_from_token(context.auth_token.clone()).ok_or_else(|| {
             FieldError::new(

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -62,6 +62,11 @@ fn get_rate(description: &str, default: f64) -> FieldResult<f64> {
 /// - Credits were successfully deducted (clamped to 0)
 fn reserve_compute_credits(auth_token: &str, amount: f64) -> FieldResult<()> {
     if let Some(ref email) = user_email_from_token(auth_token.to_string()) {
+        let global_free =
+            Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled()).unwrap_or(false);
+        if global_free {
+            return Ok(());
+        }
         let free = Ad4mDb::with_global_instance(|db| db.get_user_free_access(email))
             .map_err(|e| FieldError::new(e.to_string(), graphql_value!(null)))?;
         if !free {
@@ -78,6 +83,11 @@ fn reserve_compute_credits(auth_token: &str, amount: f64) -> FieldResult<()> {
 /// happens after the operation via reserve_compute_credits with the exact cost.
 fn check_compute_credits(auth_token: &str) -> FieldResult<()> {
     if let Some(ref email) = user_email_from_token(auth_token.to_string()) {
+        let global_free =
+            Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled()).unwrap_or(false);
+        if global_free {
+            return Ok(());
+        }
         let free = Ad4mDb::with_global_instance(|db| db.get_user_free_access(email))
             .map_err(|e| FieldError::new(e.to_string(), graphql_value!(null)))?;
         if !free {
@@ -2578,6 +2588,19 @@ impl Mutation {
         check_capability(&context.capabilities, &AGENT_UPDATE_CAPABILITY)?;
         Ad4mDb::with_global_instance(|db| {
             db.set_multi_user_enabled(enabled)
+                .map_err(|e| FieldError::new(e.to_string(), Value::null()))?;
+            Ok(enabled)
+        })
+    }
+
+    async fn runtime_set_free_hosting_enabled(
+        &self,
+        context: &RequestContext,
+        enabled: bool,
+    ) -> FieldResult<bool> {
+        check_capability(&context.capabilities, &AGENT_UPDATE_CAPABILITY)?;
+        Ad4mDb::with_global_instance(|db| {
+            db.set_free_hosting_enabled(enabled)
                 .map_err(|e| FieldError::new(e.to_string(), Value::null()))?;
             Ok(enabled)
         })

--- a/rust-executor/src/graphql/query_resolvers.rs
+++ b/rust-executor/src/graphql/query_resolvers.rs
@@ -1160,7 +1160,7 @@ impl Query {
         Ok(serde_json::to_string(&json).unwrap_or_else(|_| "[]".to_string()))
     }
 
-    /// Get the host's mHOT wallet balance from the alliance DNA ledger.
+    /// Get the host's wHOT wallet balance from the alliance DNA ledger.
     async fn runtime_hot_wallet_balance(&self, context: &RequestContext) -> FieldResult<String> {
         check_capability(&context.capabilities, &RUNTIME_HOSTING_READ_CAPABILITY)?;
 
@@ -1174,13 +1174,13 @@ impl Query {
                 Ok(serde_json::to_string(&balance).unwrap_or_else(|_| "{}".to_string()))
             }
             Err(e) => Err(FieldError::new(
-                format!("Failed to get mHOT wallet balance: {}", e),
+                format!("Failed to get wHOT wallet balance: {}", e),
                 Value::null(),
             )),
         }
     }
 
-    /// Get the host's mHOT transaction history (outgoing + incoming).
+    /// Get the host's wHOT transaction history (outgoing + incoming).
     async fn runtime_hot_wallet_history(
         &self,
         context: &RequestContext,
@@ -1359,14 +1359,14 @@ impl Query {
         Ok(serde_json::to_string(&all_txs).unwrap_or_else(|_| "[]".to_string()))
     }
 
-    /// Get the host's mHOT agent public key (their identity on the mHOT DHT).
+    /// Get the host's wHOT agent public key (their identity on the wHOT DHT).
     async fn runtime_hot_agent_pubkey(&self, context: &RequestContext) -> FieldResult<String> {
         check_capability(&context.capabilities, &RUNTIME_HOSTING_READ_CAPABILITY)?;
 
         match crate::unyt_service::whoami().await {
             Ok(pubkey) => Ok(pubkey),
             Err(e) => Err(FieldError::new(
-                format!("Failed to get mHOT agent pubkey: {}", e),
+                format!("Failed to get wHOT agent pubkey: {}", e),
                 Value::null(),
             )),
         }

--- a/rust-executor/src/graphql/query_resolvers.rs
+++ b/rust-executor/src/graphql/query_resolvers.rs
@@ -1002,6 +1002,8 @@ impl Query {
         // For each user, count their perspectives
         let mut user_stats = vec![];
         let all_perspectives = all_perspectives();
+        let global_free =
+            Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled()).unwrap_or(false);
 
         for user in users {
             // Count perspectives owned by this user
@@ -1015,8 +1017,6 @@ impl Query {
                 }
             }
 
-            let global_free =
-                Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled()).unwrap_or(false);
             let free_access: bool = global_free
                 || Ad4mDb::with_global_instance(|db| db.get_user_free_access(&user.username))
                     .map_err(|e| {

--- a/rust-executor/src/graphql/query_resolvers.rs
+++ b/rust-executor/src/graphql/query_resolvers.rs
@@ -967,6 +967,17 @@ impl Query {
         })
     }
 
+    async fn runtime_free_hosting_enabled(&self, context: &RequestContext) -> FieldResult<bool> {
+        check_capability(
+            &context.capabilities,
+            &RUNTIME_USER_MANAGEMENT_READ_ENABLED_CAPABILITY,
+        )?;
+        Ad4mDb::with_global_instance(|db| {
+            db.get_free_hosting_enabled()
+                .map_err(|e| FieldError::new(e.to_string(), Value::null()))
+        })
+    }
+
     async fn runtime_list_users(
         &self,
         context: &RequestContext,
@@ -1004,8 +1015,10 @@ impl Query {
                 }
             }
 
-            let free_access: bool =
-                Ad4mDb::with_global_instance(|db| db.get_user_free_access(&user.username))
+            let global_free =
+                Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled()).unwrap_or(false);
+            let free_access: bool = global_free
+                || Ad4mDb::with_global_instance(|db| db.get_user_free_access(&user.username))
                     .map_err(|e| {
                         FieldError::new(
                             format!("Failed to get user free access: {}", e),
@@ -1089,13 +1102,17 @@ impl Query {
             )
         })?;
 
-        let free_access = Ad4mDb::with_global_instance(|db| db.get_user_free_access(&user_email))
-            .map_err(|e| {
-            FieldError::new(
-                format!("Failed to get free access status: {}", e),
-                Value::null(),
-            )
-        })?;
+        let global_free =
+            Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled()).unwrap_or(false);
+        let free_access = global_free
+            || Ad4mDb::with_global_instance(|db| db.get_user_free_access(&user_email)).map_err(
+                |e| {
+                    FieldError::new(
+                        format!("Failed to get free access status: {}", e),
+                        Value::null(),
+                    )
+                },
+            )?;
 
         let remaining_credits = if free_access {
             "unlimited".to_string()

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -504,9 +504,15 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
             }
 
             let pubsub = get_global_pubsub().await;
+            let global_free = match Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled())
+            {
+                Ok(v) => v,
+                Err(e) => {
+                    error!("Credit flush: get_free_hosting_enabled failed: {}", e);
+                    true // default to free on transient errors to avoid wrongly blocking users
+                }
+            };
             for email in &dirty_emails {
-                let global_free = Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled())
-                    .unwrap_or(false);
                 let free_access = if global_free {
                     true
                 } else {

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -505,7 +505,11 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
 
             let pubsub = get_global_pubsub().await;
             for email in &dirty_emails {
-                let free_access =
+                let global_free = Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled())
+                    .unwrap_or(false);
+                let free_access = if global_free {
+                    true
+                } else {
                     match Ad4mDb::with_global_instance(|db| db.get_user_free_access(email)) {
                         Ok(v) => v,
                         Err(e) => {
@@ -515,7 +519,8 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
                             );
                             continue;
                         }
-                    };
+                    }
+                };
                 let remaining_credits = if free_access {
                     "unlimited".to_string()
                 } else {

--- a/ui/src/components/Hosting.tsx
+++ b/ui/src/components/Hosting.tsx
@@ -1164,14 +1164,14 @@ const Hosting = () => {
             }}
           >
             <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
-              Paid hosting via <HotLogo size={20} /> HOT
+              Paid hosting via <HotLogo size={20} /> wHOT
             </span>
           </j-toggle>
           <j-box mt="200">
             <j-text size="400" color="ui-500">
               {freeHostingEnabled
                 ? "All users have free access. No payment or wallet setup required."
-                : "Users pay with HOT credits to use this node. Configure your wallet below."}
+                : "Users pay with wHOT credits to use this node. Configure your wallet below."}
             </j-text>
           </j-box>
         </j-box>
@@ -1211,7 +1211,7 @@ const Hosting = () => {
             >
               <j-box mb="300">
                 <j-text size="400" color="ui-500">
-                  Required for receiving mHOT payments. The Unyt DNA enables
+                  Required for receiving wHOT payments. The Unyt DNA enables
                   your AD4M instance to join the payment network.
                 </j-text>
               </j-box>
@@ -1476,7 +1476,7 @@ const Hosting = () => {
                   >
                     <j-box mb="400">
                       <j-text size="400" color="ui-500">
-                        Register to appear in ad4m-connect and receive mHOT
+                        Register to appear in ad4m-connect and receive wHOT
                         payments.
                       </j-text>
                     </j-box>
@@ -1903,7 +1903,7 @@ const Hosting = () => {
                         try { parsed = JSON.parse(hostReg.rates); } catch {}
                         if (!Array.isArray(parsed)) parsed = [];
 
-                        // Defaults in HOT (at ~$0.0004/HOT)
+                        // Defaults in wHOT (at ~$0.0004/wHOT)
                         const DEFAULT_LINK_PRICE = 0.25;    // ~$0.0001 per link
                         const DEFAULT_TOKEN_PRICE = 12.5;   // ~$0.005 per token, avg API pricing
 
@@ -2006,7 +2006,7 @@ const Hosting = () => {
                               }}
                             >
                               <span>Item</span>
-                              <span>Price (HOT)</span>
+                              <span>Price (wHOT)</span>
                             </div>
 
                             {/* Base link price */}

--- a/ui/src/components/Hosting.tsx
+++ b/ui/src/components/Hosting.tsx
@@ -841,6 +841,7 @@ const Hosting = () => {
   }, [multiUserEnabled, client, getUsers]);
 
   useEffect(() => {
+    if (freeHostingEnabled) return;
     const loadHostSession = async () => {
       try {
         const reg = await invoke<{
@@ -885,13 +886,14 @@ const Hosting = () => {
       }
     };
     loadHostSession();
-  }, []);
+  }, [freeHostingEnabled]);
 
   // Auto-fetch membrane proof once when we have a session + client but no proof yet
   useEffect(() => {
+    if (freeHostingEnabled) return;
     if (!client || !hostSession || membraneProofStatus === "done" || membraneProofStatus === "fetching" || membraneProofAttempted.current) return;
     fetchMembraneProof(hostSession);
-  }, [client, hostSession]);
+  }, [client, hostSession, freeHostingEnabled]);
 
   // Auto-populate host URL from TLS domain
   useEffect(() => {
@@ -1054,10 +1056,21 @@ const Hosting = () => {
           <j-flex a="center" gap="300">
             <span>Enable multi-user hosting</span>
             {multiUserEnabled && (
-              <j-flex
-                a="center"
-                gap="200"
-                style={{ cursor: "pointer" }}
+              <button
+                type="button"
+                aria-expanded={setupInfoExpanded}
+                aria-controls="setup-info-panel"
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "4px",
+                  cursor: "pointer",
+                  background: "none",
+                  border: "none",
+                  padding: 0,
+                  font: "inherit",
+                  color: "inherit",
+                }}
                 onClick={(e: React.MouseEvent) => {
                   e.preventDefault();
                   e.stopPropagation();
@@ -1077,7 +1090,7 @@ const Hosting = () => {
                   color="ui-500"
                   size="xs"
                 ></j-icon>
-              </j-flex>
+              </button>
             )}
           </j-flex>
         </j-toggle>
@@ -1094,11 +1107,14 @@ const Hosting = () => {
       {multiUserEnabled && (
         <j-box px="500">
           <div
+            id="setup-info-panel"
             style={{
               overflow: "hidden",
               maxHeight: setupInfoExpanded ? "600px" : "0",
               opacity: setupInfoExpanded ? 1 : 0,
-              transition: "max-height 0.4s ease, opacity 0.3s ease",
+              visibility: setupInfoExpanded ? "visible" as const : "hidden" as const,
+              pointerEvents: setupInfoExpanded ? "auto" as const : "none" as const,
+              transition: "max-height 0.4s ease, opacity 0.3s ease, visibility 0.3s ease",
               marginTop: setupInfoExpanded ? "8px" : "0",
             }}
           >
@@ -1320,7 +1336,7 @@ const Hosting = () => {
                                 {user.email}
                               </j-text>
                               {getStatusBadge(user.lastSeen)}
-                              {(user as any).freeAccess && (
+                              {(freeHostingEnabled || (user as any).freeAccess) && (
                                 <j-badge variant="success">Free Access</j-badge>
                               )}
                             </j-flex>

--- a/ui/src/components/Hosting.tsx
+++ b/ui/src/components/Hosting.tsx
@@ -124,6 +124,13 @@ const Hosting = () => {
     message: string;
   } | null>(null);
   const [hostRegistering, setHostRegistering] = useState(false);
+
+  // Auto-clear status messages after 5 seconds
+  useEffect(() => {
+    if (!hostRegStatus) return;
+    const timer = setTimeout(() => setHostRegStatus(null), 5000);
+    return () => clearTimeout(timer);
+  }, [hostRegStatus]);
   const [profilePic, setProfilePic] = useState<File | null>(null);
   const [profilePicUrl, setProfilePicUrl] = useState<string | null>(null);
   React.useEffect(() => {

--- a/ui/src/components/Hosting.tsx
+++ b/ui/src/components/Hosting.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open as dialogOpen } from "@tauri-apps/plugin-dialog";
 import { Ad4minContext } from "../context/Ad4minContext";
 import { cardStyle, listStyle } from "./styles";
-import Wallet from "./Wallet";
+import Wallet, { HotLogo } from "./Wallet";
 import type { UserStatistics } from "@coasys/ad4m";
 
 type HostSession = {
@@ -96,8 +96,8 @@ const ExpandableSection = ({
 
 const Hosting = () => {
   const {
-    state: { client, multiUserEnabled },
-    methods: { setMultiUserEnabled },
+    state: { client, multiUserEnabled, freeHostingEnabled },
+    methods: { setMultiUserEnabled, setFreeHostingEnabled },
   } = useContext(Ad4minContext);
 
   // ---- Users state ----
@@ -182,6 +182,18 @@ const Hosting = () => {
   const [hostingProfileExpanded, setHostingProfileExpanded] = useState(true);
   const [tlsExpanded, setTlsExpanded] = useState(false);
   const [smtpExpanded, setSmtpExpanded] = useState(false);
+  const [setupInfoExpanded, setSetupInfoExpanded] = useState(false);
+  const prevMultiUserEnabled = useRef(multiUserEnabled);
+
+  // Auto-expand setup info when multi-user is first enabled, then auto-collapse
+  useEffect(() => {
+    if (multiUserEnabled && !prevMultiUserEnabled.current) {
+      setSetupInfoExpanded(true);
+      const timer = setTimeout(() => setSetupInfoExpanded(false), 10000);
+      return () => clearTimeout(timer);
+    }
+    prevMultiUserEnabled.current = multiUserEnabled;
+  }, [multiUserEnabled]);
 
   // ---- Helpers ----
 
@@ -1039,33 +1051,149 @@ const Hosting = () => {
             }
           }}
         >
-          Multi-user mode
+          <j-flex a="center" gap="300">
+            <span>Enable multi-user hosting</span>
+            {multiUserEnabled && (
+              <j-flex
+                a="center"
+                gap="200"
+                style={{ cursor: "pointer" }}
+                onClick={(e: React.MouseEvent) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setSetupInfoExpanded(!setupInfoExpanded);
+                }}
+              >
+                <j-icon
+                  name={setupInfoExpanded ? "info-circle-fill" : "info-circle"}
+                  color="ui-500"
+                  size="sm"
+                ></j-icon>
+                <j-text size="300" color="ui-500" weight="500" nomargin>
+                  Setup instructions
+                </j-text>
+                <j-icon
+                  name={setupInfoExpanded ? "chevron-up" : "chevron-down"}
+                  color="ui-500"
+                  size="xs"
+                ></j-icon>
+              </j-flex>
+            )}
+          </j-flex>
         </j-toggle>
       </j-box>
 
       {!multiUserEnabled && (
         <j-box px="500" my="300">
           <j-text size="500" color="ui-500">
-            Enable multi-user mode to host this AD4M instance for other users.
+            Enable this to host your AD4M node for other users.
           </j-text>
         </j-box>
       )}
 
       {multiUserEnabled && (
-        <>
-          {/* ===== WALLET (Simple Framed) ===== */}
-          <j-box px="500" my="100">
+        <j-box px="500">
+          <div
+            style={{
+              overflow: "hidden",
+              maxHeight: setupInfoExpanded ? "600px" : "0",
+              opacity: setupInfoExpanded ? 1 : 0,
+              transition: "max-height 0.4s ease, opacity 0.3s ease",
+              marginTop: setupInfoExpanded ? "8px" : "0",
+            }}
+          >
             <div
               style={{
-                border: "1px solid var(--j-color-ui-200)",
-                borderRadius: "12px",
-                padding: "10px",
+                padding: "12px 16px",
                 background: "var(--j-color-ui-50)",
+                borderRadius: "8px",
+                border: "1px solid var(--j-color-ui-200)",
               }}
             >
-              <Wallet key="wallet" />
+              <j-text size="400" color="ui-500">
+                Allows remote users to sign up and log in via email and password.
+              </j-text>
+              <j-box mt="300">
+                <j-text size="400" color="ui-500">
+                  <strong>Email verification (optional):</strong> Configure an SMTP email service
+                  in the Settings tab below to enable verification codes.
+                  Without SMTP, users will sign in with just email and password.
+                </j-text>
+              </j-box>
+              <j-box mt="300">
+                <j-text size="400" color="ui-500">
+                  <strong>TLS certificate (required for security):</strong> You should obtain a TLS
+                  certificate for your domain, e.g. from{" "}
+                  <a
+                    href="https://letsencrypt.org"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: "var(--j-color-primary-500)" }}
+                  >
+                    Let's Encrypt
+                  </a>
+                  . Then point to your certificate and key files in the{" "}
+                  <strong>TLS Configuration</strong> section in the Settings tab.
+                  TLS runs on a separate port which you can configure there.
+                </j-text>
+              </j-box>
+              <j-box mt="300">
+                <j-text size="400" color="ui-500">
+                  <strong>Network access:</strong> Make sure the AD4M executor's TLS port is
+                  publicly accessible — you may need to configure port forwarding on your
+                  router or firewall so that remote users can connect.
+                </j-text>
+              </j-box>
             </div>
+          </div>
+        </j-box>
+      )}
+
+      {multiUserEnabled && (
+        <j-box px="500" my="300">
+          <j-toggle
+            full=""
+            checked={!freeHostingEnabled}
+            onChange={async (e: any) => {
+              try {
+                await setFreeHostingEnabled(!e.target.checked);
+              } catch (error) {
+                console.error("Failed to toggle hosting mode:", error);
+                e.target.checked = !e.target.checked;
+              }
+            }}
+          >
+            <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
+              Paid hosting via <HotLogo size={20} /> HOT
+            </span>
+          </j-toggle>
+          <j-box mt="200">
+            <j-text size="400" color="ui-500">
+              {freeHostingEnabled
+                ? "All users have free access. No payment or wallet setup required."
+                : "Users pay with HOT credits to use this node. Configure your wallet below."}
+            </j-text>
           </j-box>
+        </j-box>
+      )}
+
+      {multiUserEnabled && (
+        <>
+          {/* ===== WALLET (Simple Framed) - only shown for paid hosting ===== */}
+          {!freeHostingEnabled && (
+            <j-box px="500" my="100">
+              <div
+                style={{
+                  border: "1px solid var(--j-color-ui-200)",
+                  borderRadius: "12px",
+                  padding: "10px",
+                  background: "var(--j-color-ui-50)",
+                }}
+              >
+                <Wallet key="wallet" />
+              </div>
+            </j-box>
+          )}
 
           {/* ===== UNYT DNA (Expandable) ===== */}
           {false && (
@@ -1237,23 +1365,26 @@ const Hosting = () => {
                               {user.perspectiveCount}
                             </j-text>
                           </j-flex>
-                          <j-flex direction="column" gap="100">
-                            <j-text
-                              nomargin
-                              size="300"
-                              color="ui-500"
-                              weight="500"
-                            >
-                              CREDITS
-                            </j-text>
-                            <j-text nomargin size="400" weight="600">
-                              {(user as any).remainingCredits === "unlimited"
-                                ? "Unlimited"
-                                : (user as any).remainingCredits || "0"}
-                            </j-text>
-                          </j-flex>
+                          {!freeHostingEnabled && (
+                            <j-flex direction="column" gap="100">
+                              <j-text
+                                nomargin
+                                size="300"
+                                color="ui-500"
+                                weight="500"
+                              >
+                                CREDITS
+                              </j-text>
+                              <j-text nomargin size="400" weight="600">
+                                {(user as any).remainingCredits === "unlimited"
+                                  ? "Unlimited"
+                                  : (user as any).remainingCredits || "0"}
+                              </j-text>
+                            </j-flex>
+                          )}
                         </j-flex>
 
+                        {!freeHostingEnabled && (
                         <j-box
                           style={{
                             borderTop: "1px solid var(--j-color-ui-200)",
@@ -1305,6 +1436,7 @@ const Hosting = () => {
                             )}
                           </j-flex>
                         </j-box>
+                        )}
                       </j-flex>
                     </div>
                   ))}
@@ -1316,7 +1448,8 @@ const Hosting = () => {
           {/* ===== SETTINGS TAB ===== */}
           {activeTab === "settings" && (
             <j-box px="500" my="400">
-              {/* Hosting Profile */}
+              {/* Hosting Profile - only shown for paid hosting */}
+              {!freeHostingEnabled && (
               <ExpandableSection
                 title="Hosting Profile"
                 expanded={hostingProfileExpanded}
@@ -1929,6 +2062,7 @@ const Hosting = () => {
                   </div>
                 )}
               </ExpandableSection>
+              )}
 
               {/* TLS Settings */}
               <ExpandableSection

--- a/ui/src/components/Hosting.tsx
+++ b/ui/src/components/Hosting.tsx
@@ -895,15 +895,17 @@ const Hosting = () => {
     fetchMembraneProof(hostSession);
   }, [client, hostSession, freeHostingEnabled]);
 
-  // Auto-populate host URL from TLS domain
+  // Auto-populate host URL from TLS domain + port
   useEffect(() => {
     if (!client) return;
     const fetchTlsDomain = async () => {
       try {
         const domain = await client.runtime.tlsDomain();
         if (domain) {
+          const port = tlsConfig?.tls_port || 12001;
+          const url = `wss://${domain}:${port}/graphql`;
           setHostReg((prev) =>
-            prev.hostUrl ? prev : { ...prev, hostUrl: `wss://${domain}` },
+            prev.hostUrl ? prev : { ...prev, hostUrl: url },
           );
         }
       } catch (e) {
@@ -911,7 +913,7 @@ const Hosting = () => {
       }
     };
     fetchTlsDomain();
-  }, [client]);
+  }, [client, tlsConfig]);
 
   useEffect(() => {
     if (!client) return;
@@ -1039,6 +1041,18 @@ const Hosting = () => {
 
   return (
     <div>
+      <style>{`
+        .hosting-input::placeholder {
+          color: var(--j-color-ui-300) !important;
+          font-weight: 400 !important;
+          opacity: 1;
+        }
+        textarea.hosting-input::placeholder {
+          color: var(--j-color-ui-300) !important;
+          font-weight: 400 !important;
+          opacity: 1;
+        }
+      `}</style>
       {/* Multi-user toggle */}
       <j-box px="500" my="500">
         <j-toggle
@@ -1613,8 +1627,21 @@ const Hosting = () => {
                       background: "var(--j-color-ui-50)",
                       borderRadius: "12px",
                       border: "1px solid var(--j-color-ui-200)",
+                      position: "relative" as const,
                     }}
                   >
+                    {/* Info tooltip */}
+                    <j-tooltip
+                      title="This is your public hosting profile. Other users will see this information in AD4M Connect when choosing a host."
+                      placement="left"
+                    >
+                      <j-icon
+                        name="info-circle"
+                        color="ui-400"
+                        size="sm"
+                        style={{ position: "absolute", top: "12px", right: "12px", cursor: "help" }}
+                      ></j-icon>
+                    </j-tooltip>
                     {/* Profile picture */}
                     <label
                       style={{
@@ -1709,6 +1736,7 @@ const Hosting = () => {
 
                     {/* Name */}
                     <input
+                      className="hosting-input"
                       value={hostReg.name}
                       onChange={(e) =>
                         handleHostRegChange("name", e.target.value)
@@ -1730,6 +1758,7 @@ const Hosting = () => {
 
                     {/* Location */}
                     <input
+                      className="hosting-input"
                       value={hostReg.location}
                       onChange={(e) =>
                         handleHostRegChange("location", e.target.value)
@@ -1741,7 +1770,7 @@ const Hosting = () => {
                         background: "transparent",
                         border: "none",
                         borderBottom: "1px dashed var(--j-color-ui-300)",
-                        color: "var(--j-color-ui-500)",
+                        color: "var(--j-color-black)",
                         width: "100%",
                         padding: "2px 0",
                         outline: "none",
@@ -1750,6 +1779,7 @@ const Hosting = () => {
 
                     {/* Description */}
                     <textarea
+                      className="hosting-input"
                       value={hostReg.description}
                       onChange={(e) =>
                         handleHostRegChange("description", e.target.value)
@@ -1763,7 +1793,7 @@ const Hosting = () => {
                         background: "transparent",
                         border: "none",
                         borderBottom: "1px dashed var(--j-color-ui-300)",
-                        color: "var(--j-color-ui-400)",
+                        color: "var(--j-color-black)",
                         width: "100%",
                         padding: "2px 0",
                         outline: "none",
@@ -1773,26 +1803,44 @@ const Hosting = () => {
                     />
 
                     {/* Endpoint URL */}
-                    <div style={{ width: "100%" }}>
+                    <div
+                      style={{
+                        width: "100%",
+                        padding: "12px 16px",
+                        background: "var(--j-color-primary-50, rgba(33,150,243,0.05))",
+                        borderRadius: "8px",
+                        border: "1px solid var(--j-color-primary-200, rgba(33,150,243,0.2))",
+                      }}
+                    >
                       <j-text
                         size="300"
                         weight="600"
-                        color="ui-500"
+                        color="primary-500"
                         style={{
                           textTransform: "uppercase",
                           letterSpacing: "0.5px",
                           display: "block",
-                          marginBottom: "6px",
+                          marginBottom: "4px",
                         }}
                       >
                         Endpoint URL
                       </j-text>
+                      <j-text
+                        size="300"
+                        color="ui-500"
+                        style={{ display: "block", marginBottom: "8px" }}
+                      >
+                        This is how remote users reach your node. It is auto-populated
+                        from your TLS domain and port configuration. Make sure this
+                        address is publicly reachable (check your router / firewall settings).
+                      </j-text>
                       <input
+                        className="hosting-input"
                         value={hostReg.hostUrl}
                         onChange={(e) =>
                           handleHostRegChange("hostUrl", e.target.value)
                         }
-                        placeholder="wss://your-host-domain.com"
+                        placeholder="wss://your-domain.com:12001/graphql"
                         style={{
                           fontSize: "13px",
                           width: "100%",
@@ -1800,7 +1848,8 @@ const Hosting = () => {
                           background: "var(--j-color-ui-100)",
                           border: "1px solid var(--j-color-ui-200)",
                           borderRadius: "6px",
-                          color: "var(--j-color-ui-600)",
+                          color: "var(--j-color-black)",
+                          fontWeight: 500,
                           outline: "none",
                           fontFamily: "monospace",
                         }}
@@ -1823,6 +1872,7 @@ const Hosting = () => {
                         Compute
                       </j-text>
                       <input
+                        className="hosting-input"
                         value={hostReg.computeSpecs}
                         onChange={(e) =>
                           handleHostRegChange("computeSpecs", e.target.value)
@@ -1835,7 +1885,8 @@ const Hosting = () => {
                           background: "var(--j-color-ui-100)",
                           border: "1px solid var(--j-color-ui-200)",
                           borderRadius: "6px",
-                          color: "var(--j-color-ui-600)",
+                          color: "var(--j-color-black)",
+                          fontWeight: 500,
                           outline: "none",
                           fontFamily: "inherit",
                         }}

--- a/ui/src/components/Hosting.tsx
+++ b/ui/src/components/Hosting.tsx
@@ -60,38 +60,31 @@ const ExpandableSection = ({
   children: React.ReactNode;
   badge?: React.ReactNode;
 }) => (
-  <j-box
-    my="300"
-    style={{
-      border: "1px solid var(--j-color-ui-200)",
-      borderRadius: "8px",
-      overflow: "hidden",
-    }}
-  >
-    <j-flex
-      a="center"
-      j="between"
-      p="400"
-      style={{
-        background: "var(--j-color-ui-50)",
-        cursor: "pointer",
-        borderBottom: expanded ? "1px solid var(--j-color-ui-200)" : "none",
-      }}
+  <div style={{ margin: "16px 0" }}>
+    <div
       onClick={onToggle}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        cursor: "pointer",
+        padding: "8px 0",
+        userSelect: "none",
+      }}
     >
-      <j-flex a="center" gap="300">
-        <j-icon
-          name={expanded ? "chevron-down" : "chevron-right"}
-          size="sm"
-        ></j-icon>
-        <j-text size="500" weight="600">
-          {title}
-        </j-text>
-        {badge}
-      </j-flex>
-    </j-flex>
-    {expanded && <j-box p="400">{children}</j-box>}
-  </j-box>
+      <j-icon
+        name={expanded ? "chevron-down" : "chevron-right"}
+        size="sm"
+      ></j-icon>
+      <span style={{ fontSize: "16px", fontWeight: 600, flex: 1 }}>
+        {title}
+      </span>
+      {badge}
+    </div>
+    {expanded && (
+      <div style={{ padding: "12px 0 0 24px" }}>{children}</div>
+    )}
+  </div>
 );
 
 const Hosting = () => {
@@ -1019,21 +1012,10 @@ const Hosting = () => {
           ? "danger"
           : "primary";
     return (
-      <j-box px="500" my="300">
-        <j-box
-          p="400"
-          style={{
-            backgroundColor: bg,
-            borderRadius: "8px",
-            border: `1px solid ${border}`,
-          }}
-        >
-          <j-flex a="center" gap="300">
-            <j-icon name={icon} color={color}></j-icon>
-            <j-text size="500">{hostRegStatus.message}</j-text>
-          </j-flex>
-        </j-box>
-      </j-box>
+      <div style={{ display: "flex", alignItems: "center", gap: "8px", margin: "12px 0" }}>
+        <j-icon name={icon} color={color}></j-icon>
+        <span style={{ fontSize: "14px", color: border }}>{hostRegStatus.message}</span>
+      </div>
     );
   };
 
@@ -1311,7 +1293,7 @@ const Hosting = () => {
 
           {/* ===== USERS TAB ===== */}
           {activeTab === "users" && (
-            <j-box px="500" my="400">
+            <div style={{ padding: "0 var(--j-space-500)", margin: "var(--j-space-400) 0" }}>
               {usersLoading ? (
                 <j-flex gap="300" a="center">
                   <j-spinner size="sm"></j-spinner>
@@ -1472,12 +1454,12 @@ const Hosting = () => {
                   ))}
                 </div>
               )}
-            </j-box>
+            </div>
           )}
 
           {/* ===== SETTINGS TAB ===== */}
           {activeTab === "settings" && (
-            <j-box px="500" my="400">
+            <div style={{ padding: "0 var(--j-space-500)", margin: "var(--j-space-400) 0" }}>
               {/* Hosting Profile - only shown for paid hosting */}
               {!freeHostingEnabled && (
               <ExpandableSection
@@ -1631,17 +1613,19 @@ const Hosting = () => {
                     }}
                   >
                     {/* Info tooltip */}
-                    <j-tooltip
-                      title="This is your public hosting profile. Other users will see this information in AD4M Connect when choosing a host."
-                      placement="left"
-                    >
-                      <j-icon
-                        name="info-circle"
-                        color="ui-400"
-                        size="sm"
-                        style={{ position: "absolute", top: "12px", right: "12px", cursor: "help" }}
-                      ></j-icon>
-                    </j-tooltip>
+                    <div style={{ position: "absolute", top: "12px", right: "12px", zIndex: 1 }}>
+                      <j-tooltip
+                        title="This is your public hosting profile. Other users will see this information in AD4M Connect when choosing a host."
+                        placement="left"
+                      >
+                        <j-icon
+                          name="info-circle"
+                          color="ui-400"
+                          size="sm"
+                          style={{ cursor: "help" }}
+                        ></j-icon>
+                      </j-tooltip>
+                    </div>
                     {/* Profile picture */}
                     <label
                       style={{
@@ -1743,7 +1727,7 @@ const Hosting = () => {
                       }
                       placeholder="Host Name"
                       style={{
-                        fontSize: "20px",
+                        fontSize: "22px",
                         fontWeight: 700,
                         textAlign: "center",
                         background: "transparent",
@@ -1765,7 +1749,7 @@ const Hosting = () => {
                       }
                       placeholder="Location (e.g. Frankfurt, DE)"
                       style={{
-                        fontSize: "14px",
+                        fontSize: "16px",
                         textAlign: "center",
                         background: "transparent",
                         border: "none",
@@ -1787,7 +1771,7 @@ const Hosting = () => {
                       placeholder="A brief description of your host"
                       rows={2}
                       style={{
-                        fontSize: "14px",
+                        fontSize: "16px",
                         textAlign: "center",
                         lineHeight: "1.4",
                         background: "transparent",
@@ -1813,7 +1797,7 @@ const Hosting = () => {
                       }}
                     >
                       <j-text
-                        size="300"
+                        size="400"
                         weight="600"
                         color="primary-500"
                         style={{
@@ -1826,7 +1810,7 @@ const Hosting = () => {
                         Endpoint URL
                       </j-text>
                       <j-text
-                        size="300"
+                        size="400"
                         color="ui-500"
                         style={{ display: "block", marginBottom: "8px" }}
                       >
@@ -1842,7 +1826,7 @@ const Hosting = () => {
                         }
                         placeholder="wss://your-domain.com:12001/graphql"
                         style={{
-                          fontSize: "13px",
+                          fontSize: "15px",
                           width: "100%",
                           padding: "8px 12px",
                           background: "var(--j-color-ui-100)",
@@ -1859,7 +1843,7 @@ const Hosting = () => {
                     {/* Compute Specs */}
                     <div style={{ width: "100%" }}>
                       <j-text
-                        size="300"
+                        size="400"
                         weight="600"
                         color="ui-500"
                         style={{
@@ -1879,7 +1863,7 @@ const Hosting = () => {
                         }
                         placeholder="e.g. 8 CPU, 32GB RAM, RTX 4090"
                         style={{
-                          fontSize: "14px",
+                          fontSize: "16px",
                           width: "100%",
                           padding: "8px 12px",
                           background: "var(--j-color-ui-100)",
@@ -1896,7 +1880,7 @@ const Hosting = () => {
                     {/* AI Models */}
                     <div style={{ width: "100%" }}>
                       <j-text
-                        size="300"
+                        size="400"
                         weight="600"
                         color="ui-500"
                         style={{
@@ -1921,7 +1905,7 @@ const Hosting = () => {
                             <span
                               key={i}
                               style={{
-                                fontSize: "13px",
+                                fontSize: "15px",
                                 padding: "4px 12px",
                                 borderRadius: "12px",
                                 background: "rgba(33, 150, 243, 0.1)",
@@ -1934,7 +1918,7 @@ const Hosting = () => {
                         </div>
                       ) : (
                         <j-text
-                          size="300"
+                          size="400"
                           color="ui-400"
                           style={{ fontStyle: "italic" }}
                         >
@@ -1942,7 +1926,7 @@ const Hosting = () => {
                         </j-text>
                       )}
                       <j-text
-                        size="200"
+                        size="300"
                         color="ui-400"
                         style={{ display: "block", marginTop: "6px" }}
                       >
@@ -1953,7 +1937,7 @@ const Hosting = () => {
                     {/* Pricing */}
                     <div style={{ width: "100%" }}>
                       <j-text
-                        size="300"
+                        size="400"
                         weight="600"
                         color="ui-500"
                         style={{
@@ -2027,7 +2011,7 @@ const Hosting = () => {
                         };
 
                         const inputStyle: React.CSSProperties = {
-                          fontSize: "13px",
+                          fontSize: "15px",
                           width: "110px",
                           padding: "6px 10px",
                           background: "var(--j-color-ui-100)",
@@ -2048,7 +2032,7 @@ const Hosting = () => {
                         };
 
                         const labelStyle: React.CSSProperties = {
-                          fontSize: "13px",
+                          fontSize: "15px",
                           color: "var(--j-color-ui-600)",
                         };
 
@@ -2066,7 +2050,7 @@ const Hosting = () => {
                                 ...rowStyle,
                                 background: "var(--j-color-ui-50)",
                                 fontWeight: 600,
-                                fontSize: "12px",
+                                fontSize: "14px",
                                 textTransform: "uppercase",
                                 letterSpacing: "0.5px",
                                 color: "var(--j-color-ui-500)",
@@ -2090,7 +2074,7 @@ const Hosting = () => {
                             {/* Per-model token prices */}
                             {modelNames.map((name) => (
                               <div key={name} style={rowStyle}>
-                                <span style={labelStyle}>{name} <span style={{ color: "var(--j-color-ui-400)", fontSize: "12px" }}>(per token)</span></span>
+                                <span style={labelStyle}>{name} <span style={{ color: "var(--j-color-ui-400)", fontSize: "14px" }}>(per token)</span></span>
                                 <PriceInput
                                   initialValue={getPrice(name)}
                                   placeholder={String(getDefault(name))}
@@ -2161,8 +2145,8 @@ const Hosting = () => {
                     </j-toggle>
 
                     {tlsConfig.enabled && (
-                      <j-box mt="400">
-                        <j-box mb="300">
+                      <div style={{ marginTop: "16px" }}>
+                        <div style={{ marginBottom: "12px" }}>
                           <j-text size="400" weight="500" mb="200">
                             Certificate File
                           </j-text>
@@ -2183,8 +2167,8 @@ const Hosting = () => {
                               {certPathError}
                             </j-text>
                           )}
-                        </j-box>
-                        <j-box mb="300">
+                        </div>
+                        <div style={{ marginBottom: "12px" }}>
                           <j-text size="400" weight="500" mb="200">
                             Private Key File
                           </j-text>
@@ -2202,8 +2186,8 @@ const Hosting = () => {
                               {keyPathError}
                             </j-text>
                           )}
-                        </j-box>
-                        <j-box mb="300">
+                        </div>
+                        <div style={{ marginBottom: "12px" }}>
                           <j-text size="400" weight="500" mb="200">
                             TLS Port
                           </j-text>
@@ -2219,8 +2203,8 @@ const Hosting = () => {
                               handleTlsConfigChange(newConfig);
                             }}
                           />
-                        </j-box>
-                      </j-box>
+                        </div>
+                      </div>
                     )}
                   </>
                 )}
@@ -2256,8 +2240,8 @@ const Hosting = () => {
                     </j-toggle>
 
                     {smtpConfig.enabled && (
-                      <j-box mt="400">
-                        <j-box mb="300">
+                      <div style={{ marginTop: "16px" }}>
+                        <div style={{ marginBottom: "12px" }}>
                           <j-text size="400" weight="500" mb="200">
                             SMTP Host
                           </j-text>
@@ -2271,8 +2255,8 @@ const Hosting = () => {
                             }
                             placeholder="smtp.gmail.com"
                           />
-                        </j-box>
-                        <j-box mb="300">
+                        </div>
+                        <div style={{ marginBottom: "12px" }}>
                           <j-text size="400" weight="500" mb="200">
                             Port
                           </j-text>
@@ -2286,8 +2270,8 @@ const Hosting = () => {
                               })
                             }
                           />
-                        </j-box>
-                        <j-box mb="300">
+                        </div>
+                        <div style={{ marginBottom: "12px" }}>
                           <j-text size="400" weight="500" mb="200">
                             Username
                           </j-text>
@@ -2300,8 +2284,8 @@ const Hosting = () => {
                               })
                             }
                           />
-                        </j-box>
-                        <j-box mb="300">
+                        </div>
+                        <div style={{ marginBottom: "12px" }}>
                           <j-text size="400" weight="500" mb="200">
                             Password
                           </j-text>
@@ -2329,8 +2313,8 @@ const Hosting = () => {
                               ></j-icon>
                             </j-button>
                           </j-input>
-                        </j-box>
-                        <j-box mb="300">
+                        </div>
+                        <div style={{ marginBottom: "12px" }}>
                           <j-text size="400" weight="500" mb="200">
                             From Address
                           </j-text>
@@ -2344,7 +2328,7 @@ const Hosting = () => {
                             }
                             placeholder="noreply@example.com"
                           />
-                        </j-box>
+                        </div>
 
                         <j-flex gap="300" mb="400">
                           <j-button
@@ -2365,7 +2349,7 @@ const Hosting = () => {
                         </j-flex>
 
                         {smtpTestVisible && (
-                          <j-box mb="300">
+                          <div style={{ marginBottom: "12px" }}>
                             <j-flex gap="200">
                               <j-input
                                 value={smtpTestEmail}
@@ -2387,14 +2371,14 @@ const Hosting = () => {
                                 {smtpTestStatus}
                               </j-text>
                             )}
-                          </j-box>
+                          </div>
                         )}
-                      </j-box>
+                      </div>
                     )}
                   </>
                 )}
               </ExpandableSection>
-            </j-box>
+            </div>
           )}
         </>
       )}

--- a/ui/src/components/Wallet.tsx
+++ b/ui/src/components/Wallet.tsx
@@ -130,7 +130,7 @@ const Wallet = () => {
           try {
             setBalance(JSON.parse(balStr));
           } catch {
-            setBalance({ HOT: balStr });
+            setBalance({ wHOT: balStr });
           }
         }
       } catch (e: any) {
@@ -341,7 +341,7 @@ const Wallet = () => {
                     {amount}
                   </j-text>
                   <span style={{ display: "inline-flex", alignItems: "baseline", gap: "3px", fontSize: "14px" }}>
-                    <span style={{ opacity: 0.6 }}>mirrored</span> <HotLogo size={22} />
+                    <span style={{ opacity: 0.6 }}>w</span> <HotLogo size={22} />
                   </span>
                 </span>
               ))
@@ -373,7 +373,7 @@ const Wallet = () => {
           <div style={{ marginTop: "12px" }}>
             <div style={{ marginBottom: "8px" }}>
               <j-text size="400" weight="500">
-                Amount (HOT)
+                Amount (wHOT)
               </j-text>
             </div>
             <j-flex a="center" gap="200">
@@ -542,7 +542,7 @@ const Wallet = () => {
             {confirmSend && (
               <div style={{ marginTop: "12px", padding: "12px 16px", background: "var(--j-color-ui-50)", borderRadius: "8px", border: "1px solid var(--j-color-warning-300)" }}>
                 <j-text size="400" weight="500">
-                  Confirm: Send {sendAmount} <span style={{ display: "inline-flex", alignItems: "center", gap: "2px" }}><span style={{ fontSize: "0.75em", opacity: 0.6 }}>mirrored</span> <HotLogo size={16} /></span> to {sendRecipient.includes("@") ? sendRecipient : sendRecipient.substring(0, 12) + "..."}?
+                  Confirm: Send {sendAmount} <span style={{ display: "inline-flex", alignItems: "center", gap: "2px" }}><span style={{ fontSize: "0.75em", opacity: 0.6 }}>w</span> <HotLogo size={16} /></span> to {sendRecipient.includes("@") ? sendRecipient : sendRecipient.substring(0, 12) + "..."}?
                 </j-text>
                 <j-flex gap="200" mt="200">
                   <j-button
@@ -734,7 +734,7 @@ const Wallet = () => {
                       </j-flex>
                       {amountStr && (
                         <j-text size="400" weight="500" color={amountColor}>
-                          {isIncoming && !isRejected ? "+" : isSend ? "-" : ""}{amountStr} <span style={{ display: "inline-flex", alignItems: "center", gap: "2px" }}><span style={{ fontSize: "0.75em", opacity: 0.6 }}>m</span><HotLogo size={14} /></span>
+                          {isIncoming && !isRejected ? "+" : isSend ? "-" : ""}{amountStr} <span style={{ display: "inline-flex", alignItems: "center", gap: "2px" }}><span style={{ fontSize: "0.75em", opacity: 0.6 }}>w</span><HotLogo size={14} /></span>
                         </j-text>
                       )}
                     </j-flex>

--- a/ui/src/components/Wallet.tsx
+++ b/ui/src/components/Wallet.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState, useCallback } from "react";
 import { Ad4minContext } from "../context/Ad4minContext";
 import { cardStyle } from "./styles";
 
-const HotLogo = ({ size = 14 }: { size?: number }) => (
+export const HotLogo = ({ size = 14 }: { size?: number }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1175.48 847.82"

--- a/ui/src/context/Ad4minContext.tsx
+++ b/ui/src/context/Ad4minContext.tsx
@@ -28,6 +28,7 @@ type State = {
   connectedLoading: boolean;
   expertMode: boolean;
   multiUserEnabled: boolean;
+  freeHostingEnabled: boolean;
   notifications: NotificationType[];
 };
 
@@ -40,6 +41,7 @@ type ContextProps = {
     handleLogin: (client: Ad4mClient, login: Boolean, did: string) => void;
     toggleExpertMode: () => void;
     setMultiUserEnabled: (enabled: boolean) => void;
+    setFreeHostingEnabled: (enabled: boolean) => void;
     handleNotification: (notification: NotificationType) => void;
   };
 };
@@ -58,6 +60,7 @@ const initialState: ContextProps = {
     connectedLoading: true,
     expertMode: getForVersion("expertMode") === "true",
     multiUserEnabled: false,
+    freeHostingEnabled: true,
     notifications: [],
   },
   methods: {
@@ -67,6 +70,7 @@ const initialState: ContextProps = {
     handleLogin: () => null,
     toggleExpertMode: () => null,
     setMultiUserEnabled: () => null,
+    setFreeHostingEnabled: () => null,
     handleNotification: () => null,
   },
 };
@@ -97,6 +101,21 @@ export function Ad4minProvider({ children }: any) {
         }));
       } catch (error) {
         console.error("Failed to set multi-user mode:", error);
+        throw error;
+      }
+    }
+  };
+
+  const setFreeHostingEnabled = async (enabled: boolean) => {
+    if (state.client) {
+      try {
+        await state.client.runtime.setFreeHostingEnabled(enabled);
+        setState((prevState) => ({
+          ...prevState,
+          freeHostingEnabled: enabled,
+        }));
+      } catch (error) {
+        console.error("Failed to set free hosting mode:", error);
         throw error;
       }
     }
@@ -329,22 +348,26 @@ export function Ad4minProvider({ children }: any) {
     }
   }, [state.url]);
 
-  // Load multi-user state when client is available
+  // Load multi-user and free hosting state when client is available
   useEffect(() => {
-    const loadMultiUserState = async () => {
+    const loadHostingState = async () => {
       if (state.client) {
         try {
-          const enabled = await state.client.runtime.multiUserEnabled();
+          const [multiUser, freeHosting] = await Promise.all([
+            state.client.runtime.multiUserEnabled(),
+            state.client.runtime.freeHostingEnabled(),
+          ]);
           setState((prev) => ({
             ...prev,
-            multiUserEnabled: enabled,
+            multiUserEnabled: multiUser,
+            freeHostingEnabled: freeHosting,
           }));
         } catch (error) {
-          console.error("Failed to load multi-user state:", error);
+          console.error("Failed to load hosting state:", error);
         }
       }
     };
-    loadMultiUserState();
+    loadHostingState();
   }, [state.client]);
 
   return (
@@ -358,6 +381,7 @@ export function Ad4minProvider({ children }: any) {
           handleLogin,
           toggleExpertMode,
           setMultiUserEnabled,
+          setFreeHostingEnabled,
           handleNotification,
         },
       }}

--- a/ui/src/context/Ad4minContext.tsx
+++ b/ui/src/context/Ad4minContext.tsx
@@ -352,18 +352,24 @@ export function Ad4minProvider({ children }: any) {
   useEffect(() => {
     const loadHostingState = async () => {
       if (state.client) {
-        try {
-          const [multiUser, freeHosting] = await Promise.all([
-            state.client.runtime.multiUserEnabled(),
-            state.client.runtime.freeHostingEnabled(),
-          ]);
-          setState((prev) => ({
-            ...prev,
-            multiUserEnabled: multiUser,
-            freeHostingEnabled: freeHosting,
-          }));
-        } catch (error) {
-          console.error("Failed to load hosting state:", error);
+        const [multiUserResult, freeHostingResult] = await Promise.allSettled([
+          state.client.runtime.multiUserEnabled(),
+          state.client.runtime.freeHostingEnabled(),
+        ]);
+        setState((prev) => ({
+          ...prev,
+          ...(multiUserResult.status === "fulfilled"
+            ? { multiUserEnabled: multiUserResult.value }
+            : {}),
+          ...(freeHostingResult.status === "fulfilled"
+            ? { freeHostingEnabled: freeHostingResult.value }
+            : {}),
+        }));
+        if (multiUserResult.status === "rejected") {
+          console.error("Failed to load multi-user state:", multiUserResult.reason);
+        }
+        if (freeHostingResult.status === "rejected") {
+          console.error("Failed to load free hosting state:", freeHostingResult.reason);
         }
       }
     };


### PR DESCRIPTION
 ## Summary                                                          
  - Add global free/paid hosting toggle (defaults to free) — when free, all credit checks are bypassed and payment UI is hidden                                                                                                                                                           
  - Rename "Multi-user mode" → "Enable multi-user hosting" with collapsible setup instructions (SMTP, TLS, port forwarding)                                                                                                                                                               
  - Add hosting profile improvements: info tooltip, prominent endpoint URL with auto-populate from TLS config, auto-dismissing status messages                                                                                                                                            
  - Rename all user-facing HOT/mHOT references to wHOT (wrapped HOT) across UI, Connect, and backend                                                                                                                                                                                      
  - Add trust disclaimer in AD4M Connect host browser for remote connections                                                                                                                                                                                                              
  - Add agent picker on login screen, agent switching/deletion from settings, and persist agent state  
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added global "Paid hosting via wHOT" toggle and admin API to read/set free hosting.
  - Hosting UI updates: auto-expanding setup instructions, auto-clearing status messages, trust/consent notice, and TLS port included in host WebSocket URL.
  - Context/API exposes freeHostingEnabled state and setter for UI use.

* **Behavior Changes**
  - Global free-hosting now bypasses credit/payment flows and hides wallet/credit UI when enabled.
  - Currency/unit labels changed from HOT/mHOT to wHOT across the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->