### PR TITLE
Compute Activity Log

### DIFF
--- a/connect/src/components/views/LoggedInDashboard.ts
+++ b/connect/src/components/views/LoggedInDashboard.ts
@@ -2,7 +2,7 @@ import { LitElement, html, css } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { sharedStyles } from "../../styles/shared-styles";
 import { CheckIcon, CrossIcon, CreditIcon, MapPinIcon, WalletIcon } from "../icons";
-import type { RemoteHost, UserInfo } from "../../types";
+import type { RemoteHost, UserInfo, ComputeLogEntryData } from "../../types";
 
 @customElement("logged-in-dashboard")
 export class LoggedInDashboard extends LitElement {
@@ -17,6 +17,9 @@ export class LoggedInDashboard extends LitElement {
   @state() private topUpAmount = "";
   @state() private awaitingApproval = false;
   @state() private creditsUpdated = false;
+  @state() private activityLogOpen = false;
+  @state() private activityLog: ComputeLogEntryData[] = [];
+  @state() private activityLogLoading = false;
   private previousCredits: number | null = null;
 
   static styles = [
@@ -248,6 +251,106 @@ export class LoggedInDashboard extends LitElement {
       button.full {
         width: 100%;
       }
+
+      .activity-log-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        cursor: pointer;
+        padding: 10px 12px;
+        border-radius: 8px;
+        background: rgba(128, 178, 201, 0.08);
+        box-shadow: 0 0 0 1px var(--ac-border-color-light);
+        font-size: 14px;
+        color: rgba(255, 255, 255, 0.7);
+        user-select: none;
+      }
+
+      .activity-log-toggle:hover {
+        background: rgba(128, 178, 201, 0.14);
+      }
+
+      .activity-log-toggle .chevron {
+        transition: transform 0.2s;
+        font-size: 12px;
+      }
+
+      .activity-log-toggle .chevron.open {
+        transform: rotate(90deg);
+      }
+
+      .activity-log-list {
+        max-height: 200px;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .activity-log-entry {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 6px 10px;
+        border-radius: 6px;
+        background: rgba(128, 178, 201, 0.06);
+        font-size: 13px;
+        color: rgba(255, 255, 255, 0.75);
+      }
+
+      .activity-log-entry .op-badge {
+        display: inline-block;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+      }
+
+      .activity-log-entry .op-badge.ai_prompt {
+        background: rgba(168, 130, 255, 0.2);
+        color: #c4a8ff;
+      }
+
+      .activity-log-entry .op-badge.ai_embed {
+        background: rgba(130, 200, 255, 0.2);
+        color: #a8d8ff;
+      }
+
+      .activity-log-entry .op-badge.link_write {
+        background: rgba(255, 200, 100, 0.2);
+        color: #ffd080;
+      }
+
+      .activity-log-entry .cost {
+        font-weight: 600;
+        color: #ffffff;
+        white-space: nowrap;
+      }
+
+      .activity-log-entry .time {
+        font-size: 11px;
+        color: rgba(255, 255, 255, 0.4);
+        white-space: nowrap;
+      }
+
+      .activity-log-entry .summary {
+        flex: 1;
+        margin: 0 8px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: rgba(255, 255, 255, 0.5);
+        font-size: 12px;
+      }
+
+      .activity-log-empty {
+        text-align: center;
+        padding: 12px;
+        color: rgba(255, 255, 255, 0.4);
+        font-size: 13px;
+      }
     `
   ];
 
@@ -276,6 +379,55 @@ export class LoggedInDashboard extends LitElement {
   private truncateMiddle(str: string, startChars = 8, endChars = 6): string {
     if (str.length <= startChars + endChars + 3) return str;
     return `${str.slice(0, startChars)}…${str.slice(-endChars)}`;
+  }
+
+  private async toggleActivityLog() {
+    this.activityLogOpen = !this.activityLogOpen;
+    if (this.activityLogOpen && this.activityLog.length === 0) {
+      await this.loadActivityLog();
+    }
+  }
+
+  private async loadActivityLog() {
+    this.activityLogLoading = true;
+    try {
+      this.dispatchEvent(new CustomEvent('fetch-compute-log', {
+        bubbles: true, composed: true,
+        detail: {
+          callback: (entries: ComputeLogEntryData[]) => {
+            this.activityLog = entries;
+            this.activityLogLoading = false;
+          }
+        }
+      }));
+    } catch {
+      this.activityLogLoading = false;
+    }
+  }
+
+  /** Call this externally to push a realtime log entry */
+  pushLogEntry(entry: ComputeLogEntryData) {
+    this.activityLog = [entry, ...this.activityLog].slice(0, 100);
+  }
+
+  private formatTimeAgo(timestamp: string): string {
+    const diff = Date.now() - new Date(timestamp).getTime();
+    const seconds = Math.floor(diff / 1000);
+    if (seconds < 60) return `${seconds}s ago`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    return `${Math.floor(hours / 24)}d ago`;
+  }
+
+  private formatOperation(op: string): string {
+    switch (op) {
+      case 'ai_prompt': return 'AI Prompt';
+      case 'ai_embed': return 'AI Embed';
+      case 'link_write': return 'Link Write';
+      default: return op;
+    }
   }
 
   private get hasWallet(): boolean {
@@ -458,6 +610,30 @@ export class LoggedInDashboard extends LitElement {
             <div class="error-message">${this.paymentError}</div>
           ` : ''}
         `}
+
+        <!-- Activity Log -->
+        <div class="activity-log-toggle" @click=${this.toggleActivityLog}>
+          <span>Activity Log</span>
+          <span class="chevron ${this.activityLogOpen ? 'open' : ''}">&#9654;</span>
+        </div>
+        ${this.activityLogOpen ? html`
+          ${this.activityLogLoading ? html`
+            <div class="activity-log-empty">Loading...</div>
+          ` : this.activityLog.length === 0 ? html`
+            <div class="activity-log-empty">No activity yet</div>
+          ` : html`
+            <div class="activity-log-list">
+              ${this.activityLog.map(entry => html`
+                <div class="activity-log-entry">
+                  <span class="op-badge ${entry.operation}">${this.formatOperation(entry.operation)}</span>
+                  <span class="summary" title=${entry.summary || ''}>${entry.summary || ''}</span>
+                  <span class="cost">${entry.cost.toFixed(2)}</span>
+                  <span class="time">${this.formatTimeAgo(entry.timestamp)}</span>
+                </div>
+              `)}
+            </div>
+          `}
+        ` : ''}
 
         <div class="footer-actions">
           <button class="primary" ?disabled=${this.isDepleted && !this.isFreeAccess} @click=${this.close}>

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -309,6 +309,16 @@ export default class Ad4mConnect extends EventTarget {
       console.warn('[Ad4m Connect] Subscription not available, falling back to polling:', e);
     }
 
+    // Subscribe to compute log updates for real-time activity log
+    try {
+      this.ad4mClient.agent.addComputeLogUpdatedListener((entry) => {
+        this.dispatchEvent(new CustomEvent('computelogentry', { detail: entry }));
+      });
+      this.ad4mClient.agent.subscribeComputeLogUpdated();
+    } catch (e) {
+      console.warn('[Ad4m Connect] Compute log subscription not available:', e);
+    }
+
     // Always start polling as a safety-net (at a longer 60s interval)
     this.startCreditPolling();
   }
@@ -349,6 +359,12 @@ export default class Ad4mConnect extends EventTarget {
   async requestTopUp(amountHOT: number): Promise<{ success: boolean; message: string }> {
     if (!this.ad4mClient) throw new Error('Not connected');
     return requestPayment(this.ad4mClient, amountHOT);
+  }
+
+  /** Fetch recent compute log entries. */
+  async fetchComputeLog(since?: string, limit?: number): Promise<import('./types').ComputeLogEntryData[]> {
+    if (!this.ad4mClient) throw new Error('Not connected');
+    return this.ad4mClient.agent.computeLog(since, limit) as any;
   }
 
   /** Persist selected host after successful auth */

--- a/connect/src/types.ts
+++ b/connect/src/types.ts
@@ -58,3 +58,14 @@ export type UserInfo = {
   hotWalletAddress: string | null;  // user's wHOT public address (null until set)
   freeAccess: boolean;
 };
+
+/** A single compute activity log entry */
+export type ComputeLogEntryData = {
+  id: number;
+  userEmail: string;
+  timestamp: string;
+  operation: string;
+  summary: string | null;
+  cost: number;
+  creditsAfter: number;
+};

--- a/connect/src/web.ts
+++ b/connect/src/web.ts
@@ -589,6 +589,14 @@ export class Ad4mConnectElement extends LitElement {
           @disconnect=${this.disconnect}
           @request-top-up=${this.handleRequestTopUp}
           @set-wallet-address=${this.handleSetWalletAddress}
+          @fetch-compute-log=${(e: CustomEvent) => {
+            const cb = e?.detail?.callback;
+            if (typeof cb !== 'function') return;
+            this.core.fetchComputeLog().then(cb).catch((err: any) => {
+              console.error('[Ad4m Connect] Failed to fetch compute log:', err);
+              cb([]);
+            });
+          }}
         ></logged-in-dashboard>
       `;
     }

--- a/core/src/agent/AgentClient.ts
+++ b/core/src/agent/AgentClient.ts
@@ -10,7 +10,7 @@ import {
   EntanglementProofInput,
   UserCreationResult,
 } from "./Agent";
-import { HostingUserInfo, PaymentRequestResult } from "../runtime/RuntimeResolver";
+import { HostingUserInfo, PaymentRequestResult, ComputeLogEntry } from "../runtime/RuntimeResolver";
 import { AgentStatus } from "./AgentStatus";
 import { LinkMutations } from "../links/Links";
 import { PerspectiveClient } from "../perspectives/PerspectiveClient";
@@ -83,6 +83,7 @@ export type AgentUpdatedCallback = (agent: Agent) => null;
 export type AgentStatusChangedCallback = (agent: Agent) => null;
 export type AgentAppsUpdatedCallback = () => null;
 export type HostingUserInfoChangedCallback = (info: HostingUserInfo) => void;
+export type ComputeLogUpdatedCallback = (entry: ComputeLogEntry) => void;
 /**
  * Provides access to all functions regarding the local agent,
  * such as generating, locking, unlocking, importing the DID keystore,
@@ -94,6 +95,7 @@ export class AgentClient {
   #updatedCallbacks: AgentUpdatedCallback[];
   #agentStatusChangedCallbacks: AgentStatusChangedCallback[];
   #hostingUserInfoChangedCallbacks: HostingUserInfoChangedCallback[];
+  #computeLogUpdatedCallbacks: ComputeLogUpdatedCallback[];
 
   constructor(client: ApolloClient<any>, subscribe: boolean = true) {
     this.#apolloClient = client;
@@ -101,6 +103,7 @@ export class AgentClient {
     this.#agentStatusChangedCallbacks = [];
     this.#appsChangedCallback = [];
     this.#hostingUserInfoChangedCallbacks = [];
+    this.#computeLogUpdatedCallbacks = [];
 
     if (subscribe) {
       this.subscribeAgentUpdated();
@@ -450,6 +453,34 @@ export class AgentClient {
       });
   }
 
+  addComputeLogUpdatedListener(listener: ComputeLogUpdatedCallback) {
+    this.#computeLogUpdatedCallbacks.push(listener);
+  }
+
+  subscribeComputeLogUpdated() {
+    this.#apolloClient
+      .subscribe({
+        query: gql`subscription {
+          runtimeComputeLogUpdated {
+            id
+            userEmail
+            timestamp
+            operation
+            summary
+            cost
+            creditsAfter
+          }
+        }`,
+      })
+      .subscribe({
+        next: (result) => {
+          const entry = result.data.runtimeComputeLogUpdated;
+          this.#computeLogUpdatedCallbacks.forEach((cb) => cb(entry));
+        },
+        error: (e) => console.error(e),
+      });
+  }
+
   async requestCapability(authInfo: AuthInfoInput): Promise<string> {
     const { agentRequestCapability } = unwrapApolloResult(
       await this.#apolloClient.mutate({
@@ -634,6 +665,27 @@ export class AgentClient {
       })
     );
     return runtimeHostingUserInfo;
+  }
+
+  async computeLog(since?: string, limit?: number, userEmail?: string): Promise<ComputeLogEntry[]> {
+    const { runtimeComputeLog } = unwrapApolloResult(
+      await this.#apolloClient.query({
+        query: gql`query runtimeComputeLog($since: String, $limit: Int, $userEmail: String) {
+          runtimeComputeLog(since: $since, limit: $limit, userEmail: $userEmail) {
+            id
+            userEmail
+            timestamp
+            operation
+            summary
+            cost
+            creditsAfter
+          }
+        }`,
+        variables: { since, limit, userEmail },
+        fetchPolicy: 'network-only',
+      })
+    );
+    return runtimeComputeLog;
   }
 
   async setHotWalletAddress(address: string): Promise<boolean> {

--- a/core/src/runtime/RuntimeResolver.ts
+++ b/core/src/runtime/RuntimeResolver.ts
@@ -268,6 +268,40 @@ export class PaymentRequestResult {
     }
 }
 
+@ObjectType()
+export class ComputeLogEntry {
+    @Field()
+    id: number;
+
+    @Field()
+    userEmail: string;
+
+    @Field()
+    timestamp: string;
+
+    @Field()
+    operation: string;
+
+    @Field({ nullable: true })
+    summary?: string;
+
+    @Field()
+    cost: number;
+
+    @Field()
+    creditsAfter: number;
+
+    constructor(id: number, userEmail: string, timestamp: string, operation: string, cost: number, creditsAfter: number, summary?: string) {
+        this.id = id;
+        this.userEmail = userEmail;
+        this.timestamp = timestamp;
+        this.operation = operation;
+        this.cost = cost;
+        this.creditsAfter = creditsAfter;
+        this.summary = summary;
+    }
+}
+
 /**
  * Resolver classes are used here to define the GraphQL schema 
  * (through the type-graphql annotations)
@@ -623,6 +657,15 @@ export default class RuntimeResolver {
     @Query(returns => HostingUserInfo)
     runtimeHostingUserInfo(): HostingUserInfo {
         return new HostingUserInfo("test@example.com", "100000000", null, false)
+    }
+
+    @Query(returns => [ComputeLogEntry])
+    runtimeComputeLog(
+        @Arg("since", { nullable: true }) since?: string,
+        @Arg("limit", { nullable: true }) limit?: number,
+        @Arg("userEmail", { nullable: true }) userEmail?: string,
+    ): ComputeLogEntry[] {
+        return []
     }
 
     @Mutation(returns => Boolean)

--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -3151,7 +3151,8 @@ impl Ad4mDb {
             ),
         };
         let mut stmt = self.conn.prepare(sql)?;
-        let params_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params_vec.iter().map(|p| p.as_ref()).collect();
         let entries = stmt
             .query_map(params_refs.as_slice(), |row| {
                 Ok(ComputeLogEntry {
@@ -3185,7 +3186,8 @@ impl Ad4mDb {
             ),
         };
         let mut stmt = self.conn.prepare(sql)?;
-        let params_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params_vec.iter().map(|p| p.as_ref()).collect();
         let entries = stmt
             .query_map(params_refs.as_slice(), |row| {
                 Ok(ComputeLogEntry {

--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -55,6 +55,18 @@ pub struct PaymentRequest {
     pub completed_at: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComputeLogEntry {
+    pub id: i64,
+    pub user_email: String,
+    pub timestamp: String,
+    pub operation: String,
+    pub summary: Option<String>,
+    pub cost: f64,
+    pub credits_after: f64,
+}
+
 use std::sync::{Arc, Mutex};
 
 lazy_static! {
@@ -411,6 +423,22 @@ impl Ad4mDb {
         // Add unique index for existing databases that already created the table without UNIQUE
         conn.execute_batch(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_sends_proposal_hash ON pending_sends(proposal_action_hash)",
+        )?;
+
+        // Compute activity log — one row per billing event
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS compute_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_email TEXT NOT NULL,
+                timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+                operation TEXT NOT NULL,
+                summary TEXT,
+                cost REAL NOT NULL,
+                credits_after REAL NOT NULL
+            )",
+        )?;
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_compute_log_user_time ON compute_log(user_email, timestamp)",
         )?;
 
         Ok(Self { conn })
@@ -3084,6 +3112,103 @@ impl Ad4mDb {
             return Err(anyhow!("Insufficient compute credits"));
         }
         Ok(())
+    }
+
+    // ── Compute activity log ────────────────────────────────────────────
+
+    /// Insert a compute log entry after a billing event.
+    pub fn insert_compute_log(
+        &self,
+        email: &str,
+        operation: &str,
+        summary: Option<&str>,
+        cost: f64,
+        credits_after: f64,
+    ) -> Ad4mDbResult<i64> {
+        self.conn.execute(
+            "INSERT INTO compute_log (user_email, operation, summary, cost, credits_after) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![email, operation, summary, cost, credits_after],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Query compute log entries for a user, ordered newest-first.
+    /// If `since` is provided (ISO 8601), only entries after that timestamp are returned.
+    pub fn get_compute_log(
+        &self,
+        email: &str,
+        since: Option<&str>,
+        limit: i64,
+    ) -> Ad4mDbResult<Vec<ComputeLogEntry>> {
+        let (sql, params_vec): (&str, Vec<Box<dyn rusqlite::types::ToSql>>) = match since {
+            Some(ts) => (
+                "SELECT id, user_email, timestamp, operation, summary, cost, credits_after FROM compute_log WHERE user_email = ?1 AND timestamp > ?2 ORDER BY id DESC LIMIT ?3",
+                vec![Box::new(email.to_string()), Box::new(ts.to_string()), Box::new(limit)],
+            ),
+            None => (
+                "SELECT id, user_email, timestamp, operation, summary, cost, credits_after FROM compute_log WHERE user_email = ?1 ORDER BY id DESC LIMIT ?2",
+                vec![Box::new(email.to_string()), Box::new(limit)],
+            ),
+        };
+        let mut stmt = self.conn.prepare(sql)?;
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
+        let entries = stmt
+            .query_map(params_refs.as_slice(), |row| {
+                Ok(ComputeLogEntry {
+                    id: row.get(0)?,
+                    user_email: row.get(1)?,
+                    timestamp: row.get(2)?,
+                    operation: row.get(3)?,
+                    summary: row.get(4)?,
+                    cost: row.get(5)?,
+                    credits_after: row.get(6)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(entries)
+    }
+
+    /// Query compute log entries for ALL users (admin). Newest-first.
+    pub fn get_compute_log_all(
+        &self,
+        since: Option<&str>,
+        limit: i64,
+    ) -> Ad4mDbResult<Vec<ComputeLogEntry>> {
+        let (sql, params_vec): (&str, Vec<Box<dyn rusqlite::types::ToSql>>) = match since {
+            Some(ts) => (
+                "SELECT id, user_email, timestamp, operation, summary, cost, credits_after FROM compute_log WHERE timestamp > ?1 ORDER BY id DESC LIMIT ?2",
+                vec![Box::new(ts.to_string()), Box::new(limit)],
+            ),
+            None => (
+                "SELECT id, user_email, timestamp, operation, summary, cost, credits_after FROM compute_log ORDER BY id DESC LIMIT ?1",
+                vec![Box::new(limit)],
+            ),
+        };
+        let mut stmt = self.conn.prepare(sql)?;
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
+        let entries = stmt
+            .query_map(params_refs.as_slice(), |row| {
+                Ok(ComputeLogEntry {
+                    id: row.get(0)?,
+                    user_email: row.get(1)?,
+                    timestamp: row.get(2)?,
+                    operation: row.get(3)?,
+                    summary: row.get(4)?,
+                    cost: row.get(5)?,
+                    credits_after: row.get(6)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(entries)
+    }
+
+    /// Delete log entries older than the given ISO 8601 timestamp.
+    pub fn cleanup_compute_log(&self, before: &str) -> Ad4mDbResult<usize> {
+        let rows = self.conn.execute(
+            "DELETE FROM compute_log WHERE timestamp < ?1",
+            params![before],
+        )?;
+        Ok(rows)
     }
 
     pub fn get_user_hot_wallet(&self, email: &str) -> Ad4mDbResult<Option<String>> {

--- a/rust-executor/src/db.rs
+++ b/rust-executor/src/db.rs
@@ -430,7 +430,7 @@ impl Ad4mDb {
             "CREATE TABLE IF NOT EXISTS compute_log (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 user_email TEXT NOT NULL,
-                timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+                timestamp TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
                 operation TEXT NOT NULL,
                 summary TEXT,
                 cost REAL NOT NULL,
@@ -3112,6 +3112,54 @@ impl Ad4mDb {
             return Err(anyhow!("Insufficient compute credits"));
         }
         Ok(())
+    }
+
+    /// Atomically deduct credits AND insert a compute log entry in a single transaction.
+    /// Returns the credits_after value on success.
+    pub fn deduct_credits_and_log(
+        &self,
+        email: &str,
+        amount: f64,
+        operation: &str,
+        summary: Option<&str>,
+    ) -> Ad4mDbResult<(i64, f64)> {
+        Self::validate_credit_amount(amount)?;
+        let tx = self.conn.unchecked_transaction()?;
+
+        // Deduct credits (fails if insufficient)
+        let rows = tx.execute(
+            "UPDATE users SET remaining_credits = remaining_credits - ?1 WHERE username = ?2 AND COALESCE(remaining_credits, 0) >= ?1",
+            params![amount, email],
+        )?;
+        if rows == 0 {
+            let exists: bool = tx.query_row(
+                "SELECT EXISTS(SELECT 1 FROM users WHERE username = ?1)",
+                [email],
+                |row| row.get(0),
+            )?;
+            // tx is dropped here → auto-rollback
+            if !exists {
+                return Err(anyhow!("User not found: {}", email));
+            }
+            return Err(anyhow!("Insufficient compute credits"));
+        }
+
+        // Read the resulting balance within the same transaction
+        let credits_after: f64 = tx.query_row(
+            "SELECT COALESCE(remaining_credits, 0) FROM users WHERE username = ?1",
+            [email],
+            |row| row.get(0),
+        )?;
+
+        // Insert the audit log entry
+        tx.execute(
+            "INSERT INTO compute_log (user_email, operation, summary, cost, credits_after) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![email, operation, summary, amount, credits_after],
+        )?;
+        let row_id = tx.last_insert_rowid();
+
+        tx.commit()?;
+        Ok((row_id, credits_after))
     }
 
     // ── Compute activity log ────────────────────────────────────────────

--- a/rust-executor/src/graphql/graphql_types.rs
+++ b/rust-executor/src/graphql/graphql_types.rs
@@ -732,6 +732,18 @@ pub struct PaymentRequestResult {
     pub message: String,
 }
 
+#[derive(GraphQLObject, Default, Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ComputeLogEntry {
+    pub id: i32,
+    pub user_email: String,
+    pub timestamp: String,
+    pub operation: String,
+    pub summary: Option<String>,
+    pub cost: f64,
+    pub credits_after: f64,
+}
+
 #[derive(Default, Debug, Deserialize, Serialize)]
 pub struct NeighbourhoodSignalFilter {
     pub perspective: PerspectiveHandle,
@@ -1217,6 +1229,20 @@ impl GetValue for HostingUserInfo {
 impl GetFilter for HostingUserInfo {
     fn get_filter(&self) -> Option<String> {
         Some(self.email.clone())
+    }
+}
+
+impl GetValue for ComputeLogEntry {
+    type Value = ComputeLogEntry;
+
+    fn get_value(&self) -> Self::Value {
+        self.clone()
+    }
+}
+
+impl GetFilter for ComputeLogEntry {
+    fn get_filter(&self) -> Option<String> {
+        Some(self.user_email.clone())
     }
 }
 

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -76,17 +76,18 @@ fn reserve_compute_credits(
         let free = Ad4mDb::with_global_instance(|db| db.get_user_free_access(email))
             .map_err(|e| FieldError::new(e.to_string(), graphql_value!(null)))?;
         if !free {
-            Ad4mDb::with_global_instance(|db| db.deduct_user_credits_if_available(email, amount))
-                .map_err(|e| FieldError::new(e.to_string(), graphql_value!(null)))?;
-            // Log the billing event
-            let credits_after =
-                Ad4mDb::with_global_instance(|db| db.get_user_credits(email)).unwrap_or(0.0);
-            if let Err(e) = Ad4mDb::with_global_instance(|db| {
-                db.insert_compute_log(email, operation, summary, amount, credits_after)
-            }) {
-                log::warn!("Failed to insert compute log entry: {:?}", e);
-            }
-            crate::pubsub::push_compute_log_entry(email, operation, summary, amount, credits_after);
+            let (row_id, credits_after) = Ad4mDb::with_global_instance(|db| {
+                db.deduct_credits_and_log(email, amount, operation, summary)
+            })
+            .map_err(|e| FieldError::new(e.to_string(), graphql_value!(null)))?;
+            crate::pubsub::push_compute_log_entry(
+                row_id,
+                email,
+                operation,
+                summary,
+                amount,
+                credits_after,
+            );
             mark_credits_dirty(email);
         }
     }

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -56,11 +56,17 @@ fn get_rate(description: &str, default: f64) -> FieldResult<f64> {
 /// Deduct compute credits for a user after an operation completes.
 /// Uses clamped deduction (credits go to 0, never negative) so that the
 /// pre-check in check_compute_credits will block subsequent operations.
+/// Also inserts a compute log entry with the operation metadata.
 /// Returns Ok(()) if:
 /// - No user email in token (single-user mode, no billing)
 /// - User has free_access enabled
 /// - Credits were successfully deducted (clamped to 0)
-fn reserve_compute_credits(auth_token: &str, amount: f64) -> FieldResult<()> {
+fn reserve_compute_credits(
+    auth_token: &str,
+    amount: f64,
+    operation: &str,
+    summary: Option<&str>,
+) -> FieldResult<()> {
     if let Some(ref email) = user_email_from_token(auth_token.to_string()) {
         let global_free =
             Ad4mDb::with_global_instance(|db| db.get_free_hosting_enabled()).unwrap_or(true);
@@ -72,6 +78,15 @@ fn reserve_compute_credits(auth_token: &str, amount: f64) -> FieldResult<()> {
         if !free {
             Ad4mDb::with_global_instance(|db| db.deduct_user_credits_if_available(email, amount))
                 .map_err(|e| FieldError::new(e.to_string(), graphql_value!(null)))?;
+            // Log the billing event
+            let credits_after = Ad4mDb::with_global_instance(|db| db.get_user_credits(email))
+                .unwrap_or(0.0);
+            if let Err(e) = Ad4mDb::with_global_instance(|db| {
+                db.insert_compute_log(email, operation, summary, amount, credits_after)
+            }) {
+                log::warn!("Failed to insert compute log entry: {:?}", e);
+            }
+            crate::pubsub::push_compute_log_entry(email, operation, summary, amount, credits_after);
             mark_credits_dirty(email);
         }
     }
@@ -1974,6 +1989,8 @@ impl Mutation {
         if let Err(e) = reserve_compute_credits(
             &context.auth_token,
             get_rate("link write", DEFAULT_LINK_WRITE_RATE)?,
+            "link_write",
+            Some(&format!("1 link in perspective {}", uuid)),
         ) {
             log::warn!("Call exceeded compute credits (add_link): result returned but future calls will fail. Details: {:?}", e);
         }
@@ -2002,6 +2019,8 @@ impl Mutation {
         if let Err(e) = reserve_compute_credits(
             &context.auth_token,
             get_rate("link write", DEFAULT_LINK_WRITE_RATE)?,
+            "link_write",
+            Some(&format!("1 link in perspective {}", uuid)),
         ) {
             log::warn!("Call exceeded compute credits (add_link_expression): result returned but future calls will fail. Details: {:?}", e);
         }
@@ -2037,6 +2056,8 @@ impl Mutation {
         if let Err(e) = reserve_compute_credits(
             &context.auth_token,
             link_count as f64 * get_rate("link write", DEFAULT_LINK_WRITE_RATE)?,
+            "link_write",
+            Some(&format!("{} links in perspective {}", link_count, uuid)),
         ) {
             log::warn!("Call exceeded compute credits (add_links, count={}): result returned but future calls will fail. Details: {:?}", link_count, e);
         }
@@ -2067,6 +2088,8 @@ impl Mutation {
         if let Err(e) = reserve_compute_credits(
             &context.auth_token,
             additions_count as f64 * get_rate("link write", DEFAULT_LINK_WRITE_RATE)?,
+            "link_write",
+            Some(&format!("{} additions in perspective {}", additions_count, uuid)),
         ) {
             log::warn!("Call exceeded compute credits (link_mutations, additions={}): result returned but future calls will fail. Details: {:?}", additions_count, e
             );
@@ -2963,6 +2986,8 @@ impl Mutation {
         if let Err(e) = reserve_compute_credits(
             &context.auth_token,
             total_tokens as f64 * get_rate(&model_name, DEFAULT_TOKEN_RATE)?,
+            "ai_prompt",
+            Some(&format!("{}: {} prompt + {} completion tokens", model_name, result.prompt_tokens, result.completion_tokens)),
         ) {
             log::warn!("Call exceeded compute credits (ai_prompt, model={}, tokens={}): result returned but future calls will fail. Details: {:?}", model_name, total_tokens, e);
         }
@@ -2988,6 +3013,8 @@ impl Mutation {
             &context.auth_token,
             result.token_count as f64
                 * get_rate("embedding per token", DEFAULT_EMBEDDING_TOKEN_RATE)?,
+            "ai_embed",
+            Some(&format!("{} tokens", result.token_count)),
         ) {
             log::warn!("Call exceeded compute credits (ai_embed, tokens={}): result returned but future calls will fail. Details: {:?}", result.token_count, e);
         }

--- a/rust-executor/src/graphql/mutation_resolvers.rs
+++ b/rust-executor/src/graphql/mutation_resolvers.rs
@@ -79,8 +79,8 @@ fn reserve_compute_credits(
             Ad4mDb::with_global_instance(|db| db.deduct_user_credits_if_available(email, amount))
                 .map_err(|e| FieldError::new(e.to_string(), graphql_value!(null)))?;
             // Log the billing event
-            let credits_after = Ad4mDb::with_global_instance(|db| db.get_user_credits(email))
-                .unwrap_or(0.0);
+            let credits_after =
+                Ad4mDb::with_global_instance(|db| db.get_user_credits(email)).unwrap_or(0.0);
             if let Err(e) = Ad4mDb::with_global_instance(|db| {
                 db.insert_compute_log(email, operation, summary, amount, credits_after)
             }) {
@@ -2089,7 +2089,10 @@ impl Mutation {
             &context.auth_token,
             additions_count as f64 * get_rate("link write", DEFAULT_LINK_WRITE_RATE)?,
             "link_write",
-            Some(&format!("{} additions in perspective {}", additions_count, uuid)),
+            Some(&format!(
+                "{} additions in perspective {}",
+                additions_count, uuid
+            )),
         ) {
             log::warn!("Call exceeded compute credits (link_mutations, additions={}): result returned but future calls will fail. Details: {:?}", additions_count, e
             );
@@ -2987,7 +2990,10 @@ impl Mutation {
             &context.auth_token,
             total_tokens as f64 * get_rate(&model_name, DEFAULT_TOKEN_RATE)?,
             "ai_prompt",
-            Some(&format!("{}: {} prompt + {} completion tokens", model_name, result.prompt_tokens, result.completion_tokens)),
+            Some(&format!(
+                "{}: {} prompt + {} completion tokens",
+                model_name, result.prompt_tokens, result.completion_tokens
+            )),
         ) {
             log::warn!("Call exceeded compute credits (ai_prompt, model={}, tokens={}): result returned but future calls will fail. Details: {:?}", model_name, total_tokens, e);
         }

--- a/rust-executor/src/graphql/query_resolvers.rs
+++ b/rust-executor/src/graphql/query_resolvers.rs
@@ -1398,6 +1398,98 @@ impl Query {
         .to_string())
     }
 
+    /// Get compute activity log entries.
+    /// Regular users see only their own entries; admin sees all users.
+    async fn runtime_compute_log(
+        &self,
+        context: &RequestContext,
+        since: Option<String>,
+        limit: Option<i32>,
+        user_email: Option<String>,
+    ) -> FieldResult<Vec<ComputeLogEntry>> {
+        check_capability(&context.capabilities, &RUNTIME_HOSTING_READ_CAPABILITY)?;
+
+        let max = (limit.unwrap_or(100) as i64).min(1000);
+
+        // If admin and user_email is provided, query that user's log
+        if context.is_admin_credential {
+            if let Some(ref email) = user_email {
+                let entries = Ad4mDb::with_global_instance(|db| {
+                    db.get_compute_log(email, since.as_deref(), max)
+                })
+                .map_err(|e| {
+                    FieldError::new(
+                        format!("Failed to get compute log: {}", e),
+                        Value::null(),
+                    )
+                })?;
+                return Ok(entries
+                    .into_iter()
+                    .map(|e| ComputeLogEntry {
+                        id: e.id as i32,
+                        user_email: e.user_email,
+                        timestamp: e.timestamp,
+                        operation: e.operation,
+                        summary: e.summary,
+                        cost: e.cost,
+                        credits_after: e.credits_after,
+                    })
+                    .collect());
+            }
+            // Admin with no user_email — return all users
+            let entries = Ad4mDb::with_global_instance(|db| {
+                db.get_compute_log_all(since.as_deref(), max)
+            })
+            .map_err(|e| {
+                FieldError::new(
+                    format!("Failed to get compute log: {}", e),
+                    Value::null(),
+                )
+            })?;
+            return Ok(entries
+                .into_iter()
+                .map(|e| ComputeLogEntry {
+                    id: e.id as i32,
+                    user_email: e.user_email,
+                    timestamp: e.timestamp,
+                    operation: e.operation,
+                    summary: e.summary,
+                    cost: e.cost,
+                    credits_after: e.credits_after,
+                })
+                .collect());
+        }
+
+        // Regular user — return only their own entries
+        let email = user_email_from_token(context.auth_token.clone());
+        match email {
+            Some(email) => {
+                let entries = Ad4mDb::with_global_instance(|db| {
+                    db.get_compute_log(&email, since.as_deref(), max)
+                })
+                .map_err(|e| {
+                    FieldError::new(
+                        format!("Failed to get compute log: {}", e),
+                        Value::null(),
+                    )
+                })?;
+                Ok(entries
+                    .into_iter()
+                    .map(|e| ComputeLogEntry {
+                        id: e.id as i32,
+                        user_email: e.user_email,
+                        timestamp: e.timestamp,
+                        operation: e.operation,
+                        summary: e.summary,
+                        cost: e.cost,
+                        credits_after: e.credits_after,
+                    })
+                    .collect())
+            }
+            None => Ok(vec![]),
+        }
+    }
+
     async fn ai_get_models(&self, context: &RequestContext) -> FieldResult<Vec<Model>> {
         check_capability(&context.capabilities, &AGENT_READ_CAPABILITY)?;
         let models_result = Ad4mDb::with_global_instance(|db| db.get_models());

--- a/rust-executor/src/graphql/query_resolvers.rs
+++ b/rust-executor/src/graphql/query_resolvers.rs
@@ -1418,10 +1418,7 @@ impl Query {
                     db.get_compute_log(email, since.as_deref(), max)
                 })
                 .map_err(|e| {
-                    FieldError::new(
-                        format!("Failed to get compute log: {}", e),
-                        Value::null(),
-                    )
+                    FieldError::new(format!("Failed to get compute log: {}", e), Value::null())
                 })?;
                 return Ok(entries
                     .into_iter()
@@ -1437,15 +1434,11 @@ impl Query {
                     .collect());
             }
             // Admin with no user_email — return all users
-            let entries = Ad4mDb::with_global_instance(|db| {
-                db.get_compute_log_all(since.as_deref(), max)
-            })
-            .map_err(|e| {
-                FieldError::new(
-                    format!("Failed to get compute log: {}", e),
-                    Value::null(),
-                )
-            })?;
+            let entries =
+                Ad4mDb::with_global_instance(|db| db.get_compute_log_all(since.as_deref(), max))
+                    .map_err(|e| {
+                        FieldError::new(format!("Failed to get compute log: {}", e), Value::null())
+                    })?;
             return Ok(entries
                 .into_iter()
                 .map(|e| ComputeLogEntry {
@@ -1468,10 +1461,7 @@ impl Query {
                     db.get_compute_log(&email, since.as_deref(), max)
                 })
                 .map_err(|e| {
-                    FieldError::new(
-                        format!("Failed to get compute log: {}", e),
-                        Value::null(),
-                    )
+                    FieldError::new(format!("Failed to get compute log: {}", e), Value::null())
                 })?;
                 Ok(entries
                     .into_iter()

--- a/rust-executor/src/graphql/query_resolvers.rs
+++ b/rust-executor/src/graphql/query_resolvers.rs
@@ -1409,7 +1409,11 @@ impl Query {
     ) -> FieldResult<Vec<ComputeLogEntry>> {
         check_capability(&context.capabilities, &RUNTIME_HOSTING_READ_CAPABILITY)?;
 
-        let max = (limit.unwrap_or(100) as i64).min(1000);
+        let raw_limit = limit.unwrap_or(100);
+        if raw_limit < 0 {
+            return Err(FieldError::new("limit must be non-negative", Value::Null));
+        }
+        let max = (raw_limit as i64).min(1000);
 
         // If admin and user_email is provided, query that user's log
         if context.is_admin_credential {

--- a/rust-executor/src/graphql/subscription_resolvers.rs
+++ b/rust-executor/src/graphql/subscription_resolvers.rs
@@ -8,10 +8,11 @@ use crate::{
     pubsub::{
         get_global_pubsub, subscribe_and_process, AGENT_STATUS_CHANGED_TOPIC, AGENT_UPDATED_TOPIC,
         AI_MODEL_LOADING_STATUS, AI_TRANSCRIPTION_TEXT_TOPIC, APPS_CHANGED,
-        EXCEPTION_OCCURRED_TOPIC, HOSTING_USER_INFO_CHANGED_TOPIC, NEIGHBOURHOOD_SIGNAL_TOPIC,
-        PERSPECTIVE_ADDED_TOPIC, PERSPECTIVE_LINK_ADDED_TOPIC, PERSPECTIVE_LINK_REMOVED_TOPIC,
-        PERSPECTIVE_LINK_UPDATED_TOPIC, PERSPECTIVE_QUERY_SUBSCRIPTION_TOPIC,
-        PERSPECTIVE_REMOVED_TOPIC, PERSPECTIVE_SYNC_STATE_CHANGE_TOPIC, PERSPECTIVE_UPDATED_TOPIC,
+        COMPUTE_LOG_UPDATED_TOPIC, EXCEPTION_OCCURRED_TOPIC, HOSTING_USER_INFO_CHANGED_TOPIC,
+        NEIGHBOURHOOD_SIGNAL_TOPIC, PERSPECTIVE_ADDED_TOPIC, PERSPECTIVE_LINK_ADDED_TOPIC,
+        PERSPECTIVE_LINK_REMOVED_TOPIC, PERSPECTIVE_LINK_UPDATED_TOPIC,
+        PERSPECTIVE_QUERY_SUBSCRIPTION_TOPIC, PERSPECTIVE_REMOVED_TOPIC,
+        PERSPECTIVE_SYNC_STATE_CHANGE_TOPIC, PERSPECTIVE_UPDATED_TOPIC,
         RUNTIME_MESSAGED_RECEIVED_TOPIC, RUNTIME_NOTIFICATION_TRIGGERED_TOPIC,
     },
     types::{DecoratedLinkExpression, TriggeredNotification},
@@ -574,6 +575,25 @@ impl Subscription {
                 let pubsub = get_global_pubsub().await;
                 let topic = &HOSTING_USER_INFO_CHANGED_TOPIC;
                 subscribe_and_process::<HostingUserInfo>(pubsub, topic.to_string(), filter).await
+            }
+        }
+    }
+
+    async fn runtime_compute_log_updated(
+        &self,
+        context: &RequestContext,
+    ) -> Pin<Box<dyn Stream<Item = FieldResult<ComputeLogEntry>> + Send>> {
+        match check_capability(&context.capabilities, &RUNTIME_HOSTING_READ_CAPABILITY) {
+            Err(e) => Box::pin(stream::once(async move { Err(e.into()) })),
+            Ok(_) => {
+                let filter = if context.is_admin_credential {
+                    None // Admin sees all users' log entries
+                } else {
+                    user_email_from_token(context.auth_token.clone())
+                };
+                let pubsub = get_global_pubsub().await;
+                let topic = &COMPUTE_LOG_UPDATED_TOPIC;
+                subscribe_and_process::<ComputeLogEntry>(pubsub, topic.to_string(), filter).await
             }
         }
     }

--- a/rust-executor/src/graphql/subscription_resolvers.rs
+++ b/rust-executor/src/graphql/subscription_resolvers.rs
@@ -589,7 +589,17 @@ impl Subscription {
                 let filter = if context.is_admin_credential {
                     None // Admin sees all users' log entries
                 } else {
-                    user_email_from_token(context.auth_token.clone())
+                    match user_email_from_token(context.auth_token.clone()) {
+                        Some(email) => Some(email),
+                        None => {
+                            return Box::pin(stream::once(async {
+                                Err(coasys_juniper::FieldError::new(
+                                    "Cannot resolve user identity for compute log subscription",
+                                    graphql_value!(null),
+                                ))
+                            }));
+                        }
+                    }
                 };
                 let pubsub = get_global_pubsub().await;
                 let topic = &COMPUTE_LOG_UPDATED_TOPIC;

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -481,7 +481,8 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
     tokio::spawn(async {
         use crate::db::Ad4mDb;
         use crate::pubsub::{
-            get_global_pubsub, DIRTY_CREDIT_USERS, HOSTING_USER_INFO_CHANGED_TOPIC,
+            get_global_pubsub, COMPUTE_LOG_UPDATED_TOPIC, DIRTY_CREDIT_USERS,
+            HOSTING_USER_INFO_CHANGED_TOPIC, PENDING_COMPUTE_LOG_ENTRIES,
         };
 
         loop {
@@ -561,6 +562,22 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
                     pubsub
                         .publish(&HOSTING_USER_INFO_CHANGED_TOPIC, &json)
                         .await;
+                }
+            }
+
+            // Drain and publish pending compute log entries
+            let pending_entries: Vec<crate::graphql::graphql_types::ComputeLogEntry> = {
+                match PENDING_COMPUTE_LOG_ENTRIES.lock() {
+                    Ok(mut vec) => vec.drain(..).collect(),
+                    Err(e) => {
+                        error!("Credit flush: failed to lock pending compute log entries: {}", e);
+                        Vec::new()
+                    }
+                }
+            };
+            for entry in pending_entries {
+                if let Ok(json) = serde_json::to_string(&entry) {
+                    pubsub.publish(&COMPUTE_LOG_UPDATED_TOPIC, &json).await;
                 }
             }
         }

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -570,7 +570,10 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
                 match PENDING_COMPUTE_LOG_ENTRIES.lock() {
                     Ok(mut vec) => vec.drain(..).collect(),
                     Err(e) => {
-                        error!("Credit flush: failed to lock pending compute log entries: {}", e);
+                        error!(
+                            "Credit flush: failed to lock pending compute log entries: {}",
+                            e
+                        );
                         Vec::new()
                     }
                 }

--- a/rust-executor/src/pubsub.rs
+++ b/rust-executor/src/pubsub.rs
@@ -157,6 +157,7 @@ pub static PENDING_COMPUTE_LOG_ENTRIES: LazyLock<
 > = LazyLock::new(|| std::sync::Mutex::new(Vec::new()));
 
 pub fn push_compute_log_entry(
+    id: i64,
     email: &str,
     operation: &str,
     summary: Option<&str>,
@@ -164,7 +165,7 @@ pub fn push_compute_log_entry(
     credits_after: f64,
 ) {
     let entry = crate::graphql::graphql_types::ComputeLogEntry {
-        id: 0, // will be set from DB if needed; not critical for realtime push
+        id: id as i32,
         user_email: email.to_owned(),
         timestamp: chrono::Utc::now().to_rfc3339(),
         operation: operation.to_owned(),
@@ -172,8 +173,12 @@ pub fn push_compute_log_entry(
         cost,
         credits_after,
     };
-    if let Ok(mut vec) = PENDING_COMPUTE_LOG_ENTRIES.lock() {
-        vec.push(entry);
+    match PENDING_COMPUTE_LOG_ENTRIES.lock() {
+        Ok(mut vec) => vec.push(entry),
+        Err(e) => error!(
+            "Failed to lock PENDING_COMPUTE_LOG_ENTRIES for compute log entry id={}: {}",
+            id, e
+        ),
     }
 }
 

--- a/rust-executor/src/pubsub.rs
+++ b/rust-executor/src/pubsub.rs
@@ -134,6 +134,7 @@ lazy_static::lazy_static! {
     pub static ref AI_MODEL_LOADING_STATUS: String = "ai-model-loading-status".to_owned();
     pub static ref PERSPECTIVE_QUERY_SUBSCRIPTION_TOPIC: String = "perspective-query-subscription-topic".to_owned();
     pub static ref HOSTING_USER_INFO_CHANGED_TOPIC: String = "hosting-user-info-changed-topic".to_owned();
+    pub static ref COMPUTE_LOG_UPDATED_TOPIC: String = "compute-log-updated-topic".to_owned();
 }
 
 /// Per-user dirty set for batched credit change notifications.
@@ -146,6 +147,32 @@ pub static DIRTY_CREDIT_USERS: LazyLock<std::sync::Mutex<HashSet<String>>> =
 pub fn mark_credits_dirty(email: &str) {
     if let Ok(mut set) = DIRTY_CREDIT_USERS.lock() {
         set.insert(email.to_owned());
+    }
+}
+
+/// Buffer a compute log entry for async publication.
+/// The flush loop will drain these and publish to the subscription topic.
+pub static PENDING_COMPUTE_LOG_ENTRIES: LazyLock<std::sync::Mutex<Vec<crate::graphql::graphql_types::ComputeLogEntry>>> =
+    LazyLock::new(|| std::sync::Mutex::new(Vec::new()));
+
+pub fn push_compute_log_entry(
+    email: &str,
+    operation: &str,
+    summary: Option<&str>,
+    cost: f64,
+    credits_after: f64,
+) {
+    let entry = crate::graphql::graphql_types::ComputeLogEntry {
+        id: 0, // will be set from DB if needed; not critical for realtime push
+        user_email: email.to_owned(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        operation: operation.to_owned(),
+        summary: summary.map(|s| s.to_owned()),
+        cost,
+        credits_after,
+    };
+    if let Ok(mut vec) = PENDING_COMPUTE_LOG_ENTRIES.lock() {
+        vec.push(entry);
     }
 }
 

--- a/rust-executor/src/pubsub.rs
+++ b/rust-executor/src/pubsub.rs
@@ -152,8 +152,9 @@ pub fn mark_credits_dirty(email: &str) {
 
 /// Buffer a compute log entry for async publication.
 /// The flush loop will drain these and publish to the subscription topic.
-pub static PENDING_COMPUTE_LOG_ENTRIES: LazyLock<std::sync::Mutex<Vec<crate::graphql::graphql_types::ComputeLogEntry>>> =
-    LazyLock::new(|| std::sync::Mutex::new(Vec::new()));
+pub static PENDING_COMPUTE_LOG_ENTRIES: LazyLock<
+    std::sync::Mutex<Vec<crate::graphql::graphql_types::ComputeLogEntry>>,
+> = LazyLock::new(|| std::sync::Mutex::new(Vec::new()));
 
 pub fn push_compute_log_entry(
     email: &str,

--- a/ui/src/components/Hosting.tsx
+++ b/ui/src/components/Hosting.tsx
@@ -102,6 +102,9 @@ const Hosting = () => {
   const [actionLoading, setActionLoading] = useState<Record<string, boolean>>(
     {},
   );
+  const [userLogOpen, setUserLogOpen] = useState<string | null>(null);
+  const [userLogEntries, setUserLogEntries] = useState<any[]>([]);
+  const [userLogLoading, setUserLogLoading] = useState(false);
 
   // ---- Host Registration state ----
   const [hostSession, setHostSession] = useState<HostSession>(null);
@@ -842,6 +845,44 @@ const Hosting = () => {
     }
   };
 
+  const handleViewUserLog = async (email: string) => {
+    if (userLogOpen === email) {
+      setUserLogOpen(null);
+      return;
+    }
+    setUserLogOpen(email);
+    setUserLogLoading(true);
+    try {
+      const entries = await client!.agent.computeLog(undefined, 50, email);
+      setUserLogEntries(entries);
+    } catch (error) {
+      console.error("Failed to load compute log:", error);
+      setUserLogEntries([]);
+    } finally {
+      setUserLogLoading(false);
+    }
+  };
+
+  const formatTimeAgo = (timestamp: string): string => {
+    const diff = Date.now() - new Date(timestamp).getTime();
+    const seconds = Math.floor(diff / 1000);
+    if (seconds < 60) return `${seconds}s ago`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    return `${Math.floor(hours / 24)}d ago`;
+  };
+
+  const formatOperation = (op: string): string => {
+    switch (op) {
+      case 'ai_prompt': return 'AI Prompt';
+      case 'ai_embed': return 'AI Embed';
+      case 'link_write': return 'Link Write';
+      default: return op;
+    }
+  };
+
   // ---- Effects ----
 
   useEffect(() => {
@@ -1471,6 +1512,70 @@ const Hosting = () => {
                           </j-flex>
                         </j-box>
                         )}
+
+                        {/* Activity Log */}
+                        <j-box
+                          style={{
+                            borderTop: "1px solid var(--j-color-ui-200)",
+                            paddingTop: "var(--j-space-400)",
+                          }}
+                        >
+                          <j-button
+                            size="sm"
+                            variant="subtle"
+                            onClick={() => handleViewUserLog(user.email)}
+                          >
+                            <j-icon
+                              name={userLogOpen === user.email ? "chevron-down" : "chevron-right"}
+                              size="xs"
+                              slot="start"
+                            ></j-icon>
+                            Activity Log
+                          </j-button>
+                          {userLogOpen === user.email && (
+                            <div style={{ marginTop: "8px" }}>
+                              {userLogLoading ? (
+                                <j-text size="300" color="ui-500">Loading...</j-text>
+                              ) : userLogEntries.length === 0 ? (
+                                <j-text size="300" color="ui-500">No activity yet</j-text>
+                              ) : (
+                                <div style={{ maxHeight: "200px", overflowY: "auto", display: "flex", flexDirection: "column", gap: "4px" }}>
+                                  {userLogEntries.map((entry: any) => (
+                                    <div
+                                      key={entry.id}
+                                      style={{
+                                        display: "flex",
+                                        alignItems: "center",
+                                        justifyContent: "space-between",
+                                        padding: "4px 8px",
+                                        borderRadius: "4px",
+                                        background: "var(--j-color-ui-50)",
+                                        fontSize: "13px",
+                                        gap: "8px",
+                                      }}
+                                    >
+                                      <j-badge
+                                        variant={entry.operation === "ai_prompt" ? "primary" : "warning"}
+                                        size="sm"
+                                      >
+                                        {formatOperation(entry.operation)}
+                                      </j-badge>
+                                      <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", color: "var(--j-color-ui-500)", fontSize: "12px" }}>
+                                        {entry.summary || ""}
+                                      </span>
+                                      <span style={{ fontWeight: 600, whiteSpace: "nowrap" }}>
+                                        {entry.cost.toFixed(2)}
+                                      </span>
+                                      <span style={{ fontSize: "11px", color: "var(--j-color-ui-400)", whiteSpace: "nowrap" }}>
+                                        {formatTimeAgo(entry.timestamp)}
+                                      </span>
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                          )}
+                        </j-box>
                       </j-flex>
                     </div>
                   ))}

--- a/ui/src/components/Hosting.tsx
+++ b/ui/src/components/Hosting.tsx
@@ -103,7 +103,7 @@ const Hosting = () => {
     {},
   );
   const [userLogOpen, setUserLogOpen] = useState<string | null>(null);
-  const [userLogs, setUserLogs] = useState<Record<string, { entries: any[]; loading: boolean; unavailable?: boolean }>>({});
+const [userLogs, setUserLogs] = useState<Record<string, { entries: any[]; loading: boolean; unavailable?: boolean; _token?: number }>>({});
 
   // ---- Host Registration state ----
   const [hostSession, setHostSession] = useState<HostSession>(null);
@@ -851,13 +851,13 @@ const Hosting = () => {
     }
     setUserLogOpen(email);
     const requestToken = Date.now();
-    setUserLogs(prev => ({ ...prev, [email]: { entries: prev[email]?.entries ?? [], loading: true } }));
+    setUserLogs(prev => ({ ...prev, [email]: { entries: prev[email]?.entries ?? [], loading: true, _token: requestToken } }));
     try {
       const entries = await client!.agent.computeLog(undefined, 50, email);
       setUserLogs(prev => {
         // Discard stale responses if another fetch started for this email
-        if ((prev[email] as any)?._token > requestToken) return prev;
-        return { ...prev, [email]: { entries, loading: false } };
+        if ((prev[email]?._token ?? 0) > requestToken) return prev;
+        return { ...prev, [email]: { entries, loading: false, _token: requestToken } };
       });
     } catch (error) {
       console.error("Failed to load compute log:", error);
@@ -866,7 +866,9 @@ const Hosting = () => {
   };
 
   const formatTimeAgo = (timestamp: string): string => {
-    const diff = Date.now() - new Date(timestamp).getTime();
+    const date = new Date(timestamp);
+    if (isNaN(date.getTime())) return "";
+    const diff = Date.now() - date.getTime();
     const seconds = Math.floor(diff / 1000);
     if (seconds < 60) return `${seconds}s ago`;
     const minutes = Math.floor(seconds / 60);

--- a/ui/src/components/Hosting.tsx
+++ b/ui/src/components/Hosting.tsx
@@ -103,8 +103,7 @@ const Hosting = () => {
     {},
   );
   const [userLogOpen, setUserLogOpen] = useState<string | null>(null);
-  const [userLogEntries, setUserLogEntries] = useState<any[]>([]);
-  const [userLogLoading, setUserLogLoading] = useState(false);
+  const [userLogs, setUserLogs] = useState<Record<string, { entries: any[]; loading: boolean; unavailable?: boolean }>>({});
 
   // ---- Host Registration state ----
   const [hostSession, setHostSession] = useState<HostSession>(null);
@@ -851,15 +850,18 @@ const Hosting = () => {
       return;
     }
     setUserLogOpen(email);
-    setUserLogLoading(true);
+    const requestToken = Date.now();
+    setUserLogs(prev => ({ ...prev, [email]: { entries: prev[email]?.entries ?? [], loading: true } }));
     try {
       const entries = await client!.agent.computeLog(undefined, 50, email);
-      setUserLogEntries(entries);
+      setUserLogs(prev => {
+        // Discard stale responses if another fetch started for this email
+        if ((prev[email] as any)?._token > requestToken) return prev;
+        return { ...prev, [email]: { entries, loading: false } };
+      });
     } catch (error) {
       console.error("Failed to load compute log:", error);
-      setUserLogEntries([]);
-    } finally {
-      setUserLogLoading(false);
+      setUserLogs(prev => ({ ...prev, [email]: { entries: [], loading: false, unavailable: true } }));
     }
   };
 
@@ -1534,13 +1536,15 @@ const Hosting = () => {
                           </j-button>
                           {userLogOpen === user.email && (
                             <div style={{ marginTop: "8px" }}>
-                              {userLogLoading ? (
+                              {userLogs[user.email]?.loading ? (
                                 <j-text size="300" color="ui-500">Loading...</j-text>
-                              ) : userLogEntries.length === 0 ? (
+                              ) : userLogs[user.email]?.unavailable ? (
+                                <j-text size="300" color="ui-500">Activity unavailable</j-text>
+                              ) : (userLogs[user.email]?.entries ?? []).length === 0 ? (
                                 <j-text size="300" color="ui-500">No activity yet</j-text>
                               ) : (
                                 <div style={{ maxHeight: "200px", overflowY: "auto", display: "flex", flexDirection: "column", gap: "4px" }}>
-                                  {userLogEntries.map((entry: any) => (
+                                  {(userLogs[user.email]?.entries ?? []).map((entry: any) => (
                                     <div
                                       key={entry.id}
                                       style={{


### PR DESCRIPTION
# Compute Activity Log

## Problem

When multi-agent hosting or connecting to a remote host via ad4m-connect, users and hosters had no visibility into what operations consumed compute credits. The system tracked credits and deducted them, but there was no record of _what_ happened — just an opaque balance number.

## Solution

Add a per-operation activity log that records every billing event, exposed via GraphQL and displayed in both the client (ad4m-connect) and host admin (launcher) UIs.

### Backend

- **New `compute_log` SQLite table** with columns: `user_email`, `timestamp`, `operation`, `summary`, `cost`, `credits_after`
- **Extended `reserve_compute_credits()`** to accept operation metadata and insert a log row on every deduction
- **One log entry per GraphQL mutation call**, not per individual link — a batch of 10 links produces one row like `"10 links in perspective abc123"`
- **GraphQL query** `runtimeComputeLog(since, limit, userEmail)` — regular users see only their own entries; admin sees all
- **GraphQL subscription** `runtimeComputeLogUpdated` — live push of new entries via the existing pubsub flush loop (2s batching)

### Core TypeScript

- `ComputeLogEntry` type with `id`, `userEmail`, `timestamp`, `operation`, `summary`, `cost`, `creditsAfter`
- `computeLog()` query, `subscribeComputeLogUpdated()`, and `addComputeLogUpdatedListener()` on `AgentClient`

### ad4m-connect (client UI)

- Expandable **"Activity Log"** section in the dashboard below the credit balance
- Shows recent entries with operation badges (AI Prompt / AI Embed / Link Write), human-readable summaries, costs, and relative timestamps
- Live updates via subscription

### Launcher (host admin UI)

- **"Activity Log"** toggle per user in the hosting users table
- Shows that user's recent compute log entries with operation type, summary, cost, and timestamp

## Operations Logged

| Operation    | Summary Example                              | Logged Per            |
| ------------ | -------------------------------------------- | --------------------- |
| `link_write` | `10 links in perspective abc123`             | GraphQL mutation call |
| `ai_prompt`  | `GPT-4o: 340 prompt + 120 completion tokens` | Prompt call           |
| `ai_embed`   | `256 tokens`                                 | Embed call            |

## Files Changed

| File                                                  | Change                                            |
| ----------------------------------------------------- | ------------------------------------------------- |
| `rust-executor/src/db.rs`                             | Table schema, insert/query/cleanup methods        |
| `rust-executor/src/graphql/graphql_types.rs`          | `ComputeLogEntry` GraphQL type                    |
| `rust-executor/src/graphql/mutation_resolvers.rs`     | Extended `reserve_compute_credits()` with logging |
| `rust-executor/src/graphql/query_resolvers.rs`        | `runtimeComputeLog` query resolver                |
| `rust-executor/src/graphql/subscription_resolvers.rs` | `runtimeComputeLogUpdated` subscription           |
| `rust-executor/src/pubsub.rs`                         | Topic, buffer, `push_compute_log_entry()`         |
| `rust-executor/src/lib.rs`                            | Flush loop extension                              |
| `core/src/runtime/RuntimeResolver.ts`                 | `ComputeLogEntry` class + mock query              |
| `core/src/agent/AgentClient.ts`                       | Client query/subscription methods                 |
| `connect/src/types.ts`                                | `ComputeLogEntryData` type                        |
| `connect/src/core.ts`                                 | Subscription wiring + `fetchComputeLog()`         |
| `connect/src/web.ts`                                  | `@fetch-compute-log` event handler                |
| `connect/src/components/views/LoggedInDashboard.ts`   | Activity log UI section                           |
| `ui/src/components/Hosting.tsx`                       | Per-user log in admin panel                       |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity Log: view dashboard and per-user compute activity (AI prompts, embeddings, link writes) with operation badge, summary, cost (two decimals), and relative timestamp.
  * Expandable panels load on demand and show “Loading…”, “No activity yet”, or a scrollable recent-entries list.
  * Real-time updates push new entries live; logs prepend new items and are capped for performance (recent entries kept).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->