### PR TITLE
fix: Show TLS errors

### DIFF
--- a/rust-executor/src/graphql/mod.rs
+++ b/rust-executor/src/graphql/mod.rs
@@ -207,21 +207,37 @@ pub async fn start_server(config: Ad4mConfig) -> Result<(), AnyError> {
         let cert_path = tls_config.cert_file_path.clone();
         let key_path = tls_config.key_file_path.clone();
 
-        // Box the routes to make them Send + 'static
-        let routes_boxed = routes_with_cors.boxed();
+        // Validate TLS files are readable before attempting to start the server
+        if let Err(e) = std::fs::File::open(&cert_path) {
+            log::error!(
+                "TLS certificate file '{}' is not readable: {}. TLS server will NOT start.",
+                cert_path,
+                e
+            );
+        } else if let Err(e) = std::fs::File::open(&key_path) {
+            log::error!(
+                "TLS key file '{}' is not readable: {}. TLS server will NOT start.",
+                key_path,
+                e
+            );
+        } else {
+            // Box the routes to make them Send + 'static
+            let routes_boxed = routes_with_cors.boxed();
 
-        // Spawn TLS listener on 0.0.0.0 in background
-        tokio::spawn(async move {
-            warp::serve(routes_boxed)
-                .tls()
-                .cert_path(cert_path)
-                .key_path(key_path)
-                .run(([0, 0, 0, 0], tls_port))
-                .await;
-        });
+            // Spawn TLS listener on 0.0.0.0 in background
+            tokio::spawn(async move {
+                log::info!("TLS server starting on 0.0.0.0:{}", tls_port);
+                warp::serve(routes_boxed)
+                    .tls()
+                    .cert_path(cert_path)
+                    .key_path(key_path)
+                    .run(([0, 0, 0, 0], tls_port))
+                    .await;
+            });
 
-        // Give the TLS server a moment to start
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            // Give the TLS server a moment to start
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
 
         // Run plain HTTP listener on localhost - this one will handle local connections
         // We need to rebuild the same routes for the second server

--- a/ui/src-tauri/src/commands/app.rs
+++ b/ui/src-tauri/src/commands/app.rs
@@ -236,16 +236,31 @@ pub fn get_tls_config() -> Option<TlsConfig> {
 
 #[tauri::command]
 pub fn set_tls_config(config: TlsConfig) -> Result<(), String> {
-    // Validate file paths exist if TLS is enabled
+    // Validate file paths exist and are readable if TLS is enabled
     if config.enabled {
-        if !std::path::Path::new(&config.cert_file_path).exists() {
+        let cert_path = std::path::Path::new(&config.cert_file_path);
+        if !cert_path.exists() {
             return Err(format!(
                 "Certificate file not found: {}",
                 config.cert_file_path
             ));
         }
-        if !std::path::Path::new(&config.key_file_path).exists() {
+        if std::fs::File::open(cert_path).is_err() {
+            return Err(format!(
+                "Certificate file is not readable (check permissions): {}",
+                config.cert_file_path
+            ));
+        }
+
+        let key_path = std::path::Path::new(&config.key_file_path);
+        if !key_path.exists() {
             return Err(format!("Key file not found: {}", config.key_file_path));
+        }
+        if std::fs::File::open(key_path).is_err() {
+            return Err(format!(
+                "Key file is not readable (check permissions): {}",
+                config.key_file_path
+            ));
         }
     }
 
@@ -278,6 +293,50 @@ pub fn set_tls_config(config: TlsConfig) -> Result<(), String> {
         .map_err(|e| format!("Failed to save launcher state: {}", e))?;
 
     Ok(())
+}
+
+#[tauri::command]
+pub fn validate_tls_config() -> Result<Vec<String>, String> {
+    let state =
+        LauncherState::load().map_err(|e| format!("Failed to load launcher state: {}", e))?;
+
+    let tls_cfg = state
+        .multi_user_config
+        .as_ref()
+        .and_then(|m| m.tls_config.as_ref())
+        .or(state.tls_config.as_ref());
+
+    let config = match tls_cfg {
+        Some(c) if c.enabled => c,
+        _ => return Ok(vec![]),
+    };
+
+    let mut errors = Vec::new();
+
+    let cert_path = std::path::Path::new(&config.cert_file_path);
+    if !cert_path.exists() {
+        errors.push(format!(
+            "Certificate file not found: {}",
+            config.cert_file_path
+        ));
+    } else if std::fs::File::open(cert_path).is_err() {
+        errors.push(format!(
+            "Certificate file is not readable (permission denied): {}",
+            config.cert_file_path
+        ));
+    }
+
+    let key_path = std::path::Path::new(&config.key_file_path);
+    if !key_path.exists() {
+        errors.push(format!("Key file not found: {}", config.key_file_path));
+    } else if std::fs::File::open(key_path).is_err() {
+        errors.push(format!(
+            "Key file is not readable (permission denied): {}",
+            config.key_file_path
+        ));
+    }
+
+    Ok(errors)
 }
 
 #[tauri::command]

--- a/ui/src-tauri/src/lib.rs
+++ b/ui/src-tauri/src/lib.rs
@@ -45,6 +45,7 @@ use crate::commands::app::{
     get_smtp_config, get_tls_config, open_dapp, open_tray, open_tray_message,
     remove_app_agent_state, set_host_registration, set_log_config, set_mcp_config,
     set_selected_agent, set_smtp_config, set_tls_config, show_main_window, test_smtp_config,
+    validate_tls_config,
 };
 use crate::commands::proxy::{get_proxy, login_proxy, setup_proxy, stop_proxy};
 use crate::commands::state::{get_port, request_credential};
@@ -118,20 +119,42 @@ fn rlim_execute() {
 pub fn run() {
     let state = LauncherState::load().unwrap();
 
-    // Validate TLS config if enabled
-    if let Some(tls_cfg) = &state.tls_config {
+    // Validate TLS config if enabled (check both multi_user_config and legacy tls_config)
+    let tls_to_validate = state
+        .multi_user_config
+        .as_ref()
+        .and_then(|m| m.tls_config.as_ref())
+        .or(state.tls_config.as_ref());
+
+    if let Some(tls_cfg) = tls_to_validate {
         if tls_cfg.enabled {
-            if !std::path::Path::new(&tls_cfg.cert_file_path).exists() {
+            let cert_path = std::path::Path::new(&tls_cfg.cert_file_path);
+            let key_path = std::path::Path::new(&tls_cfg.key_file_path);
+
+            if !cert_path.exists() {
                 error!(
                     "TLS is enabled but certificate file not found: {}. \
                      TLS will be disabled. Please check your TLS settings.",
                     tls_cfg.cert_file_path
                 );
+            } else if std::fs::File::open(cert_path).is_err() {
+                error!(
+                    "TLS is enabled but certificate file is not readable: {}. \
+                     Check file permissions.",
+                    tls_cfg.cert_file_path
+                );
             }
-            if !std::path::Path::new(&tls_cfg.key_file_path).exists() {
+
+            if !key_path.exists() {
                 error!(
                     "TLS is enabled but key file not found: {}. \
                      TLS will be disabled. Please check your TLS settings.",
+                    tls_cfg.key_file_path
+                );
+            } else if std::fs::File::open(key_path).is_err() {
+                error!(
+                    "TLS is enabled but key file is not readable: {}. \
+                     Check file permissions (current user needs read access).",
                     tls_cfg.key_file_path
                 );
             }
@@ -256,6 +279,7 @@ pub fn run() {
             test_smtp_config,
             get_tls_config,
             set_tls_config,
+            validate_tls_config,
             get_mcp_config,
             set_mcp_config,
             get_host_registration,

--- a/ui/src/components/Hosting.tsx
+++ b/ui/src/components/Hosting.tsx
@@ -175,6 +175,7 @@ const Hosting = () => {
   const [tlsChanged, setTlsChanged] = useState(false);
   const [certPathError, setCertPathError] = useState("");
   const [keyPathError, setKeyPathError] = useState("");
+  const [tlsValidationErrors, setTlsValidationErrors] = useState<string[]>([]);
 
   // ---- UI state ----
   const [activeTab, setActiveTab] = useState<"users" | "settings">("settings");
@@ -730,6 +731,13 @@ const Hosting = () => {
       setTlsChanged(true);
       setCertPathError("");
       setKeyPathError("");
+      // Re-validate after saving
+      try {
+        const errors = await invoke<string[]>("validate_tls_config");
+        setTlsValidationErrors(errors);
+      } catch (_) {
+        // validation not available
+      }
     } catch (error) {
       const errorMsg = String(error);
       if (errorMsg.includes("Certificate")) setCertPathError(errorMsg);
@@ -961,6 +969,13 @@ const Hosting = () => {
             tls_port: 12001,
           },
         );
+        // Validate TLS files after loading config
+        try {
+          const errors = await invoke<string[]>("validate_tls_config");
+          setTlsValidationErrors(errors);
+        } catch (_) {
+          // validation command not available
+        }
       } catch (e) {
         console.error("Failed to load TLS config:", e);
       }
@@ -2129,7 +2144,11 @@ const Hosting = () => {
                 onToggle={() => setTlsExpanded(!tlsExpanded)}
                 badge={
                   tlsConfig?.enabled ? (
-                    <j-badge variant="success">Enabled</j-badge>
+                    tlsValidationErrors.length > 0 ? (
+                      <j-badge variant="danger">Error</j-badge>
+                    ) : (
+                      <j-badge variant="success">Enabled</j-badge>
+                    )
                   ) : (
                     <j-badge variant="gray">Disabled</j-badge>
                   )
@@ -2211,6 +2230,41 @@ const Hosting = () => {
                             }}
                           />
                         </div>
+                        {tlsValidationErrors.length > 0 && (
+                          <div
+                            style={{
+                              marginTop: "12px",
+                              padding: "12px",
+                              backgroundColor: "var(--j-color-danger-50, #fef2f2)",
+                              border: "1px solid var(--j-color-danger-200, #fecaca)",
+                              borderRadius: "8px",
+                            }}
+                          >
+                            <j-text size="400" weight="600" color="danger-500">
+                              TLS Configuration Issues
+                            </j-text>
+                            {tlsValidationErrors.map((err, i) => (
+                              <j-text key={i} size="300" color="danger-500" style={{ display: "block", marginTop: "4px" }}>
+                                {err}
+                              </j-text>
+                            ))}
+                          </div>
+                        )}
+                        {tlsValidationErrors.length === 0 && tlsConfig.cert_file_path && tlsConfig.key_file_path && (
+                          <div
+                            style={{
+                              marginTop: "12px",
+                              padding: "12px",
+                              backgroundColor: "var(--j-color-success-50, #f0fdf4)",
+                              border: "1px solid var(--j-color-success-200, #bbf7d0)",
+                              borderRadius: "8px",
+                            }}
+                          >
+                            <j-text size="400" color="success-500">
+                              TLS files are valid and readable.
+                            </j-text>
+                          </div>
+                        )}
                       </div>
                     )}
                   </>


### PR DESCRIPTION
Writes and error log and shows the error in the launcher if TLS won't work - for instance because the permissions for the certificate files are wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TLS configuration validation that checks file readability in addition to existence.
  * New validation endpoint provides detailed error messages for misconfigured TLS files.
  * Enhanced UI displays TLS configuration status with success confirmation or specific error details.

* **Bug Fixes**
  * Improved error detection for unreadable TLS certificate and key files.
  * Added preflight validation checks before starting HTTPS/WSS listeners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->