### PR TITLE
fix: reduce flakiness in telepresence broadcast and multi-user signal routing tests

### DIFF
--- a/tests/js/tests/multi-user-simple.test.ts
+++ b/tests/js/tests/multi-user-simple.test.ts
@@ -4,7 +4,7 @@ import fs from "fs-extra";
 import { fileURLToPath } from 'url';
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { apolloClient, sleep, startExecutor, runHcLocalServices, gracefulShutdown } from "../utils/utils";
+import { apolloClient, sleep, waitFor, startExecutor, runHcLocalServices, gracefulShutdown } from "../utils/utils";
 import { getFreePorts, registerPorts, deregisterPorts } from "../helpers/ports.js";
 import { ChildProcess } from 'node:child_process';
 import fetch from 'node-fetch'
@@ -2780,7 +2780,8 @@ describe("Multi-User Simple integration tests", () => {
         });
     });
 
-    describe("Cross-Node Signal Routing: Remote Main Agent <-> Local Managed User (Flux Scenario)", () => {
+    describe("Cross-Node Signal Routing: Remote Main Agent <-> Local Managed User (Flux Scenario)", function() {
+        this.retries(2); // Holochain signal routing is timing-sensitive on CI
         // This test replicates the Flux bug:
         // - Node 1: standalone main agent (no multi-user)
         // - Node 2: main agent + managed user (multi-user enabled)
@@ -2904,7 +2905,10 @@ describe("Multi-User Simple integration tests", () => {
 
             // Wait for the two main agents to fully sync
             console.log("Waiting for main agents to sync...");
-            await sleep(15000);
+            await waitFor(async () => {
+                const online = await adminAd4mClient!.runtime.hcAgentInfos();
+                return online.length >= 2;
+            }, 30000, 'Main agents should sync (hcAgentInfos >= 2)');
 
             // Verify the two main agents see each other before proceeding
             const localMainPerspectives = await adminAd4mClient!.perspective.all();
@@ -2954,7 +2958,7 @@ describe("Multi-User Simple integration tests", () => {
             // Step 4: Managed user joins the neighbourhood
             console.log("Managed user joining neighbourhood (late joiner)...");
             await localManagedUserClient!.neighbourhood.joinFromUrl(neighbourhoodUrl);
-            await sleep(5000);
+            await sleep(3000); // Brief settle time after join
 
             // Re-exchange agent infos so the remote node can discover
             // the managed user's DID-to-AgentPubKey mapping
@@ -2974,7 +2978,10 @@ describe("Multi-User Simple integration tests", () => {
 
             // Wait for the managed user's DID link to gossip
             console.log("Waiting for managed user DID gossip...");
-            await sleep(10000);
+            await waitFor(async () => {
+                const infos = await adminAd4mClient!.runtime.hcAgentInfos();
+                return infos.length >= 3;
+            }, 60000, 'Managed user DID should gossip (hcAgentInfos >= 3)');
 
             // Get managed user's neighbourhood proxy
             const localManagedPerspectives = await localManagedUserClient!.perspective.all();

--- a/tests/js/tests/neighbourhood.ts
+++ b/tests/js/tests/neighbourhood.ts
@@ -1,6 +1,6 @@
 import { Link, Perspective, LinkExpression, ExpressionProof, LinkQuery, PerspectiveState, NeighbourhoodProxy, PerspectiveUnsignedInput, PerspectiveProxy, PerspectiveHandle } from "@coasys/ad4m";
 import { TestContext } from './integration.test'
-import { sleep } from "../utils/utils";
+import { sleep, waitFor } from "../utils/utils";
 import fs from "fs";
 import { v4 as uuidv4 } from 'uuid';
 import { expect } from "chai";
@@ -316,7 +316,8 @@ export default function neighbourhoodTests(testContext: TestContext) {
             // })
 
 
-            describe('with set up and joined NH for Telepresence', async () => {
+            describe('with set up and joined NH for Telepresence', function() {
+                this.retries(2); // Holochain signal routing is timing-sensitive on CI
                 let aliceNH: NeighbourhoodProxy|undefined
                 let bobNH: NeighbourhoodProxy|undefined
                 let aliceDID: string|undefined
@@ -338,6 +339,20 @@ export default function neighbourhoodTests(testContext: TestContext) {
                     bobNH = bobP1!.getNeighbourhoodProxy()
                     aliceDID = (await alice.agent.me()).did
                     bobDID = (await bob.agent.me()).did
+
+                    // Poll until both agents can see each other via otherAgents
+                    const maxWait = 30000;
+                    const start = Date.now();
+                    while (Date.now() - start < maxWait) {
+                        const aliceAgents = await aliceNH!.otherAgents();
+                        const bobAgents = await bobNH!.otherAgents();
+                        if (aliceAgents.length >= 1 && bobAgents.length >= 1) {
+                            console.log('Agents discovered each other in ' + (Date.now() - start) + 'ms');
+                            break;
+                        }
+                        await sleep(500);
+                    }
+                    // Wait for DHT propagation after agent discovery
                     await sleep(5000)
                 })
 
@@ -432,9 +447,18 @@ export default function neighbourhoodTests(testContext: TestContext) {
                     link.proof = new ExpressionProof("sig", "key");
                     const aliceSignal = new Perspective([link])
 
-                    await aliceNH!.sendSignal(bobDID!, aliceSignal)
+                    for (let attempt = 0; attempt < 5; attempt++) {
+                        try {
+                            await aliceNH!.sendSignal(bobDID!, aliceSignal);
+                            break;
+                        } catch (e) {
+                            if (attempt === 4) throw e;
+                            console.log(`Signal send attempt ${attempt + 1} failed, retrying...`);
+                            await sleep(3000);
+                        }
+                    }
 
-                    await sleep(1000)
+                    await waitFor(() => bobCalls >= 1, 30000, 'Bob should receive directed signal')
 
                     expect(bobCalls).to.be.equal(1)
                     expect(aliceCalls).to.be.equal(0)
@@ -450,7 +474,7 @@ export default function neighbourhoodTests(testContext: TestContext) {
 
                     await bobNH!.sendBroadcastU(bobSignal)
 
-                    await sleep(1000)
+                    await waitFor(() => aliceCalls >= 1, 30000, 'Alice should receive broadcast from Bob')
 
                     expect(aliceCalls).to.be.equal(1)
 
@@ -480,9 +504,18 @@ export default function neighbourhoodTests(testContext: TestContext) {
                     // Test broadcast without loopback
                     let link = new Link({source: "alice", target: "broadcast", predicate: "test"});
                     const aliceSignal = new PerspectiveUnsignedInput([link])
-                    await aliceNH!.sendBroadcastU(aliceSignal)
+                    for (let attempt = 0; attempt < 3; attempt++) {
+                        try {
+                            await aliceNH!.sendBroadcastU(aliceSignal);
+                            break;
+                        } catch (e) {
+                            if (attempt === 2) throw e;
+                            console.log(`Broadcast send attempt ${attempt + 1} failed, retrying...`);
+                            await sleep(2000);
+                        }
+                    }
 
-                    await sleep(1000)
+                    await waitFor(() => bobCalls >= 1, 30000, 'Bob should receive broadcast without loopback')
 
                     expect(bobCalls).to.be.equal(1)
                     expect(aliceCalls).to.be.equal(0) // Alice shouldn't receive her own broadcast
@@ -501,7 +534,7 @@ export default function neighbourhoodTests(testContext: TestContext) {
                     // @ts-ignore - Ignoring the type error since we know the implementation supports loopback
                     await aliceNH!.sendBroadcastU(aliceSignal2, true)
 
-                    await sleep(1000)
+                    await waitFor(() => bobCalls >= 1 && aliceCalls >= 1, 30000, 'Both should receive loopback broadcast')
 
                     expect(bobCalls).to.be.equal(1)
                     expect(aliceCalls).to.be.equal(1) // Alice should receive her own broadcast
@@ -516,7 +549,7 @@ export default function neighbourhoodTests(testContext: TestContext) {
                     // @ts-ignore - Ignoring the type error since we know the implementation supports loopback
                     await bobNH!.sendBroadcastU(bobSignal, true)
 
-                    await sleep(1000)
+                    await waitFor(() => bobCalls >= 2 && aliceCalls >= 2, 30000, 'Both should receive Bob loopback broadcast')
 
                     expect(bobCalls).to.be.equal(2) // Bob should receive his own broadcast
                     expect(aliceCalls).to.be.equal(2) // Alice should receive Bob's broadcast

--- a/tests/js/utils/utils.ts
+++ b/tests/js/utils/utils.ts
@@ -273,6 +273,25 @@ export function sleep(ms: number) {
 }
 
 /**
+ * Poll a condition until it returns true, checking every 100ms.
+ * Throws after timeoutMs with a descriptive error.
+ * Condition can be sync or async.
+ */
+export async function waitFor(
+  condition: () => boolean | Promise<boolean>,
+  timeoutMs: number,
+  description: string
+) {
+  const start = Date.now();
+  while (!(await condition())) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`Timed out waiting for: ${description} (after ${timeoutMs}ms)`);
+    }
+    await sleep(100);
+  }
+}
+
+/**
  * Clears all links in a perspective in a single removeLinks() batch call.
  * Import from here or from helpers/assertions to get a clean slate before each test.
  */


### PR DESCRIPTION
## Fix: Reduce Flakiness in Holochain Signal Integration Tests

### Changes (test code only — no WASM or executor changes)

Replace timing-sensitive `sleep()` calls with `waitFor()` polling that checks actual state instead of guessing:

- **`waitFor()` helper** — polls condition every 100ms, descriptive timeout errors, supports sync/async conditions
- **Broadcast/signal tests** — `waitFor` with 30s timeout (was `sleep(1000)`)
- **Agent sync waits** — `waitFor` with 60s polling for `hcAgentInfos` (was `sleep(15000)`)
- **Signal send retries** — 5 attempts with 3s delay for `sendSignal`/`sendBroadcastU`
- **`this.retries(2)`** — Mocha retry on Holochain networking test blocks
- **Agent discovery in `before()` hook** — polls `otherAgents()` until both agents see each other before running signal tests

### Files Changed

| File | Change |
|------|--------|
| `tests/js/utils/utils.ts` | Add `waitFor()` helper |
| `tests/js/tests/neighbourhood.ts` | Replace `sleep()` with `waitFor()` polling, add retries |
| `tests/js/tests/multi-user-simple.test.ts` | Replace sync waits with `waitFor()` polling, add retries |

No changes to `p-diff-sync` WASM, executor code, or any production code.
