### PR TITLE
Fix: Auto-refresh users list in Hosting tab

### DIFF
--- a/ui/src/components/Hosting.tsx
+++ b/ui/src/components/Hosting.tsx
@@ -780,7 +780,7 @@ const [userLogs, setUserLogs] = useState<Record<string, { entries: any[]; loadin
   const getUsers = useCallback(async () => {
     if (!client) return;
     try {
-      setUsersLoading(true);
+      setUsersLoading((prev) => prev || users.length === 0);
       const userList = await client.runtime.listUsers();
       setUsers(userList);
     } catch (error) {
@@ -788,7 +788,7 @@ const [userLogs, setUserLogs] = useState<Record<string, { entries: any[]; loadin
     } finally {
       setUsersLoading(false);
     }
-  }, [client]);
+  }, [client, users.length]);
 
   const formatLastSeen = (lastSeen: string | null | undefined) => {
     if (!lastSeen) return "Never";
@@ -892,9 +892,13 @@ const [userLogs, setUserLogs] = useState<Record<string, { entries: any[]; loadin
 
   // ---- Effects ----
 
+  // Fetch users immediately on tab switch and poll every 15s while viewing
   useEffect(() => {
-    if (multiUserEnabled && client) getUsers();
-  }, [multiUserEnabled, client, getUsers]);
+    if (!multiUserEnabled || !client || activeTab !== "users") return;
+    getUsers();
+    const interval = setInterval(getUsers, 15000);
+    return () => clearInterval(interval);
+  }, [multiUserEnabled, client, activeTab, getUsers]);
 
   useEffect(() => {
     if (freeHostingEnabled) return;

--- a/ui/src/components/Hosting.tsx
+++ b/ui/src/components/Hosting.tsx
@@ -97,6 +97,7 @@ const Hosting = () => {
   const [users, setUsers] = useState<UserStatistics[]>([]);
   const [usersLoading, setUsersLoading] = useState(true);
   const usersFirstLoadDone = useRef(false);
+  const isFetchingUsers = useRef(false);
   const [creditAmounts, setCreditAmounts] = useState<Record<string, string>>(
     {},
   );
@@ -779,7 +780,8 @@ const [userLogs, setUserLogs] = useState<Record<string, { entries: any[]; loadin
   // ---- Users handlers ----
 
   const getUsers = useCallback(async () => {
-    if (!client) return;
+    if (!client || isFetchingUsers.current) return;
+    isFetchingUsers.current = true;
     try {
       if (!usersFirstLoadDone.current) {
         setUsersLoading(true);
@@ -791,6 +793,7 @@ const [userLogs, setUserLogs] = useState<Record<string, { entries: any[]; loadin
     } finally {
       usersFirstLoadDone.current = true;
       setUsersLoading(false);
+      isFetchingUsers.current = false;
     }
   }, [client]);
 
@@ -896,12 +899,31 @@ const [userLogs, setUserLogs] = useState<Record<string, { entries: any[]; loadin
 
   // ---- Effects ----
 
-  // Fetch users immediately on tab switch and poll every 15s while viewing
+  // Reset cached user state when the backing runtime changes so stale
+  // lists / finished-first-load flags don't persist across switches.
+  useEffect(() => {
+    setUsers([]);
+    setUsersLoading(true);
+    usersFirstLoadDone.current = false;
+  }, [client, multiUserEnabled]);
+
+  // Fetch users immediately on tab switch and poll every 15s while viewing.
+  // Uses self-scheduling setTimeout so each poll waits for the prior one.
   useEffect(() => {
     if (!multiUserEnabled || !client || activeTab !== "users") return;
-    getUsers();
-    const interval = setInterval(getUsers, 15000);
-    return () => clearInterval(interval);
+    let cancelled = false;
+    const poll = async () => {
+      await getUsers();
+      if (!cancelled) {
+        timer = setTimeout(poll, 15000);
+      }
+    };
+    let timer: ReturnType<typeof setTimeout>;
+    poll();
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
   }, [multiUserEnabled, client, activeTab, getUsers]);
 
   useEffect(() => {

--- a/ui/src/components/Hosting.tsx
+++ b/ui/src/components/Hosting.tsx
@@ -96,6 +96,7 @@ const Hosting = () => {
   // ---- Users state ----
   const [users, setUsers] = useState<UserStatistics[]>([]);
   const [usersLoading, setUsersLoading] = useState(true);
+  const usersFirstLoadDone = useRef(false);
   const [creditAmounts, setCreditAmounts] = useState<Record<string, string>>(
     {},
   );
@@ -780,15 +781,18 @@ const [userLogs, setUserLogs] = useState<Record<string, { entries: any[]; loadin
   const getUsers = useCallback(async () => {
     if (!client) return;
     try {
-      setUsersLoading((prev) => prev || users.length === 0);
+      if (!usersFirstLoadDone.current) {
+        setUsersLoading(true);
+      }
       const userList = await client.runtime.listUsers();
       setUsers(userList);
     } catch (error) {
       console.error("Failed to load users:", error);
     } finally {
+      usersFirstLoadDone.current = true;
       setUsersLoading(false);
     }
-  }, [client, users.length]);
+  }, [client]);
 
   const formatLastSeen = (lastSeen: string | null | undefined) => {
     if (!lastSeen) return "Never";


### PR DESCRIPTION
# Fix: Auto-refresh users list in Hosting tab

## Problem

The registered users list in the multi-user hosting section of the launcher UI did not update in real-time. The `useEffect` that fetched users only depended on `multiUserEnabled` and `client`, so after the initial mount, the list would never refresh. Users had to navigate away from the Hosting page and come back to see updated data.

## Solution

Implemented a hybrid refresh strategy in `ui/src/components/Hosting.tsx`:

1. **Immediate fetch on tab switch** — Added `activeTab` as a dependency so `getUsers()` fires immediately when switching to the "Users" tab.
2. **Polling while viewing** — A 15-second `setInterval` keeps the list fresh while the user is on the "Users" tab. The interval is cleaned up when leaving the tab or unmounting.
3. **No spinner flash on polls** — The loading spinner now only appears on the initial fetch (when the user list is empty). Subsequent background polls update the list silently.

## Changes

- `ui/src/components/Hosting.tsx`
  - Updated the `getUsers` `useCallback` to only set `usersLoading` to `true` when `users.length === 0` (initial load)
  - Replaced the existing `useEffect` for user fetching with one that depends on `activeTab`, triggers only when `activeTab === "users"`, and sets up a 15s polling interval with proper cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate loading indicator for the Users list: the spinner appears only during the initial fetch and no longer flashes on background updates.
  * Smarter Users tab polling: the list auto-refreshes every 15 seconds only while the Users tab is active and multi-user mode is enabled, reducing unnecessary requests and UI noise.
  * More reliable state when toggling multi-user or reconnecting: cached user state resets to avoid stale or blocked loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
depends on d9011e34-8219-4ba1-bdd1-7d104a25cd1f/91215135-9143-46eb-8f5d-b38504a40392#478