### PR TITLE
fix: OC plugin - setup flow for "external" mode & waker fixes

### DIFF
--- a/plugins/ad4m/executor.ts
+++ b/plugins/ad4m/executor.ts
@@ -340,7 +340,7 @@ export async function isExecutorRunning(
   timeoutMs: number = 3000,
   graphqlHttpUrl: string = "http://localhost:12000/graphql",
 ): Promise<"mcp" | "graphql" | false> {
-  const probe = (url: string, body: string): Promise<boolean> =>
+  const probe = (url: string, body: string, validate?: (json: any) => boolean): Promise<boolean> =>
     new Promise((resolve) => {
       const controller = new AbortController();
       const timeout = setTimeout(() => {
@@ -354,9 +354,16 @@ export async function isExecutorRunning(
         body,
         signal: controller.signal,
       })
-        .then((res) => {
+        .then(async (res) => {
           clearTimeout(timeout);
-          resolve(res.ok);
+          if (!res.ok) return resolve(false);
+          if (!validate) return resolve(true);
+          try {
+            const json = await res.json();
+            resolve(validate(json));
+          } catch {
+            resolve(false);
+          }
         })
         .catch(() => {
           clearTimeout(timeout);
@@ -373,6 +380,10 @@ export async function isExecutorRunning(
     probe(
       graphqlHttpUrl,
       JSON.stringify({ query: "{ agentStatus { isInitialized } }" }),
+      (json) =>
+        json != null &&
+        !json.errors?.length &&
+        json.data?.agentStatus != null,
     ),
   ]);
 

--- a/plugins/ad4m/executor.ts
+++ b/plugins/ad4m/executor.ts
@@ -325,37 +325,60 @@ export async function downloadExecutor(logger: any): Promise<boolean> {
 let executorProcess: ReturnType<typeof spawn> | null = null;
 let executorLogStream: fs.WriteStream | null = null;
 
-export function isExecutorRunning(
+/**
+ * Check whether an executor is reachable.
+ *
+ * Tries the MCP endpoint first, then falls back to a lightweight GraphQL
+ * query on the default HTTP port (12000).  This ensures we detect executors
+ * launched via ad4m-launcher where MCP is typically disabled.
+ *
+ * Returns `"mcp"` or `"graphql"` to indicate which interface responded,
+ * or `false` if neither is reachable.
+ */
+export async function isExecutorRunning(
   endpoint: string,
   timeoutMs: number = 3000,
-): Promise<boolean> {
-  return new Promise((resolve) => {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => {
-      controller.abort();
-      resolve(false);
-    }, timeoutMs);
-
-    fetch(endpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 0,
-        method: "tools/list",
-        params: {},
-      }),
-      signal: controller.signal,
-    })
-      .then(() => {
-        clearTimeout(timeout);
-        resolve(true);
-      })
-      .catch(() => {
-        clearTimeout(timeout);
+  graphqlHttpUrl: string = "http://localhost:12000/graphql",
+): Promise<"mcp" | "graphql" | false> {
+  const probe = (url: string, body: string): Promise<boolean> =>
+    new Promise((resolve) => {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => {
+        controller.abort();
         resolve(false);
-      });
-  });
+      }, timeoutMs);
+
+      fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+        signal: controller.signal,
+      })
+        .then((res) => {
+          clearTimeout(timeout);
+          resolve(res.ok);
+        })
+        .catch(() => {
+          clearTimeout(timeout);
+          resolve(false);
+        });
+    });
+
+  // Try MCP and GraphQL in parallel — return the first that succeeds
+  const [mcp, gql] = await Promise.all([
+    probe(
+      endpoint,
+      JSON.stringify({ jsonrpc: "2.0", id: 0, method: "tools/list", params: {} }),
+    ),
+    probe(
+      graphqlHttpUrl,
+      JSON.stringify({ query: "{ agentStatus { isInitialized } }" }),
+    ),
+  ]);
+
+  if (mcp) return "mcp";
+  if (gql) return "graphql";
+  return false;
 }
 
 /**

--- a/plugins/ad4m/executor.ts
+++ b/plugins/ad4m/executor.ts
@@ -380,10 +380,10 @@ export async function isExecutorRunning(
     probe(
       graphqlHttpUrl,
       JSON.stringify({ query: "{ agentStatus { isInitialized } }" }),
-      (json) =>
-        json != null &&
-        !json.errors?.length &&
-        json.data?.agentStatus != null,
+      // Unauthenticated requests lack AGENT_READ_CAPABILITY so the query
+      // returns errors — but any GraphQL-shaped response (data or errors key)
+      // confirms an AD4M executor is listening.
+      (json) => json != null && ("data" in json || "errors" in json),
     ),
   ]);
 

--- a/plugins/ad4m/index.test.ts
+++ b/plugins/ad4m/index.test.ts
@@ -54,7 +54,7 @@ import {
   type AgentResult,
 } from "./index";
 
-import ad4mPlugin from "./index";
+import ad4mPlugin, { _resetModuleState } from "./index";
 import { WakerSubscriptionManager } from "./wakerSubscriptionManager";
 
 // ---------------------------------------------------------------------------
@@ -1486,6 +1486,7 @@ describe("postWake", () => {
 describe("ad4mPlugin", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    _resetModuleState();
   });
 
   it("registers expected tools and services", async () => {

--- a/plugins/ad4m/index.test.ts
+++ b/plugins/ad4m/index.test.ts
@@ -275,15 +275,33 @@ describe("isExecutorRunning", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns true when endpoint responds", async () => {
+  it("returns 'mcp' when MCP endpoint responds", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       fakeJsonResponse({ jsonrpc: "2.0", id: 0, result: {} }),
     );
     const result = await isExecutorRunning("http://localhost:3001/mcp", 1000);
-    expect(result).toBe(true);
+    expect(result).toBe("mcp");
   });
 
-  it("returns false when endpoint times out or errors", async () => {
+  it("returns 'graphql' when only GraphQL endpoint responds", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((url: any) => {
+      if (String(url).includes("/mcp")) {
+        return Promise.reject(new Error("ECONNREFUSED"));
+      }
+      // GraphQL endpoint responds
+      return Promise.resolve(
+        fakeJsonResponse({ data: { agentStatus: { isInitialized: true } } }),
+      );
+    });
+    const result = await isExecutorRunning(
+      "http://localhost:3001/mcp",
+      1000,
+      "http://localhost:12000/graphql",
+    );
+    expect(result).toBe("graphql");
+  });
+
+  it("returns false when both endpoints fail", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
     const result = await isExecutorRunning("http://localhost:3001/mcp", 500);
     expect(result).toBe(false);

--- a/plugins/ad4m/index.test.ts
+++ b/plugins/ad4m/index.test.ts
@@ -325,7 +325,7 @@ describe("isExecutorRunning", () => {
       1000,
       "http://localhost:12000/graphql",
     );
-    expect(result).toBe(false);
+    expect(result).toBe("graphql");
   });
 
   it("returns false when both endpoints fail", async () => {

--- a/plugins/ad4m/index.test.ts
+++ b/plugins/ad4m/index.test.ts
@@ -276,10 +276,19 @@ describe("isExecutorRunning", () => {
   });
 
   it("returns 'mcp' when MCP endpoint responds", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      fakeJsonResponse({ jsonrpc: "2.0", id: 0, result: {} }),
+    vi.spyOn(globalThis, "fetch").mockImplementation((url: any) => {
+      if (String(url).includes("/mcp")) {
+        return Promise.resolve(
+          fakeJsonResponse({ jsonrpc: "2.0", id: 0, result: {} }),
+        );
+      }
+      return Promise.reject(new Error("ECONNREFUSED"));
+    });
+    const result = await isExecutorRunning(
+      "http://localhost:3001/mcp",
+      1000,
+      "http://localhost:12000/graphql",
     );
-    const result = await isExecutorRunning("http://localhost:3001/mcp", 1000);
     expect(result).toBe("mcp");
   });
 
@@ -299,6 +308,24 @@ describe("isExecutorRunning", () => {
       "http://localhost:12000/graphql",
     );
     expect(result).toBe("graphql");
+  });
+
+  it("returns false when GraphQL returns 200 with errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((url: any) => {
+      if (String(url).includes("/mcp")) {
+        return Promise.reject(new Error("ECONNREFUSED"));
+      }
+      // GraphQL 200 but with errors array
+      return Promise.resolve(
+        fakeJsonResponse({ errors: [{ message: "not ready" }], data: null }),
+      );
+    });
+    const result = await isExecutorRunning(
+      "http://localhost:3001/mcp",
+      1000,
+      "http://localhost:12000/graphql",
+    );
+    expect(result).toBe(false);
   });
 
   it("returns false when both endpoints fail", async () => {

--- a/plugins/ad4m/index.ts
+++ b/plugins/ad4m/index.ts
@@ -88,6 +88,35 @@ export { runSetup } from "./setup";
 let requestIdCounter = 0;
 
 // ---------------------------------------------------------------------------
+// Module-level mutable state — survives plugin hot-reloads.
+// The OpenClaw framework may re-invoke ad4mPlugin() on config changes,
+// creating new tool closures. Services (MCP, waker) are only started once,
+// so state they set must live at module scope to remain visible to the
+// new tool closures.
+// ---------------------------------------------------------------------------
+let _authToken: string = "";
+let _pluginAgentDid: string = "";
+let _stateDir: string = "";
+let _wakerClient: any = null;
+let _subscriptionManager: WakerSubscriptionManager | null = null;
+let _sessionId = "";
+let _registeredTools = new Set<string>();
+let _refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+/** @internal Reset module-level state between tests. */
+export function _resetModuleState(): void {
+  _authToken = "";
+  _pluginAgentDid = "";
+  _stateDir = "";
+  _wakerClient = null;
+  _subscriptionManager = null;
+  _sessionId = "";
+  _registeredTools = new Set<string>();
+  if (_refreshTimer) clearInterval(_refreshTimer);
+  _refreshTimer = null;
+}
+
+// ---------------------------------------------------------------------------
 // Plugin Export
 // ---------------------------------------------------------------------------
 
@@ -104,12 +133,10 @@ export default function ad4mPlugin(api: any) {
   const executorWsUrl =
     providedConfig.executorWsUrl ?? "ws://localhost:12000/graphql";
 
-  // Mutable state set during service start() — shared across tools and services
-  let authToken: string = providedConfig.token || "";
-  let pluginAgentDid: string = "";
-
-  // State directory for waker subscription persistence (set by service ctx)
-  let stateDir: string = "";
+  // On reload, pick up token from config if module-level state is empty
+  if (!_authToken && providedConfig.token) {
+    _authToken = providedConfig.token;
+  }
 
   // Resolve wakeToken: plugin config override > OpenClaw global hooks config
   let resolvedWakeToken = providedConfig.wakeToken;
@@ -129,7 +156,7 @@ export default function ad4mPlugin(api: any) {
     ...providedConfig,
     mode: mode || "managed",
     mcpEndpoint: endpoint,
-    token: authToken || undefined,
+    token: _authToken || undefined,
     executorWsUrl,
     wakeUrl: providedConfig.wakeUrl ?? "http://localhost:18789/hooks/wake",
     wakeToken: resolvedWakeToken,
@@ -153,33 +180,29 @@ export default function ad4mPlugin(api: any) {
     })}`,
   );
 
-  // -- MCP bridge state --
-  let sessionId = "";
-  let registeredTools = new Set<string>();
-  let refreshTimer: ReturnType<typeof setInterval> | null = null;
+  // -- MCP bridge state (aliases to module-level vars) --
+  // These are module-level so they survive plugin hot-reloads.
 
-  // -- Waker state --
-  let wakerClient: any = null;
-  let subscriptionManager: WakerSubscriptionManager | null = null;
+  // -- Waker state (aliases to module-level vars) --
 
   /**
    * (Re-)initialize the MCP session. Called on first connect and when the
    * session becomes invalid (e.g. executor restart, session expiry -> 422).
    */
   async function ensureSession(): Promise<string> {
-    if (sessionId) return sessionId;
+    if (_sessionId) return _sessionId;
     logger.info(`[ad4m] Initializing MCP session at ${endpoint}`);
-    const init = await mcpInitialize(endpoint, authToken);
-    sessionId = init.sessionId;
-    logger.info(`[ad4m] MCP session established (id: ${sessionId})`);
-    return sessionId;
+    const init = await mcpInitialize(endpoint, _authToken);
+    _sessionId = init.sessionId;
+    logger.info(`[ad4m] MCP session established (id: ${_sessionId})`);
+    return _sessionId;
   }
 
   /**
    * Drop the current session so the next ensureSession() re-initializes.
    */
   function invalidateSession(): void {
-    sessionId = "";
+    _sessionId = "";
   }
 
   /**
@@ -193,7 +216,7 @@ export default function ad4mPlugin(api: any) {
   ): Promise<any> {
     await ensureSession();
     try {
-      return await mcpCallTool(endpoint, toolName, args, sessionId, authToken);
+      return await mcpCallTool(endpoint, toolName, args, _sessionId, _authToken);
     } catch (err: any) {
       if (err.message && /MCP HTTP 4\d\d/.test(err.message)) {
         logger.info(
@@ -205,8 +228,8 @@ export default function ad4mPlugin(api: any) {
           endpoint,
           toolName,
           args,
-          sessionId,
-          authToken,
+          _sessionId,
+          _authToken,
         );
       }
       throw err;
@@ -260,7 +283,7 @@ export default function ad4mPlugin(api: any) {
   }
 
   function registerMcpTool(tool: McpTool) {
-    if (registeredTools.has(tool.name)) return;
+    if (_registeredTools.has(tool.name)) return;
 
     const isNeighbourhoodTool = NEIGHBOURHOOD_TOOLS.has(tool.name);
     const prefixedName = `ad4m_${tool.name}`;
@@ -290,7 +313,7 @@ export default function ad4mPlugin(api: any) {
       },
     });
 
-    registeredTools.add(tool.name);
+    _registeredTools.add(tool.name);
   }
 
   /**
@@ -301,17 +324,17 @@ export default function ad4mPlugin(api: any) {
     try {
       await ensureSession();
       try {
-        const tools = await mcpListTools(endpoint, sessionId, authToken);
+        const tools = await mcpListTools(endpoint, _sessionId, _authToken);
         let newCount = 0;
         for (const tool of tools) {
-          if (!registeredTools.has(tool.name)) {
+          if (!_registeredTools.has(tool.name)) {
             registerMcpTool(tool);
             newCount++;
           }
         }
         if (newCount > 0) {
           logger.info(
-            `[ad4m] Registered ${newCount} new tool(s), total: ${registeredTools.size}`,
+            `[ad4m] Registered ${newCount} new tool(s), total: ${_registeredTools.size}`,
           );
         }
         return newCount;
@@ -323,17 +346,17 @@ export default function ad4mPlugin(api: any) {
           );
           invalidateSession();
           await ensureSession();
-          const tools = await mcpListTools(endpoint, sessionId, authToken);
+          const tools = await mcpListTools(endpoint, _sessionId, _authToken);
           let newCount = 0;
           for (const tool of tools) {
-            if (!registeredTools.has(tool.name)) {
+            if (!_registeredTools.has(tool.name)) {
               registerMcpTool(tool);
               newCount++;
             }
           }
           if (newCount > 0) {
             logger.info(
-              `[ad4m] Registered ${newCount} new tool(s), total: ${registeredTools.size}`,
+              `[ad4m] Registered ${newCount} new tool(s), total: ${_registeredTools.size}`,
             );
           }
           return newCount;
@@ -348,15 +371,15 @@ export default function ad4mPlugin(api: any) {
 
   /**
    * Create a live waker subscription from a WakerSubscription config.
-   * Requires the waker service to be running (wakerClient set).
+   * Requires the waker service to be running (_wakerClient set).
    */
   async function createLiveSubscription(sub: WakerSubscription): Promise<void> {
-    if (!subscriptionManager) {
+    if (!_subscriptionManager) {
       throw new Error(
         "Waker service not connected. Ensure ad4m-executor is running and wakerEnabled is true.",
       );
     }
-    await subscriptionManager.subscribe(sub);
+    await _subscriptionManager.subscribe(sub);
   }
 
   /**
@@ -365,8 +388,8 @@ export default function ad4mPlugin(api: any) {
    *   so saved subscriptions survive for restore on next start).
    */
   function disposeLiveSubscription(id: string, persist = true): void {
-    if (subscriptionManager) {
-      subscriptionManager.dispose(id, persist);
+    if (_subscriptionManager) {
+      _subscriptionManager.dispose(id, persist);
     }
   }
 
@@ -459,8 +482,8 @@ Notes:
       const newCount = await refreshTools();
       const msg =
         newCount > 0
-          ? `Discovered and registered ${newCount} new tool(s). Total tools: ${registeredTools.size}.`
-          : `No new tools found. Total tools: ${registeredTools.size}.`;
+          ? `Discovered and registered ${newCount} new tool(s). Total tools: ${_registeredTools.size}.`
+          : `No new tools found. Total tools: ${_registeredTools.size}.`;
       return { content: [{ type: "text", text: msg }] };
     },
   });
@@ -477,7 +500,7 @@ Notes:
   ): Promise<string> {
     // Skip if already subscribed
     const existingId = `mention-${perspectiveId.substring(0, 8)}`;
-    if (subscriptionManager?.has(existingId)) {
+    if (_subscriptionManager?.has(existingId)) {
       return `Already subscribed to mentions in perspective ${perspectiveId}.`;
     }
 
@@ -519,7 +542,7 @@ Notes:
    * Best-effort: logs errors but never throws.
    */
   async function autoSubscribeMentions(perspectiveId: string): Promise<void> {
-    if (!wakerClient) {
+    if (!_wakerClient) {
       logger.info(
         `[ad4m-waker] Skipping auto-subscribe for ${perspectiveId} — waker not connected`,
       );
@@ -580,7 +603,7 @@ Notes:
     async execute(_id: string, params: { perspective_id: string }) {
       // Find subscription by perspective
       let found = false;
-      for (const sub of (subscriptionManager?.getActive() ?? [])) {
+      for (const sub of (_subscriptionManager?.getActive() ?? [])) {
         if (
           sub.perspective === params.perspective_id &&
           sub.type === "mention"
@@ -702,7 +725,7 @@ Notes:
       params: { perspective_id: string; expression_address: string },
     ) {
       let found = false;
-      for (const sub of (subscriptionManager?.getActive() ?? [])) {
+      for (const sub of (_subscriptionManager?.getActive() ?? [])) {
         if (
           sub.perspective === params.perspective_id &&
           sub.channel === params.expression_address &&
@@ -731,7 +754,7 @@ Notes:
     description: "List all active waker subscriptions.",
     parameters: { type: "object", properties: {}, required: [] },
     async execute() {
-      const subs = subscriptionManager?.getActive() ?? [];
+      const subs = _subscriptionManager?.getActive() ?? [];
       if (subs.length === 0) {
         return {
           content: [{ type: "text", text: "No active waker subscriptions." }],
@@ -827,9 +850,9 @@ Notes:
   api.registerService({
     id: "ad4m-mcp",
     async start(ctx: any) {
-      // Capture stateDir from service context
-      if (ctx?.stateDir) {
-        stateDir = ctx.stateDir;
+      // Capture _stateDir from service context
+      if (ctx?._stateDir) {
+        _stateDir = ctx.stateDir;
       }
 
       // If mode is not configured, the user hasn't run setup yet
@@ -846,18 +869,18 @@ Notes:
 
       if (mode === "external") {
         // External mode: use token from config, or obtain JWT
-        if (!authToken) {
+        if (!_authToken) {
           logger.info("[ad4m] No token found, attempting JWT auth via MCP...");
           const jwt = await obtainJwtFromExecutor();
           if (jwt) {
-            authToken = jwt;
+            _authToken = jwt;
             logger.info("[ad4m] JWT obtained");
           }
         }
       } else {
         // Managed mode: generate ephemeral admin credential (not persisted)
         const adminCredential = generateRandomPassphrase(24);
-        authToken = adminCredential;
+        _authToken = adminCredential;
 
         // Resolve executor binary path: config > discover > auto-download
         let binaryPath = providedConfig.ad4mBinaryPath;
@@ -902,22 +925,22 @@ Notes:
           );
           const jwt = await obtainJwtFromExecutor();
           if (jwt) {
-            authToken = jwt;
+            _authToken = jwt;
             logger.info("[ad4m] JWT obtained for pre-existing executor");
           } else {
             logger.warn("[ad4m] JWT auth failed for pre-existing executor");
-            authToken = "";
+            _authToken = "";
           }
 
-          if (authToken) {
+          if (_authToken) {
             const agentResult = await ensureAgentReady(
               executorWsUrl,
-              authToken,
+              _authToken,
               logger,
               agentPassphrase,
             );
             if (agentResult) {
-              pluginAgentDid = agentResult.did;
+              _pluginAgentDid = agentResult.did;
             } else {
               logger.warn(
                 "[ad4m] Could not verify agent on pre-existing executor.",
@@ -933,7 +956,7 @@ Notes:
             agentPassphrase,
           );
           if (agentResult) {
-            pluginAgentDid = agentResult.did;
+            _pluginAgentDid = agentResult.did;
           } else {
             logger.error(
               `[ad4m] Agent management failed. MCP tools and waker will not work correctly.`,
@@ -944,8 +967,8 @@ Notes:
 
       // ── MCP session + tool discovery ──
 
-      if (authToken) {
-        logger.info(`[ad4m] Auth token ready (length: ${authToken.length})`);
+      if (_authToken) {
+        logger.info(`[ad4m] Auth token ready (length: ${_authToken.length})`);
       } else {
         logger.warn(
           `[ad4m] No auth token. Tools may not work until authenticated.`,
@@ -953,7 +976,7 @@ Notes:
       }
 
       // Update config with resolved token
-      config.token = authToken || undefined;
+      config.token = _authToken || undefined;
 
       try {
         await ensureSession();
@@ -961,12 +984,12 @@ Notes:
         // Initial tool discovery
         await refreshTools();
         logger.info(
-          `[ad4m] Registered ${registeredTools.size} initial tool(s)`,
+          `[ad4m] Registered ${_registeredTools.size} initial tool(s)`,
         );
 
         // Start periodic polling for dynamic SHACL tools
         const refreshInterval = config.toolRefreshIntervalMs ?? 30000;
-        refreshTimer = setInterval(() => {
+        _refreshTimer = setInterval(() => {
           refreshTools();
         }, refreshInterval);
         logger.info(`[ad4m] Dynamic tool polling every ${refreshInterval}ms`);
@@ -978,9 +1001,9 @@ Notes:
       }
     },
     stop() {
-      if (refreshTimer) {
-        clearInterval(refreshTimer);
-        refreshTimer = null;
+      if (_refreshTimer) {
+        clearInterval(_refreshTimer);
+        _refreshTimer = null;
       }
       stopExecutor(logger);
       logger.info("[ad4m] AD4M MCP service stopped");
@@ -988,18 +1011,18 @@ Notes:
   });
 
   // -- Waker service (registered second — starts after ad4m-mcp) --
-  // By the time this starts, authToken and pluginAgentDid are set by
+  // By the time this starts, _authToken and _pluginAgentDid are set by
   // the mcp service above (OpenClaw starts services sequentially).
 
   api.registerService({
     id: "ad4m-waker",
     async start(ctx: any) {
       logger.info("[ad4m-waker] ── Waker service start() ──");
-      logger.info(`[ad4m-waker] stateDir from ctx: ${ctx?.stateDir ?? "N/A"}, existing stateDir: ${stateDir || "N/A"}`);
+      logger.info(`[ad4m-waker] stateDir from ctx: ${ctx?.stateDir ?? "N/A"}, existing stateDir: ${_stateDir || "N/A"}`);
 
-      // Capture stateDir from service context (in case mcp service didn't set it)
-      if (ctx?.stateDir && !stateDir) {
-        stateDir = ctx.stateDir;
+      // Capture _stateDir from service context (in case mcp service didn't set it)
+      if (ctx?._stateDir && !_stateDir) {
+        _stateDir = ctx.stateDir;
       }
 
       const wakerEnabled = config.wakerEnabled ?? true;
@@ -1021,10 +1044,10 @@ Notes:
         return;
       }
 
-      const tokenType = authToken.startsWith("eyJ") ? "JWT" : authToken.length <= 32 ? "admin-credential" : "unknown";
-      logger.info(`[ad4m-waker] authToken: ${authToken ? `${authToken.substring(0, 16)}...${authToken.substring(authToken.length - 8)} [${authToken.length} chars, type=${tokenType}]` : "EMPTY"}`);
+      const tokenType = _authToken.startsWith("eyJ") ? "JWT" : _authToken.length <= 32 ? "admin-credential" : "unknown";
+      logger.info(`[ad4m-waker] _authToken: ${_authToken ? `${_authToken.substring(0, 16)}...${_authToken.substring(_authToken.length - 8)} [${_authToken.length} chars, type=${tokenType}]` : "EMPTY"}`);
 
-      if (!authToken) {
+      if (!_authToken) {
         logger.warn(
           "[ad4m-waker] No auth token available — cannot connect to executor. Skipping.",
         );
@@ -1043,10 +1066,10 @@ Notes:
         const WebSocket = require("ws");
         logger.info("[ad4m-waker] Dependencies loaded OK");
 
-        const connParams = authToken
-          ? { headers: { authorization: authToken } }
+        const connParams = _authToken
+          ? { headers: { authorization: _authToken } }
           : {};
-        logger.info(`[ad4m-waker] connectionParams: ${JSON.stringify({ headers: { authorization: authToken ? `${tokenType}[${authToken.length}]` : "EMPTY" } })}`);
+        logger.info(`[ad4m-waker] connectionParams: ${JSON.stringify({ headers: { authorization: _authToken ? `${tokenType}[${_authToken.length}]` : "EMPTY" } })}`);
         logger.info(`[ad4m-waker] Connecting WebSocket to ${wsUrl}...`);
 
         const wsClient = createClient({
@@ -1089,25 +1112,25 @@ Notes:
           },
         });
 
-        wakerClient = new Ad4mClient(apolloClient);
+        _wakerClient = new Ad4mClient(apolloClient);
         logger.info("[ad4m-waker] Ad4mClient created, calling agent.status()...");
 
         // Load persisted state (subscriptions + seen messages) before creating manager
-        const savedState = stateDir ? loadWakerState(stateDir) : { subscriptions: [], seenMessages: {} };
+        const savedState = _stateDir ? loadWakerState(_stateDir) : { subscriptions: [], seenMessages: {} };
         logger.info(`[ad4m-waker] Loaded persisted state: ${savedState.subscriptions.length} subscription(s), ${Object.keys(savedState.seenMessages).length} seen-message set(s)`);
 
         // Create subscription manager wired to the Ad4mClient and wake callback
-        subscriptionManager = new WakerSubscriptionManager({
-          perspectiveClient: wakerClient.perspective,
+        _subscriptionManager = new WakerSubscriptionManager({
+          perspectiveClient: _wakerClient.perspective,
           logger,
           QuerySubscriptionProxy,
           debounceMs: config.debounceMs,
           previousSeenMessages: savedState.seenMessages,
           onWake: (sub, _result, mentions) => {
-            postWake(config, sub, pluginAgentDid, logger, mentions);
+            postWake(config, sub, _pluginAgentDid, logger, mentions);
           },
           onPersist: (subs, seenMessages) => {
-            if (stateDir) saveWakerState(stateDir, subs, seenMessages);
+            if (_stateDir) saveWakerState(_stateDir, subs, seenMessages);
           },
         });
 
@@ -1115,7 +1138,7 @@ Notes:
         // initialized/unlocked by ensureAgentReady during mcp service start)
         let status: any;
         try {
-          status = await wakerClient.agent.status();
+          status = await _wakerClient.agent.status();
           logger.info(`[ad4m-waker] agent.status() returned: initialized=${status.isInitialized}, unlocked=${status.isUnlocked}, did=${status.did?.substring(0, 30) ?? "N/A"}`);
         } catch (statusErr: any) {
           logger.error(`[ad4m-waker] agent.status() FAILED: ${statusErr.message}`);
@@ -1137,10 +1160,10 @@ Notes:
           logger.error(
             `[ad4m-waker] Agent is not ready (initialized=${status.isInitialized}, unlocked=${status.isUnlocked}). Agent management should have run during mcp service start.`,
           );
-          wakerClient = null;
+          _wakerClient = null;
           return;
         }
-        pluginAgentDid = status.did;
+        _pluginAgentDid = status.did;
         logger.info(
           `[ad4m-waker] Connected — agent: ${status.did.substring(0, 40)}...`,
         );
@@ -1170,15 +1193,15 @@ Notes:
         logger.error(
           `[ad4m-waker] Make sure @coasys/ad4m and dependencies are installed (npm install in the plugin directory).`,
         );
-        wakerClient = null;
+        _wakerClient = null;
       }
     },
     stop() {
-      if (subscriptionManager) {
-        subscriptionManager.disposeAll();
-        subscriptionManager = null;
+      if (_subscriptionManager) {
+        _subscriptionManager.disposeAll();
+        _subscriptionManager = null;
       }
-      wakerClient = null;
+      _wakerClient = null;
       logger.info("[ad4m-waker] Waker service stopped");
     },
   });

--- a/plugins/ad4m/index.ts
+++ b/plugins/ad4m/index.ts
@@ -1052,7 +1052,9 @@ Notes:
         const wsClient = createClient({
           url: wsUrl,
           webSocketImpl: WebSocket,
-          connectionParams: connParams,
+          connectionParams: () => connParams,
+          lazy: false,
+          keepAlive: 10_000,
           retryAttempts: Infinity,
           retryWait: async (retries: number) => {
             const delay = Math.min(1000 * Math.pow(2, retries), 30000);
@@ -1087,7 +1089,7 @@ Notes:
           },
         });
 
-        wakerClient = new Ad4mClient(apolloClient, false);
+        wakerClient = new Ad4mClient(apolloClient);
         logger.info("[ad4m-waker] Ad4mClient created, calling agent.status()...");
 
         // Load persisted state (subscriptions + seen messages) before creating manager

--- a/plugins/ad4m/index.ts
+++ b/plugins/ad4m/index.ts
@@ -994,6 +994,9 @@ Notes:
   api.registerService({
     id: "ad4m-waker",
     async start(ctx: any) {
+      logger.info("[ad4m-waker] ── Waker service start() ──");
+      logger.info(`[ad4m-waker] stateDir from ctx: ${ctx?.stateDir ?? "N/A"}, existing stateDir: ${stateDir || "N/A"}`);
+
       // Capture stateDir from service context (in case mcp service didn't set it)
       if (ctx?.stateDir && !stateDir) {
         stateDir = ctx.stateDir;
@@ -1005,12 +1008,21 @@ Notes:
         return;
       }
 
+      logger.info(`[ad4m-waker] config.wakeToken: ${config.wakeToken ? `set (${config.wakeToken.length} chars)` : "NOT SET"}`);
+      logger.info(`[ad4m-waker] config.wakeUrl: ${config.wakeUrl ?? "default"}`);
+      logger.info(`[ad4m-waker] config.executorWsUrl: ${config.executorWsUrl ?? "default"}`);
+      logger.info(`[ad4m-waker] config.mode: ${config.mode}`);
+      logger.info(`[ad4m-waker] config.debounceMs: ${config.debounceMs}`);
+
       if (!config.wakeToken) {
         logger.info(
           "[ad4m-waker] wakeToken not configured. Set wakeToken in plugin config to enable the waker. Skipping.",
         );
         return;
       }
+
+      const tokenType = authToken.startsWith("eyJ") ? "JWT" : authToken.length <= 32 ? "admin-credential" : "unknown";
+      logger.info(`[ad4m-waker] authToken: ${authToken ? `${authToken.substring(0, 16)}...${authToken.substring(authToken.length - 8)} [${authToken.length} chars, type=${tokenType}]` : "EMPTY"}`);
 
       if (!authToken) {
         logger.warn(
@@ -1023,20 +1035,24 @@ Notes:
 
       try {
         // Dynamic imports to avoid load-time issues with @holochain/client transitive deps
+        logger.info("[ad4m-waker] Loading dependencies...");
         const { Ad4mClient, QuerySubscriptionProxy } = require("@coasys/ad4m");
         const { ApolloClient, InMemoryCache } = require("@apollo/client/core");
         const { GraphQLWsLink } = require("@apollo/client/link/subscriptions");
         const { createClient } = require("graphql-ws");
         const WebSocket = require("ws");
+        logger.info("[ad4m-waker] Dependencies loaded OK");
 
-        logger.info(`[ad4m-waker] Connecting to ${wsUrl}`);
+        const connParams = authToken
+          ? { headers: { authorization: authToken } }
+          : {};
+        logger.info(`[ad4m-waker] connectionParams: ${JSON.stringify({ headers: { authorization: authToken ? `${tokenType}[${authToken.length}]` : "EMPTY" } })}`);
+        logger.info(`[ad4m-waker] Connecting WebSocket to ${wsUrl}...`);
 
         const wsClient = createClient({
           url: wsUrl,
           webSocketImpl: WebSocket,
-          connectionParams: authToken
-            ? { headers: { authorization: authToken } }
-            : {},
+          connectionParams: connParams,
           retryAttempts: Infinity,
           retryWait: async (retries: number) => {
             const delay = Math.min(1000 * Math.pow(2, retries), 30000);
@@ -1046,9 +1062,17 @@ Notes:
             await new Promise((r: any) => setTimeout(r, delay));
           },
           on: {
-            connected: () => logger.info("[ad4m-waker] WebSocket connected"),
-            closed: (event: any) => logger.warn(`[ad4m-waker] WebSocket closed: ${JSON.stringify(event)}`),
-            error: (error: any) => logger.error(`[ad4m-waker] WebSocket error: ${error?.message ?? error}`),
+            connected: (socket: any) => {
+              logger.info(`[ad4m-waker] WebSocket connected (protocol: ${socket?.protocol ?? "unknown"})`);
+            },
+            closed: (event: any) => {
+              logger.warn(`[ad4m-waker] WebSocket closed — code: ${event?.code ?? "N/A"}, reason: "${event?.reason ?? "N/A"}", wasClean: ${event?.wasClean ?? "N/A"}`);
+              logger.warn(`[ad4m-waker] WebSocket closed — full event: ${JSON.stringify(event)}`);
+            },
+            error: (error: any) => {
+              logger.error(`[ad4m-waker] WebSocket error: ${error?.message ?? error}`);
+              if (error?.stack) logger.error(`[ad4m-waker] WebSocket error stack: ${error.stack}`);
+            },
           },
         });
 
@@ -1064,9 +1088,11 @@ Notes:
         });
 
         wakerClient = new Ad4mClient(apolloClient, false);
+        logger.info("[ad4m-waker] Ad4mClient created, calling agent.status()...");
 
         // Load persisted state (subscriptions + seen messages) before creating manager
         const savedState = stateDir ? loadWakerState(stateDir) : { subscriptions: [], seenMessages: {} };
+        logger.info(`[ad4m-waker] Loaded persisted state: ${savedState.subscriptions.length} subscription(s), ${Object.keys(savedState.seenMessages).length} seen-message set(s)`);
 
         // Create subscription manager wired to the Ad4mClient and wake callback
         subscriptionManager = new WakerSubscriptionManager({
@@ -1085,7 +1111,26 @@ Notes:
 
         // Verify connection and get agent DID (agent should already be
         // initialized/unlocked by ensureAgentReady during mcp service start)
-        const status = await wakerClient.agent.status();
+        let status: any;
+        try {
+          status = await wakerClient.agent.status();
+          logger.info(`[ad4m-waker] agent.status() returned: initialized=${status.isInitialized}, unlocked=${status.isUnlocked}, did=${status.did?.substring(0, 30) ?? "N/A"}`);
+        } catch (statusErr: any) {
+          logger.error(`[ad4m-waker] agent.status() FAILED: ${statusErr.message}`);
+          if (statusErr.graphQLErrors) {
+            for (const gqlErr of statusErr.graphQLErrors) {
+              logger.error(`[ad4m-waker]   GraphQL error: ${gqlErr.message}`);
+            }
+          }
+          if (statusErr.networkError) {
+            logger.error(`[ad4m-waker]   Network error: ${statusErr.networkError.message}`);
+            if (statusErr.networkError.result) {
+              logger.error(`[ad4m-waker]   Network error result: ${JSON.stringify(statusErr.networkError.result)}`);
+            }
+          }
+          throw statusErr;
+        }
+
         if (!status.isInitialized || status.isUnlocked === false) {
           logger.error(
             `[ad4m-waker] Agent is not ready (initialized=${status.isInitialized}, unlocked=${status.isUnlocked}). Agent management should have run during mcp service start.`,
@@ -1119,6 +1164,7 @@ Notes:
         }
       } catch (err: any) {
         logger.error(`[ad4m-waker] Failed to connect: ${err.message}`);
+        if (err.stack) logger.error(`[ad4m-waker] Stack: ${err.stack}`);
         logger.error(
           `[ad4m-waker] Make sure @coasys/ad4m and dependencies are installed (npm install in the plugin directory).`,
         );

--- a/plugins/ad4m/setup.ts
+++ b/plugins/ad4m/setup.ts
@@ -65,13 +65,19 @@ export async function runSetup(
   }
 
   // ── Step 3: Check if executor is already running ──
-  const running = await isExecutorRunning(endpoint);
+  // Derive the GraphQL HTTP URL from the WS URL so both probes use the same port
+  const graphqlHttpUrl = executorWsUrl
+    .replace(/^ws(s?):/, "http$1:")
+    .replace(/\/$/, "");
+  const running = await isExecutorRunning(endpoint, 3000, graphqlHttpUrl);
 
   // ── Branch routing ──
 
   if (running) {
     // Branch B: Executor already running
-    await setupExternalMode(logger, endpoint, wakeToken);
+    // If detected via GraphQL (MCP disabled), pass the GraphQL URL so
+    // external-mode can use Ad4mClient instead of MCP for auth.
+    await setupExternalMode(logger, endpoint, wakeToken, running, executorWsUrl);
   } else if (binaryPath) {
     // Branch A: No running executor, binary found
     await setupManagedMode(logger, binaryPath, endpoint, executorWsUrl, wakeToken);
@@ -188,7 +194,40 @@ async function setupExternalMode(
   logger: any,
   endpoint: string,
   wakeToken?: string,
+  detectedVia: "mcp" | "graphql" = "mcp",
+  executorWsUrl: string = "ws://localhost:12000/graphql",
 ): Promise<void> {
+  if (detectedVia === "graphql") {
+    // Executor found via GraphQL (MCP is disabled / not available).
+    // Use Ad4mClient over GraphQL WS to request capabilities.
+    logger.info(
+      `[ad4m-setup] Found a running AD4M executor via GraphQL at ${executorWsUrl}. ` +
+        "MCP does not appear to be enabled.",
+    );
+    logger.info(
+      "[ad4m-setup] Attempting capability request via Ad4mClient...",
+    );
+
+    try {
+      await setupExternalModeViaGraphQL(logger, executorWsUrl, wakeToken);
+      return;
+    } catch (e: any) {
+      logger.error(
+        `[ad4m-setup] GraphQL auth flow failed: ${e.message}`,
+      );
+      if (e.stack) {
+        logger.error(`[ad4m-setup] Stack: ${e.stack}`);
+      }
+      printConfigSnippet(logger, "external", {
+        executorWsUrl,
+        token: "<paste-your-jwt-here>",
+        wakeToken,
+      });
+      return;
+    }
+  }
+
+  // ── MCP path (original logic) ──
   logger.info(
     `[ad4m-setup] Found a running AD4M executor at ${endpoint}. ` +
       "Will attempt to request capabilities.",
@@ -260,6 +299,158 @@ async function setupExternalMode(
       token: "<paste-your-jwt-here>",
       wakeToken,
     });
+  }
+}
+
+/**
+ * Prompt the user for a line of input on stdin.
+ */
+function promptUser(question: string): Promise<string> {
+  const readline = require("readline");
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question(question, (answer: string) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+/**
+ * External-mode auth flow using Ad4mClient over GraphQL WebSocket.
+ * Used when the executor is detected via GraphQL (MCP disabled).
+ *
+ * Flow:
+ * 1. requestCapability → returns requestId, launcher shows 6-digit code
+ * 2. User enters the 6-digit code from the launcher UI
+ * 3. generateJwt(requestId, code) → returns JWT
+ */
+async function setupExternalModeViaGraphQL(
+  logger: any,
+  executorWsUrl: string,
+  wakeToken?: string,
+): Promise<void> {
+  const { Ad4mClient } = require("@coasys/ad4m");
+  const { ApolloClient, InMemoryCache } = require("@apollo/client/core");
+  const { GraphQLWsLink } = require("@apollo/client/link/subscriptions");
+  const { createClient } = require("graphql-ws");
+  const WebSocket = require("ws");
+
+  logger.info(`[ad4m-setup] Creating GraphQL WS client for ${executorWsUrl}...`);
+  const wsClient = createClient({
+    url: executorWsUrl,
+    webSocketImpl: WebSocket,
+    on: {
+      connected: () => logger.info("[ad4m-setup] WebSocket connected"),
+      closed: (event: any) => logger.warn(`[ad4m-setup] WebSocket closed: ${JSON.stringify(event)}`),
+      error: (err: any) => logger.error(`[ad4m-setup] WebSocket error: ${err?.message ?? JSON.stringify(err)}`),
+    },
+  });
+  const link = new GraphQLWsLink(wsClient);
+  const apollo = new ApolloClient({
+    link,
+    cache: new InMemoryCache(),
+    defaultOptions: { query: { fetchPolicy: "no-cache" } },
+  });
+
+  try {
+    // Pass subscribe=false to avoid triggering GraphQL subscriptions
+    // before auth is complete (those would fail with capability errors).
+    logger.info("[ad4m-setup] Creating Ad4mClient (subscribe=false)...");
+    const client = new Ad4mClient(apollo, false);
+    logger.info("[ad4m-setup] Ad4mClient created successfully");
+
+    // Step 1: Request capability — triggers the verification popup in the launcher
+    // Use a plain object rather than `new AuthInfoInput()` — the GraphQL
+    // mutation only needs the correct field names in the variables, and
+    // constructing the class without its positional args can leave fields
+    // undefined depending on how type-graphql decorators serialise.
+    const authInfo = {
+      appName: "OpenClaw AD4M Plugin",
+      appDesc: "OpenClaw agent plugin for AD4M neighbourhoods",
+      appDomain: "",
+    };
+
+    logger.info("[ad4m-setup] Sending requestCapability mutation...");
+    logger.info(`[ad4m-setup] authInfo: ${JSON.stringify(authInfo)}`);
+    const requestId = await client.agent.requestCapability(authInfo);
+
+    logger.info(
+      `[ad4m-setup] Capability requested (id: ${requestId}).`,
+    );
+    logger.info("");
+    logger.info(
+      "[ad4m-setup] ┌─────────────────────────────────────────────────────────┐",
+    );
+    logger.info(
+      "[ad4m-setup] │  A capability request has been sent to your AD4M       │",
+    );
+    logger.info(
+      "[ad4m-setup] │  launcher. Please:                                     │",
+    );
+    logger.info(
+      "[ad4m-setup] │                                                        │",
+    );
+    logger.info(
+      "[ad4m-setup] │  1. Open your AD4M launcher                            │",
+    );
+    logger.info(
+      "[ad4m-setup] │  2. Approve the capability request from 'OpenClaw'     │",
+    );
+    logger.info(
+      "[ad4m-setup] │  3. Note the 6-digit verification code shown           │",
+    );
+    logger.info(
+      "[ad4m-setup] │  4. Come back here and enter that code below           │",
+    );
+    logger.info(
+      "[ad4m-setup] └─────────────────────────────────────────────────────────┘",
+    );
+    logger.info("");
+
+    // Step 2: Prompt the user for the 6-digit code shown in the launcher
+    const code = await promptUser(
+      "[ad4m-setup] Enter the 6-digit code from your AD4M launcher: ",
+    );
+
+    if (!code) {
+      logger.warn("[ad4m-setup] No code entered. Setup cancelled.");
+      printConfigSnippet(logger, "external", {
+        executorWsUrl,
+        token: "<paste-your-jwt-here>",
+        wakeToken,
+      });
+      return;
+    }
+
+    // Step 3: Generate JWT using requestId + user-provided code
+    logger.info(`[ad4m-setup] Sending generateJwt mutation (requestId: ${requestId}, code: ${code})...`);
+    const jwt = await client.agent.generateJwt(requestId, code);
+    logger.info(`[ad4m-setup] generateJwt returned: ${jwt ? `token (${jwt.length} chars)` : "null/empty"}`);
+
+    if (jwt) {
+      logger.info("[ad4m-setup] JWT obtained successfully via GraphQL!");
+      printConfigSnippet(logger, "external", {
+        executorWsUrl,
+        token: jwt,
+        wakeToken,
+      });
+    } else {
+      logger.warn(
+        "[ad4m-setup] Could not obtain JWT. The code may have been incorrect. " +
+          "Please try running setup again or obtain a JWT manually.",
+      );
+      printConfigSnippet(logger, "external", {
+        executorWsUrl,
+        token: "<paste-your-jwt-here>",
+        wakeToken,
+      });
+    }
+  } finally {
+    wsClient.dispose();
   }
 }
 

--- a/plugins/ad4m/setup.ts
+++ b/plugins/ad4m/setup.ts
@@ -372,6 +372,9 @@ async function setupExternalModeViaGraphQL(
       appName: "OpenClaw AD4M Plugin",
       appDesc: "OpenClaw agent plugin for AD4M neighbourhoods",
       appDomain: "",
+      capabilities: [
+        { with: { domain: "*", pointers: ["*"] }, can: ["*"] },
+      ],
     };
 
     logger.info("[ad4m-setup] Sending requestCapability mutation...");
@@ -379,7 +382,7 @@ async function setupExternalModeViaGraphQL(
     const requestId = await client.agent.requestCapability(authInfo);
 
     logger.info(
-      `[ad4m-setup] Capability requested (id: ${requestId}).`,
+      `[ad4m-setup] Capability requested successfully.`,
     );
     logger.info("");
     logger.info(
@@ -427,7 +430,7 @@ async function setupExternalModeViaGraphQL(
     }
 
     // Step 3: Generate JWT using requestId + user-provided code
-    logger.info(`[ad4m-setup] Sending generateJwt mutation (requestId: ${requestId}, code: ${code})...`);
+    logger.info(`[ad4m-setup] Sending generateJwt mutation...`);
     const jwt = await client.agent.generateJwt(requestId, code);
     logger.info(`[ad4m-setup] generateJwt returned: ${jwt ? `token (${jwt.length} chars)` : "null/empty"}`);
 
@@ -519,6 +522,7 @@ function printConfigSnippet(
     if (values.agentPassphrase) config.agentPassphrase = values.agentPassphrase;
   } else {
     if (values.mcpEndpoint) config.mcpEndpoint = values.mcpEndpoint;
+    if (values.executorWsUrl) config.executorWsUrl = values.executorWsUrl;
     if (values.token) config.token = values.token;
   }
 

--- a/rust-executor/src/agent/capabilities/types.rs
+++ b/rust-executor/src/agent/capabilities/types.rs
@@ -21,16 +21,16 @@ pub struct AuthInfo {
     pub user_email: Option<String>, // Email field for multi-user tokens
 }
 
-impl From<crate::graphql::graphql_types::AuthInfoInput> for AuthInfo {
-    fn from(input: crate::graphql::graphql_types::AuthInfoInput) -> Self {
-        use crate::agent::capabilities::defs::ALL_CAPABILITY;
+impl TryFrom<crate::graphql::graphql_types::AuthInfoInput> for AuthInfo {
+    type Error = String;
 
+    fn try_from(input: crate::graphql::graphql_types::AuthInfoInput) -> Result<Self, Self::Error> {
         let capabilities = match input.capabilities {
-            Some(vec) => Some(vec.into_iter().map(|c| c.into()).collect()),
-            None => Some(vec![ALL_CAPABILITY.clone()]),
+            Some(vec) if !vec.is_empty() => Some(vec.into_iter().map(|c| c.into()).collect()),
+            _ => return Err("Capability request must include explicit capabilities".to_string()),
         };
 
-        Self {
+        Ok(Self {
             app_name: input.app_name,
             app_desc: input.app_desc,
             app_domain: Some(input.app_domain),
@@ -38,7 +38,7 @@ impl From<crate::graphql::graphql_types::AuthInfoInput> for AuthInfo {
             app_icon_path: input.app_icon_path,
             capabilities,
             user_email: None, // Will be set by login process
-        }
+        })
     }
 }
 

--- a/rust-executor/src/agent/capabilities/types.rs
+++ b/rust-executor/src/agent/capabilities/types.rs
@@ -23,15 +23,20 @@ pub struct AuthInfo {
 
 impl From<crate::graphql::graphql_types::AuthInfoInput> for AuthInfo {
     fn from(input: crate::graphql::graphql_types::AuthInfoInput) -> Self {
+        use crate::agent::capabilities::defs::ALL_CAPABILITY;
+
+        let capabilities = match input.capabilities {
+            Some(vec) => Some(vec.into_iter().map(|c| c.into()).collect()),
+            None => Some(vec![ALL_CAPABILITY.clone()]),
+        };
+
         Self {
             app_name: input.app_name,
             app_desc: input.app_desc,
             app_domain: Some(input.app_domain),
             app_url: input.app_url,
             app_icon_path: input.app_icon_path,
-            capabilities: input
-                .capabilities
-                .map(|vec| vec.into_iter().map(|c| c.into()).collect()),
+            capabilities,
             user_email: None, // Will be set by login process
         }
     }

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -330,7 +330,9 @@ impl Mutation {
         auth_info: AuthInfoInput,
     ) -> FieldResult<String> {
         check_capability(&context.capabilities, &AGENT_AUTH_CAPABILITY)?;
-        let auth_info: AuthInfo = auth_info.into();
+        let auth_info: AuthInfo = auth_info.try_into().map_err(|e: String| {
+            coasys_juniper::FieldError::new(e, coasys_juniper::Value::null())
+        })?;
         let request_id = request_capability(auth_info.clone()).await;
         if context.auto_permit_cap_requests {
             println!("======================================");


### PR DESCRIPTION
The detection of a running ad4m node was only checking for MCP.
This now checks the GraphQL interface on port 12000 and runs through the request capability flow. With user guidance.

Also the waker needed 2 fixes:
 - configuring its WS client to not drop the connection after first successful query
 - persist across plugin hot-reloads
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive GraphQL WebSocket authentication flow with a 6‑digit prompt and external-mode config output (includes executor WS URL).
  * Executor detection now reports which interface responded (MCP or GraphQL) or that none are running.

* **Bug Fixes**
  * More robust reachability probes with timeouts, concurrent checks, and stricter response validation (GraphQL reachable on data or errors).
  * Validation tightened for capability requests; failures surface as explicit errors.
  * Improved startup logging and richer error details for connection and agent readiness. 

* **Tests**
  * Updated tests for protocol-specific detection and failing MCP/GraphQL scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->