### PR TITLE
fix(ad4m-plugin): improve executor startup reliability

### DIFF
--- a/plugins/ad4m/README.md
+++ b/plugins/ad4m/README.md
@@ -40,6 +40,52 @@ openclaw plugins install -l plugins/ad4m
 
 ---
 
+## What Gets Installed
+
+When you run `openclaw plugins install @coasys/openclaw-ad4m`, three components are set up:
+
+### 1. Plugin (runtime bridge)
+
+Installed to `~/.openclaw/plugins/ad4m/`. The plugin handles:
+- Spawning/managing the executor process (managed mode)
+- Establishing an MCP session with the executor
+- Registering all AD4M tools as native agent tools
+- Running the waker service for real-time subscriptions
+- Dynamically discovering new tools as SHACL schemas sync
+
+### 2. Skill (agent instructions)
+
+Bundled at `plugins/ad4m/skills/ad4m/SKILL.md`. The plugin declares this via `"skills": ["skills/ad4m"]` in its manifest. OpenClaw loads it automatically when the plugin is enabled. The skill teaches the agent:
+- How to use AD4M tools correctly
+- Rules for message posting, channel creation, subject classes
+- How to handle wake events and subscriptions
+- Data model conventions (Flux compatibility)
+
+The skill does **not** provide tools — it provides **instructions** for using the 77+ tools registered by the MCP bridge.
+
+### 3. MCP tools (dynamic)
+
+The executor's MCP server exposes tools based on the connected perspectives and their SHACL schemas. New tools appear as neighbourhoods sync their data models. The plugin polls for changes every 30 seconds (configurable via `toolRefreshIntervalMs`).
+
+### Verification
+
+```bash
+# Verify plugin is loaded
+openclaw plugins list | grep ad4m
+# Expected: ✓ loaded
+
+# Verify skill is available
+openclaw skills list | grep ad4m
+# Expected: ✓ ready, source: openclaw-extra
+
+# Verify tools are registered (after executor starts)
+# In chat, the agent will have tools like ad4m_list_perspectives, ad4m_message_create, etc.
+```
+
+**Note:** Skills are snapshotted per session. If you install the plugin mid-session, start a new session (or `/reset`) to pick up the skill.
+
+---
+
 ## Setup
 
 ### Automated setup (recommended)
@@ -220,6 +266,21 @@ The agent wallet exists but hasn't been unlocked yet. The plugin handles this au
 ### MCP probe returns 406 (Not Acceptable)
 
 The plugin sends the required `Accept: application/json, text/event-stream` header. If you see this in manual testing, ensure you include that header.
+
+### AD4M skill not appearing in agent's available skills
+
+OpenClaw snapshots eligible skills **when a session starts**. If you install the plugin mid-session, the skill won't appear until the next new session. To verify the skill is loaded by the gateway:
+
+```bash
+openclaw skills list | grep ad4m
+```
+
+If it shows `✓ ready` with source `openclaw-extra`, the skill is loaded — start a new session (or run `/reset`) to pick it up.
+
+If it doesn't appear at all, ensure:
+- The plugin is enabled (`plugins.entries.ad4m.enabled: true`)
+- The plugin manifest has `"skills": ["skills/ad4m"]`
+- The `skills/ad4m/SKILL.md` file exists with valid frontmatter
 
 ### Tools not appearing after joining a neighbourhood
 

--- a/plugins/ad4m/README.md
+++ b/plugins/ad4m/README.md
@@ -1,6 +1,6 @@
 # AD4M Plugin for OpenClaw
 
-Connect your AI agent to **AD4M** — a peer-to-peer application framework built on holochain and based on semantic knowledge graphs. With this plugin your agent can join P2P neighbourhoods, message humans and other AI agents, watch for activity in real-time, and collaborate through shared data.
+Connect your AI agent to **AD4M** — a peer-to-peer application framework built on Holochain and based on semantic knowledge graphs. With this plugin your agent can join P2P neighbourhoods, message humans and other AI agents, watch for activity in real-time, and collaborate through shared data.
 
 ## What can your agent do with AD4M?
 
@@ -16,58 +16,66 @@ Once set up, you can ask your agent to:
 - **Set your profile** — update your agent's name, profile picture, and other details
 - **Install languages** — add new AD4M languages (expression types) to your agent
 
+---
+
 ## Installation
+
+### Quick install (from npm registry)
 
 ```bash
 openclaw plugins install @coasys/openclaw-ad4m
 ```
 
-For local development:
+### Local development install
 
 ```bash
 openclaw plugins install -l plugins/ad4m
 ```
 
+### What `plugins install` does
+
+1. Copies the plugin files into `~/.openclaw/plugins/ad4m/`
+2. Registers the plugin in your `openclaw.json` under `plugins.entries.ad4m`
+3. Installs the bundled skill at `skills/ad4m/` so your agent gets the AD4M SKILL.md instructions
+
+---
+
 ## Setup
 
-After installation, run the interactive setup command:
+### Automated setup (recommended)
 
 ```bash
 openclaw ad4m-setup
 ```
 
-This command handles everything automatically:
+This interactive command handles everything:
 
-1. **Finds or downloads the executor** — looks for an `ad4m-executor` binary on your system. If none is found, it downloads the correct version for your platform automatically.
-2. **Starts the executor** — launches `ad4m-executor` with MCP enabled.
-3. **Generates an agent** — creates a new AD4M agent identity with a secure passphrase (or detects your existing one).
-4. **Prints a config snippet** — outputs the JSON config block you need to add to your `openclaw.json`.
+1. **Finds or downloads the executor** — looks for `ad4m-executor` in PATH and common locations. If not found, downloads the correct binary for your platform.
+2. **Starts the executor** — launches it with MCP enabled on default ports.
+3. **Generates an agent** — creates a new AD4M agent identity with a secure passphrase (or detects an existing one).
+4. **Prints a config snippet** — outputs the JSON config block to paste into `openclaw.json`.
 
-### Adding the config
+After setup, paste the snippet and restart OpenClaw (`openclaw gateway restart`).
 
-At the end of setup, you'll see a config snippet like this:
+### Manual configuration
 
-```json
-{
-  "mode": "managed",
-  "ad4mBinaryPath": "/path/to/ad4m-executor",
-  "agentPassphrase": "your-generated-passphrase"
-}
-```
-
-Copy it into your `openclaw.json` under the plugin entry:
+If you prefer to configure manually or need non-default ports (e.g. to avoid conflicts with another executor):
 
 ```json5
+// openclaw.json
 {
-  plugins: {
-    entries: {
+  "plugins": {
+    "entries": {
       "ad4m": {
-        enabled: true,
-        config: {
-          // paste the snippet here
+        "enabled": true,
+        "config": {
           "mode": "managed",
           "ad4mBinaryPath": "/path/to/ad4m-executor",
-          "agentPassphrase": "your-generated-passphrase"
+          "agentPassphrase": "your-secure-passphrase",
+          // Optional overrides:
+          "mcpEndpoint": "http://localhost:3100/mcp",       // default: 3001
+          "executorWsUrl": "ws://localhost:12100/graphql",  // default: 12000
+          "appDataPath": "/custom/path/.ad4m"              // default: ~/.ad4m
         }
       }
     }
@@ -75,46 +83,77 @@ Copy it into your `openclaw.json` under the plugin entry:
 }
 ```
 
-Then restart OpenClaw. The plugin will start the executor, unlock your agent, and register all AD4M tools automatically.
+Then restart: `openclaw gateway restart`
 
-### Setup modes
+---
 
-The setup detects your environment and picks the right path:
+## Configuration Reference
 
-| Scenario | What happens |
-|----------|-------------|
-| No executor binary found | Downloads it automatically, then runs managed setup |
-| Binary found, no running executor | Starts executor, generates agent, prints managed config |
-| Executor already running | Connects to it, requests capabilities via JWT, prints external config |
-| Existing agent data in `~/.ad4m` | Asks you to provide your existing passphrase in the config |
+All fields are optional. In managed mode, credentials are auto-generated during `openclaw ad4m-setup`.
+
+| Field | Default | Mode | Description |
+|-------|---------|------|-------------|
+| `mode` | `"managed"` | both | `"managed"` = plugin manages executor lifecycle; `"external"` = connect to existing |
+| `ad4mBinaryPath` | auto-detected | managed | Full path to the `ad4m-executor` binary |
+| `agentPassphrase` | generated during setup | managed | Passphrase to unlock the agent wallet |
+| `appDataPath` | `~/.ad4m` | managed | Custom data directory for executor state (keys, Holochain, Prolog) |
+| `mcpEndpoint` | `http://localhost:3001/mcp` | both | AD4M executor MCP endpoint URL |
+| `executorWsUrl` | `ws://localhost:12000/graphql` | both | GraphQL WebSocket URL (used by waker + agent management) |
+| `token` | — | external | JWT token obtained during external-mode setup |
+| `toolRefreshIntervalMs` | `30000` | both | How often to poll for new dynamic SHACL tools (ms) |
+| `wakerEnabled` | `true` | both | Enable the embedded waker service (real-time subscriptions) |
+| `wakeUrl` | `http://localhost:18789/hooks/wake` | both | OpenClaw wake endpoint URL |
+| `wakeToken` | auto from `hooks.token` | both | Override for the hooks authentication token |
+| `debounceMs` | `2000` | both | Debounce interval for wake events (ms) |
+| `rustLog` | — | managed | `RUST_LOG` value for the executor process |
+| `executorLogTarget` | `"file"` | managed | Where executor logs go: `"file"`, `"openclaw"`, or `"both"` |
+
+### Port configuration
+
+The plugin derives ports from the endpoint URLs:
+
+- **MCP port** — parsed from `mcpEndpoint` (default `3001` from `http://localhost:3001/mcp`)
+- **GraphQL port** — parsed from `executorWsUrl` (default `12000` from `ws://localhost:12000/graphql`)
+
+To use custom ports (e.g. to avoid conflicts), set both `mcpEndpoint` and `executorWsUrl` with the desired ports. The plugin passes these to the executor's `--mcp-port` and `--gql-port` arguments.
+
+---
+
+## Setup Modes
+
+### Managed mode (default)
+
+The plugin fully manages the executor lifecycle:
+
+1. On startup, checks if the executor is already running (probes MCP + GraphQL endpoints)
+2. If not running, spawns `ad4m-executor` with MCP enabled
+3. Waits up to 90 seconds for the executor to become ready (Holochain init takes ~30-40s)
+4. Unlocks the agent wallet with the configured passphrase
+5. Establishes the MCP session and registers all tools
+6. Starts the waker service for real-time subscriptions
+
+On OpenClaw shutdown, the executor process is terminated.
 
 ### External mode
 
-Use external mode when you already have an `ad4m-executor` running — for example via the AD4M Launcher or a manually started instance.
+Use when you have a separately managed executor (e.g. via AD4M Launcher or a server deployment):
 
-#### Setup flow
-
-1. Run `openclaw ad4m-setup`. The setup detects that an executor is already running and enters external mode automatically.
-2. The plugin connects to the executor's MCP endpoint and calls `request_capability`, requesting all capabilities on behalf of the OpenClaw agent.
-3. The executor prompts you to approve the request. Depending on your executor configuration:
-   - **AD4M Launcher**: A capability request dialog appears in the launcher UI. Approve it and note the 6-digit verification code shown.
-   - **CLI executor with `--auto-permit-cap-requests`**: The code is logged to stdout and auto-approved.
-4. Enter the verification code back into the setup prompt. The plugin exchanges it for a JWT token via `generate_jwt`.
-5. Setup prints a config snippet containing the JWT. Copy it into your `openclaw.json`.
-
-#### Example external config
+1. Run `openclaw ad4m-setup` — it detects the running executor automatically
+2. The plugin requests capabilities via `request_capability` → approve in your executor UI
+3. Enter the 6-digit verification code → plugin exchanges it for a JWT
+4. Setup prints config with the JWT → paste into `openclaw.json`
 
 ```json5
 {
-  plugins: {
-    entries: {
+  "plugins": {
+    "entries": {
       "ad4m": {
-        enabled: true,
-        config: {
+        "enabled": true,
+        "config": {
           "mode": "external",
-          "token": "eyJhbGciOi...",        // JWT from setup
+          "token": "eyJhbGciOi...",
           "executorWsUrl": "ws://localhost:12000/graphql",
-          "wakeToken": "your-hooks-token"   // optional, for waker
+          "mcpEndpoint": "http://localhost:3001/mcp"
         }
       }
     }
@@ -122,80 +161,124 @@ Use external mode when you already have an `ad4m-executor` running — for examp
 }
 ```
 
-The JWT grants the plugin full access to the executor. If the executor is restarted with new agent keys, the token becomes invalid and you'll need to re-run `openclaw ad4m-setup`.
+---
 
-## Configuration reference
-
-All fields are optional. In managed mode, credentials are auto-generated during setup.
-
-| Field | Default | Description |
-|-------|---------|-------------|
-| `mode` | `managed` | `managed` = plugin manages executor lifecycle; `external` = connect to existing |
-| `ad4mBinaryPath` | auto-detected | Path to the `ad4m-executor` binary |
-| `agentPassphrase` | generated during setup | Passphrase to unlock the agent |
-| `mcpEndpoint` | `http://localhost:3001/mcp` | AD4M executor MCP endpoint URL |
-| `token` | — | JWT token for external mode authentication |
-| `toolRefreshIntervalMs` | `30000` | How often to poll for new dynamic tools (ms) |
-| `executorWsUrl` | `ws://localhost:12000/graphql` | GraphQL WebSocket URL for the waker |
-| `wakeUrl` | `http://localhost:18789/hooks/wake` | OpenClaw wake endpoint URL |
-| `wakeToken` | auto from `hooks.token` | Override for the hooks authentication token |
-| `debounceMs` | `2000` | Debounce interval for wake events (ms) |
-
-## How it works
+## How It Works
 
 The plugin runs two background services:
 
 ### `ad4m-mcp` — MCP tool bridge
 
-Connects to the AD4M executor's MCP endpoint, discovers all available tools, and registers them as native OpenClaw agent tools. As perspectives sync SHACL schemas, new tools (e.g. `ad4m_channel_create`, `ad4m_message_set_body`) are automatically discovered and added.
+Connects to the AD4M executor's MCP endpoint, discovers all available tools, and registers them as native OpenClaw agent tools. As perspectives sync SHACL schemas from neighbourhoods, new tools (e.g. `ad4m_channel_create`, `ad4m_message_set_body`) are automatically discovered and added every `toolRefreshIntervalMs`.
 
 ### `ad4m-waker` — real-time subscriptions
 
-Connects to the executor's GraphQL WebSocket. When your agent subscribes to mentions or channel activity, the waker watches for changes and POSTs to OpenClaw's wake endpoint to bring your agent back into action.
+Connects to the executor's GraphQL WebSocket. When your agent subscribes to mentions or channel activity, the waker watches for changes and POSTs to OpenClaw's `/hooks/wake` endpoint to bring your agent back into action.
 
-## Plugin-provided tools
+```
+AD4M Executor ──GraphQL WS──→ Plugin (ad4m-waker) ──HTTP POST──→ OpenClaw /hooks/wake
+     │                              │                                    │
+  SurrealQL subscription     Debounce + filter                    Agent wakes up,
+  detects new links          (2s default)                         reads context via MCP
+```
 
-In addition to all dynamically discovered AD4M MCP tools, the plugin registers:
+---
+
+## Plugin-Provided Tools
+
+In addition to all dynamically discovered AD4M MCP tools, the plugin registers these native tools:
 
 | Tool | Description |
 |------|-------------|
-| `ad4m_refresh_ad4m_tools()` | Re-fetch the MCP tool list immediately |
+| `ad4m_refresh_ad4m_tools()` | Re-fetch the MCP tool list immediately (call after joining a neighbourhood) |
 | `ad4m_subscribe_to_mentions(perspective_id)` | Watch for messages mentioning your agent |
-| `ad4m_subscribe_to_children(perspective_id, expression_address)` | Watch for new messages in a channel |
+| `ad4m_subscribe_to_children(perspective_id, expression_address)` | Watch for new messages in a specific channel |
 | `ad4m_unsubscribe_from_mentions(perspective_id)` | Stop watching mentions |
 | `ad4m_unsubscribe_from_children(perspective_id, expression_address)` | Stop watching a channel |
 | `ad4m_list_waker_subscriptions()` | List all active subscriptions |
-| `ad4m_set_profile_picture_from_file(file_path)` | Set your agent's profile picture |
+| `ad4m_set_profile_picture_from_file(file_path)` | Set your agent's profile picture from a local file |
 
-## Plugin structure
+---
+
+## Troubleshooting
+
+### "Executor failed to start within 90 seconds"
+
+The executor is taking too long to initialize. Common causes:
+- First run with Holochain enabled — bootstrap can take 60+ seconds
+- Slow disk I/O (especially on SD cards / NFS mounts)
+- Port conflict — another process is using the configured ports
+
+**Fix:** Check if the executor started anyway (`lsof -i :<gql-port>`). If it's running, restart OpenClaw — it will detect the already-running executor.
+
+### "main key not found" in logs
+
+The agent wallet exists but hasn't been unlocked yet. The plugin handles this automatically in managed mode if `agentPassphrase` is correct.
+
+**Fix:** Ensure `agentPassphrase` in your config matches the passphrase used during `openclaw ad4m-setup` or `ad4m-executor init`.
+
+### MCP probe returns 406 (Not Acceptable)
+
+The plugin sends the required `Accept: application/json, text/event-stream` header. If you see this in manual testing, ensure you include that header.
+
+### Tools not appearing after joining a neighbourhood
+
+SHACL schemas sync via Holochain gossip, which can take 3-5 minutes for initial sync. The plugin polls every `toolRefreshIntervalMs` (default 30s). Call `ad4m_refresh_ad4m_tools()` to force an immediate check.
+
+### "Executor was already running — obtaining JWT"
+
+Another executor instance was detected on the configured ports. The plugin will attempt JWT auth via `request_capability`. If this fails (no one to approve the capability request), either:
+- Stop the other executor and restart OpenClaw
+- Switch to `"mode": "external"` with a pre-obtained JWT
+
+---
+
+## Plugin Structure
 
 ```
 plugins/ad4m/
-├── openclaw.plugin.json        # Plugin manifest
-├── index.ts                    # Plugin entry point (MCP bridge + waker)
-├── setup.ts                    # Interactive setup flow
+├── openclaw.plugin.json        # Plugin manifest + config schema
+├── index.ts                    # Plugin entry point (MCP bridge + waker services)
+├── setup.ts                    # Interactive setup CLI (openclaw ad4m-setup)
 ├── executor.ts                 # Binary discovery, process management, auto-download
-├── agent.ts                    # Agent initialization
-├── config.ts                   # Config and state management
+├── agent.ts                    # Agent initialization + wallet unlock
+├── config.ts                   # Config/state persistence
 ├── mcpClient.ts                # MCP transport and tool listing
-├── package.json                # NPM package
+├── wakerHelpers.ts             # Wake event formatting
+├── wakerSubscriptionManager.ts # Subscription state management
+├── types.ts                    # TypeScript interfaces
+├── index.test.ts               # Test suite
+├── package.json                # NPM package (@coasys/openclaw-ad4m)
 ├── skills/
 │   └── ad4m/
-│       ├── SKILL.md            # Agent instructions
+│       ├── SKILL.md            # Agent instructions (loaded by OpenClaw)
 │       └── references/         # Detailed reference docs
-└── README.md
+│           ├── mcp.md          # Full MCP tools list + parameters
+│           ├── architecture.md # AD4M concepts, links, SHACL reference
+│           ├── setup.md        # Executor download, deployment, networking
+│           └── waker.md        # Waker config + subscription format
+└── README.md                   # This file
 ```
+
+---
 
 ## Changelog
 
+### 0.0.3 (current)
+
+- **Fixed `--data-path` not passed to `init`** — custom `appDataPath` now works on first run
+- **Fixed port probe using wrong GraphQL URL** — derives URL from `executorWsUrl` instead of hardcoding port 12000
+- **Fixed startup timeout** — increased from 30s to 90s for Holochain-enabled executors; logs every 10s instead of every 1s
+- **Fixed "main key not found" error** — attempts direct unlock when wallet is locked instead of retrying status 10×
+- **Fixed MCP probe** — includes required `Accept` header so the health check actually works
+- **Added `appDataPath` config field** — isolate executor data to a custom directory
+
 ### 0.0.2
 
-- **Fixed external mode setup flow** — the JWT capability request and code verification now works correctly with running executors
-- **Fixed waker WebSocket staying connected** — the waker now uses `lazy: false` and `keepAlive` to maintain a persistent connection instead of disconnecting after the first query
-- **Fixed waker surviving plugin hot-reloads** — shared state (auth token, subscription manager, session) is now module-level so it persists when the OpenClaw framework re-evaluates the plugin on config changes
-
+- **Fixed external mode setup flow** — JWT capability request and code verification works correctly
+- **Fixed waker WebSocket** — uses `lazy: false` and `keepAlive` for persistent connection
+- **Fixed waker surviving plugin hot-reloads** — shared state persists across config changes
 
 ### 0.0.1
 
 - Initial release with managed and external modes, MCP tool bridge, waker subscriptions, auto-download of `ad4m-executor`
-- **Renamed plugin** — package is now `@coasys/openclaw-ad4m`, plugin ID is `ad4m` (config goes under `plugins.entries["ad4m"]`)

--- a/plugins/ad4m/agent.ts
+++ b/plugins/ad4m/agent.ts
@@ -93,6 +93,36 @@ export async function ensureAgentReady(
         );
         break; // Connected successfully
       } catch (e: any) {
+        // Handle "main key not found" — wallet is locked, not a connection error
+        if (e.message && e.message.includes("main key not found")) {
+          if (agentPassphrase) {
+            logger.info(
+              `[ad4m] Wallet locked ("main key not found"), attempting unlock...`,
+            );
+            try {
+              await client.agent.unlock(agentPassphrase);
+              const newStatus = await client.agent.status();
+              logger.info(
+                `[ad4m] Agent unlocked successfully. DID: ${newStatus.did}`,
+              );
+              return { did: newStatus.did };
+            } catch (unlockErr: any) {
+              logger.error(
+                `[ad4m] Failed to unlock agent after "main key not found": ${unlockErr.message}`,
+              );
+              logger.warn(
+                `[ad4m] You may need to provide the correct agentPassphrase in config or reconfigure.`,
+              );
+              return null;
+            }
+          } else {
+            logger.error(
+              `[ad4m] Wallet locked ("main key not found") but no passphrase available. Set agentPassphrase in plugin config.`,
+            );
+            return null;
+          }
+        }
+
         if (attempt < maxAttempts) {
           logger.info(
             `[ad4m] WS not ready yet (${e.message}), retrying in ${CONNECT_RETRY_DELAY_MS}ms... (${attempt}/${maxAttempts})`,

--- a/plugins/ad4m/executor.ts
+++ b/plugins/ad4m/executor.ts
@@ -340,7 +340,7 @@ export async function isExecutorRunning(
   timeoutMs: number = 3000,
   graphqlHttpUrl: string = "http://localhost:12000/graphql",
 ): Promise<"mcp" | "graphql" | false> {
-  const probe = (url: string, body: string, validate?: (json: any) => boolean): Promise<boolean> =>
+  const probe = (url: string, body: string, headers?: Record<string, string>, validate?: (json: any) => boolean): Promise<boolean> =>
     new Promise((resolve) => {
       const controller = new AbortController();
       const timeout = setTimeout(() => {
@@ -350,7 +350,7 @@ export async function isExecutorRunning(
 
       fetch(url, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...headers },
         body,
         signal: controller.signal,
       })
@@ -376,10 +376,12 @@ export async function isExecutorRunning(
     probe(
       endpoint,
       JSON.stringify({ jsonrpc: "2.0", id: 0, method: "tools/list", params: {} }),
+      { "Accept": "application/json, text/event-stream" },
     ),
     probe(
       graphqlHttpUrl,
       JSON.stringify({ query: "{ agentStatus { isInitialized } }" }),
+      undefined,
       // Unauthenticated requests lack AGENT_READ_CAPABILITY so the query
       // returns errors — but any GraphQL-shaped response (data or errors key)
       // confirms an AD4M executor is listening.
@@ -391,6 +393,9 @@ export async function isExecutorRunning(
   if (gql) return "graphql";
   return false;
 }
+
+/** Maximum iterations to wait for the executor to become ready (1 iteration = 1 second). */
+export const EXECUTOR_STARTUP_WAIT_ITERATIONS = 90;
 
 /**
  * Result of ensureExecutorRunning:
@@ -408,11 +413,17 @@ export async function ensureExecutorRunning(
   binaryPath?: string,
   rustLog?: string,
   logTarget: "file" | "openclaw" | "both" = "file",
+  appDataPath?: string,
 ): Promise<ExecutorStartResult> {
+  // Derive the GraphQL HTTP URL from the WS endpoint for probe consistency
+  const graphqlHttpUrl = wsEndpoint
+    .replace(/^ws:/, "http:")
+    .replace(/^wss:/, "https:");
+
   logger.info(`[ad4m] Checking if executor is running at ${endpoint}...`);
 
   // Check if already running
-  if (await isExecutorRunning(endpoint, 3000)) {
+  if (await isExecutorRunning(endpoint, 3000, graphqlHttpUrl)) {
     logger.info(`[ad4m] Executor is already running`);
     return "already_running";
   }
@@ -427,14 +438,18 @@ export async function ensureExecutorRunning(
   // Running init on an existing directory can wipe agent keys via
   // its version-mismatch cleanup logic.
   const home = process.env.HOME || process.env.USERPROFILE || "/tmp";
-  const ad4mDir = path.join(home, ".ad4m");
+  const ad4mDir = appDataPath || path.join(home, ".ad4m");
 
   if (!fs.existsSync(ad4mDir)) {
     logger.info(
       `[ad4m] Data directory ${ad4mDir} not found — running init for first-time setup...`,
     );
     try {
-      execFileSync(executorPath, ["init"], {
+      const initArgs = ["init"];
+      if (appDataPath) {
+        initArgs.push("--data-path", appDataPath);
+      }
+      execFileSync(executorPath, initArgs, {
         stdio: ["ignore", "pipe", "pipe"],
         timeout: 30000,
       });
@@ -545,7 +560,7 @@ export async function ensureExecutorRunning(
 
     // Wait for executor to be ready (check spawn failure each iteration)
     logger.info(`[ad4m] Waiting for executor to start...`);
-    for (let i = 0; i < 30; i++) {
+    for (let i = 0; i < EXECUTOR_STARTUP_WAIT_ITERATIONS; i++) {
       await new Promise((r) => setTimeout(r, 1000));
 
       // If spawn failed (ENOENT, permission, non-zero exit), stop waiting
@@ -561,14 +576,17 @@ export async function ensureExecutorRunning(
         return false;
       }
 
-      if (await isExecutorRunning(endpoint, 2000)) {
+      if (await isExecutorRunning(endpoint, 2000, graphqlHttpUrl)) {
         logger.info(`[ad4m] Executor started successfully`);
         return "spawned";
       }
-      logger.info(`[ad4m] Waiting... (${i + 1}/30)`);
+      // Log progress every 10 iterations to reduce spam
+      if ((i + 1) % 10 === 0) {
+        logger.info(`[ad4m] Waiting... (${i + 1}/${EXECUTOR_STARTUP_WAIT_ITERATIONS})`);
+      }
     }
 
-    logger.error(`[ad4m] Executor failed to start within 30 seconds`);
+    logger.error(`[ad4m] Executor failed to start within ${EXECUTOR_STARTUP_WAIT_ITERATIONS} seconds`);
     return false;
   } catch (err: any) {
     logger.error(`[ad4m] Error starting executor: ${err.message}`);

--- a/plugins/ad4m/executor.ts
+++ b/plugins/ad4m/executor.ts
@@ -325,6 +325,40 @@ export async function downloadExecutor(logger: any): Promise<boolean> {
 let executorProcess: ReturnType<typeof spawn> | null = null;
 let executorLogStream: fs.WriteStream | null = null;
 
+// --- Supervisor state ---
+let _shouldRestart = true;
+let _restartAttempts: number[] = []; // timestamps of restart attempts
+let _lastSpawnParams: {
+  adminCredential: string;
+  logger: any;
+  endpoint: string;
+  wsEndpoint: string;
+  binaryPath?: string;
+  rustLog?: string;
+  logTarget: "file" | "openclaw" | "both";
+  appDataPath?: string;
+  config?: PluginConfig;
+} | null = null;
+
+/**
+ * Parse the port from a URL string.
+ * Falls back to default ports (80 for http/ws, 443 for https/wss) if no port is specified.
+ */
+function parsePortFromUrl(url: string, fallback: string): string {
+  try {
+    // URL constructor doesn't handle ws:// natively in all environments,
+    // so normalise to http(s) for parsing
+    const normalized = url.replace(/^ws:/, "http:").replace(/^wss:/, "https:");
+    const parsed = new URL(normalized);
+    if (parsed.port) return parsed.port;
+    // No explicit port — use protocol defaults
+    if (url.startsWith("https:") || url.startsWith("wss:")) return "443";
+    return "80";
+  } catch {
+    return fallback;
+  }
+}
+
 /**
  * Check whether an executor is reachable.
  *
@@ -414,7 +448,11 @@ export async function ensureExecutorRunning(
   rustLog?: string,
   logTarget: "file" | "openclaw" | "both" = "file",
   appDataPath?: string,
+  config?: PluginConfig,
 ): Promise<ExecutorStartResult> {
+  // Store params for supervisor restart
+  _lastSpawnParams = { adminCredential, logger, endpoint, wsEndpoint, binaryPath, rustLog, logTarget, appDataPath, config };
+  _shouldRestart = true;
   // Derive the GraphQL HTTP URL from the WS endpoint for probe consistency
   const graphqlHttpUrl = wsEndpoint
     .replace(/^ws:/, "http:")
@@ -488,18 +526,43 @@ export async function ensureExecutorRunning(
       logger.info(`[ad4m] Setting RUST_LOG=${rustLog}`);
     }
 
+    // Parse ports from configured URLs
+    const mcpPort = parsePortFromUrl(endpoint, "3001");
+    const gqlPort = parsePortFromUrl(wsEndpoint, "12000");
+
+    // Build spawn args
+    const spawnArgs: string[] = [
+      "run",
+      "--enable-mcp", "true",
+      "--admin-credential", adminCredential,
+      "--mcp-port", mcpPort,
+      "--gql-port", gqlPort,
+    ];
+
+    // Fix 2: Pass --app-data-path to run command
+    if (appDataPath) {
+      spawnArgs.push("--app-data-path", appDataPath);
+    }
+
+    // Fix 3: Holochain connectivity flags
+    const hcUseBootstrap = config?.hcUseBootstrap !== false; // default true
+    const hcUseProxy = config?.hcUseProxy !== false; // default true
+    const connectHolochain = config?.connectHolochain !== false; // default true
+    const runDappServer = config?.runDappServer === true; // default false
+
+    spawnArgs.push("--hc-use-bootstrap", String(hcUseBootstrap));
+    spawnArgs.push("--hc-use-proxy", String(hcUseProxy));
+    if (connectHolochain) {
+      spawnArgs.push("--connect-holochain", "true");
+    }
+    spawnArgs.push("--run-dapp-server", String(runDappServer));
+
+    logger.info(`[ad4m] Spawn args: ${spawnArgs.join(" ")}`);
+
     // Start the executor as a child process
     executorProcess = spawn(
       executorPath,
-      [
-        "run",
-        "--enable-mcp",
-        "true",
-        "--admin-credential",
-        adminCredential,
-        "--mcp-port",
-        "3001",
-      ],
+      spawnArgs,
       {
         stdio: ["ignore", "pipe", "pipe"],
         detached: false,
@@ -545,8 +608,8 @@ export async function ensureExecutorRunning(
       executorProcess = null;
     });
 
-    executorProcess.on("exit", (code: number | null) => {
-      logger.info(`[ad4m] Executor exited with code ${code}`);
+    executorProcess.on("exit", (code: number | null, signal: string | null) => {
+      logger.info(`[ad4m] Executor exited with code ${code}, signal ${signal}`);
       if (code !== null && code !== 0) {
         spawnFailed = true;
         spawnError = `Executor exited with code ${code}`;
@@ -556,6 +619,36 @@ export async function ensureExecutorRunning(
         executorLogStream = null;
       }
       executorProcess = null;
+
+      // Supervisor: auto-restart on unexpected death
+      const isUnexpected = (code !== null && code !== 0) || signal != null;
+      if (_shouldRestart && isUnexpected && _lastSpawnParams) {
+        const maxAttempts = config?.maxRestartAttempts ?? 3;
+        const now = Date.now();
+        // Prune attempts older than 60 seconds
+        _restartAttempts = _restartAttempts.filter((t) => now - t < 60_000);
+        if (_restartAttempts.length < maxAttempts) {
+          _restartAttempts.push(now);
+          const attemptNum = _restartAttempts.length;
+          logger.warn(
+            `[ad4m] Executor died unexpectedly (code ${code}), restarting in 5s... (attempt ${attemptNum}/${maxAttempts})`,
+          );
+          setTimeout(() => {
+            if (!_shouldRestart || !_lastSpawnParams) return;
+            const p = _lastSpawnParams;
+            ensureExecutorRunning(
+              p.adminCredential, p.logger, p.endpoint, p.wsEndpoint,
+              p.binaryPath, p.rustLog, p.logTarget, p.appDataPath, p.config,
+            ).catch((err) => {
+              logger.error(`[ad4m] Supervisor restart failed: ${err.message}`);
+            });
+          }, 5000);
+        } else {
+          logger.error(
+            `[ad4m] Executor died unexpectedly (code ${code}). Max restart attempts (${maxAttempts}) reached within 60s. Giving up.`,
+          );
+        }
+      }
     });
 
     // Wait for executor to be ready (check spawn failure each iteration)
@@ -600,6 +693,7 @@ export async function ensureExecutorRunning(
 }
 
 export function stopExecutor(logger?: any): void {
+  _shouldRestart = false; // Prevent supervisor from restarting
   if (executorProcess) {
     executorProcess.kill("SIGTERM");
     executorProcess = null;

--- a/plugins/ad4m/index.test.ts
+++ b/plugins/ad4m/index.test.ts
@@ -46,6 +46,7 @@ import {
   extractMcpResultData,
   buildWakeMessage,
   postWake,
+  EXECUTOR_STARTUP_WAIT_ITERATIONS,
   type PluginConfig,
   type WakerSubscription,
   type McpTool,
@@ -1025,11 +1026,279 @@ describe("ensureAgentReady", () => {
       ),
     ).toBe(true);
   });
+
+  it("handles 'main key not found' error with passphrase by unlocking", async () => {
+    const mockStatus = vi.fn()
+      .mockRejectedValueOnce(new Error("main key not found"))
+      .mockResolvedValueOnce({
+        isInitialized: true,
+        isUnlocked: true,
+        did: "did:key:z6MkUnlockedAfterMainKeyError",
+      });
+    const mockUnlock = vi.fn().mockResolvedValue(undefined);
+    const client = makeMockAd4mClient({
+      status: mockStatus,
+      unlock: mockUnlock,
+    });
+
+    const logger = makeMockLogger();
+    const result = await ensureAgentReady(
+      "ws://localhost:12000/graphql",
+      "test-cred",
+      logger,
+      "my-passphrase",
+      client,
+    );
+
+    expect(result).toEqual({ did: "did:key:z6MkUnlockedAfterMainKeyError" });
+    expect(mockUnlock).toHaveBeenCalledWith("my-passphrase");
+
+    const msgs = logger.info.mock.calls.map((c: any[]) => c[0]);
+    expect(
+      msgs.some((m: string) => m.includes("main key not found")),
+    ).toBe(true);
+    expect(
+      msgs.some((m: string) => m.includes("unlocked successfully")),
+    ).toBe(true);
+  });
+
+  it("handles 'main key not found' error without passphrase gracefully", async () => {
+    const mockStatus = vi.fn()
+      .mockRejectedValue(new Error("main key not found"));
+    const mockUnlock = vi.fn();
+    const client = makeMockAd4mClient({
+      status: mockStatus,
+      unlock: mockUnlock,
+    });
+
+    const logger = makeMockLogger();
+    const result = await ensureAgentReady(
+      "ws://localhost:12000/graphql",
+      "test-cred",
+      logger,
+      undefined,
+      client,
+    );
+
+    expect(result).toBeNull();
+    expect(mockUnlock).not.toHaveBeenCalled();
+
+    const errorMsgs = logger.error.mock.calls.map((c: any[]) => c[0]);
+    expect(
+      errorMsgs.some((m: string) =>
+        m.includes("main key not found") && m.includes("no passphrase"),
+      ),
+    ).toBe(true);
+  });
+
+  it("handles 'main key not found' when unlock itself fails", async () => {
+    const mockStatus = vi.fn()
+      .mockRejectedValue(new Error("main key not found"));
+    const mockUnlock = vi.fn().mockRejectedValue(new Error("wrong passphrase"));
+    const client = makeMockAd4mClient({
+      status: mockStatus,
+      unlock: mockUnlock,
+    });
+
+    const logger = makeMockLogger();
+    const result = await ensureAgentReady(
+      "ws://localhost:12000/graphql",
+      "test-cred",
+      logger,
+      "bad-passphrase",
+      client,
+    );
+
+    expect(result).toBeNull();
+    expect(mockUnlock).toHaveBeenCalledWith("bad-passphrase");
+
+    const errorMsgs = logger.error.mock.calls.map((c: any[]) => c[0]);
+    expect(
+      errorMsgs.some((m: string) =>
+        m.includes("Failed to unlock agent after"),
+      ),
+    ).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
-// parseSSEStream
+// isExecutorRunning — port configuration and Accept header
 // ---------------------------------------------------------------------------
+
+describe("isExecutorRunning — port and header tests", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("probes custom GraphQL port when provided", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url: any) => {
+      if (String(url).includes(":15000/graphql")) {
+        return Promise.resolve(
+          fakeJsonResponse({ data: { agentStatus: { isInitialized: true } } }),
+        );
+      }
+      return Promise.reject(new Error("ECONNREFUSED"));
+    });
+
+    const result = await isExecutorRunning(
+      "http://localhost:3001/mcp",
+      1000,
+      "http://localhost:15000/graphql",
+    );
+    expect(result).toBe("graphql");
+
+    // Verify it called with the custom port
+    const calls = fetchSpy.mock.calls.map((c: any[]) => String(c[0]));
+    expect(calls.some((url: string) => url.includes(":15000/graphql"))).toBe(true);
+  });
+
+  it("sends Accept header on MCP probe", async () => {
+    let capturedHeaders: Record<string, string> | null = null;
+    vi.spyOn(globalThis, "fetch").mockImplementation((url: any, opts: any) => {
+      if (String(url).includes("/mcp")) {
+        capturedHeaders = opts?.headers ?? null;
+        return Promise.resolve(
+          fakeJsonResponse({ jsonrpc: "2.0", id: 0, result: {} }),
+        );
+      }
+      return Promise.reject(new Error("ECONNREFUSED"));
+    });
+
+    await isExecutorRunning("http://localhost:3001/mcp", 1000);
+
+    expect(capturedHeaders).not.toBeNull();
+    expect(capturedHeaders!["Accept"]).toBe("application/json, text/event-stream");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureExecutorRunning — wait loop timeout and init --data-path
+// ---------------------------------------------------------------------------
+
+describe("ensureExecutorRunning — timeout and data-path", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes --data-path to init when appDataPath is provided", async () => {
+    const home = process.env.HOME || process.env.USERPROFILE || "/tmp";
+    const customDataPath = "/custom/ad4m-data";
+
+    // Mock fs.existsSync to report custom data directory as missing
+    const realExistsSync = fs.existsSync;
+    vi.spyOn(fs, "existsSync").mockImplementation((p: fs.PathLike) => {
+      if (p === customDataPath) return false;
+      return realExistsSync(p);
+    });
+
+    try {
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+      mockExecFileSync.mockReturnValue(Buffer.from(""));
+
+      const fakeProc = createFakeChildProcess();
+      mockSpawn.mockReturnValue(fakeProc as any);
+
+      const logger = makeMockLogger();
+      const resultPromise = ensureExecutorRunning(
+        "cred",
+        logger,
+        "http://localhost:3001/mcp",
+        "ws://localhost:12000/graphql",
+        undefined,
+        undefined,
+        "file",
+        customDataPath,
+      );
+
+      setTimeout(() => {
+        fakeProc.emit("error", new Error("spawn ENOENT"));
+      }, 100);
+
+      await resultPromise;
+
+      // Should have called init with --data-path
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "ad4m-executor",
+        ["init", "--data-path", customDataPath],
+        expect.any(Object),
+      );
+    } finally {
+      mockExecFileSync.mockReset();
+    }
+  }, 10000);
+
+  it("does not pass --data-path to init when appDataPath is not provided", async () => {
+    const home = process.env.HOME || process.env.USERPROFILE || "/tmp";
+    const ad4mDir = path.join(home, ".ad4m");
+
+    // Mock fs.existsSync to report default data directory as missing
+    const realExistsSync = fs.existsSync;
+    vi.spyOn(fs, "existsSync").mockImplementation((p: fs.PathLike) => {
+      if (p === ad4mDir) return false;
+      return realExistsSync(p);
+    });
+
+    try {
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+      mockExecFileSync.mockReturnValue(Buffer.from(""));
+
+      const fakeProc = createFakeChildProcess();
+      mockSpawn.mockReturnValue(fakeProc as any);
+
+      const logger = makeMockLogger();
+      const resultPromise = ensureExecutorRunning("cred", logger);
+
+      setTimeout(() => {
+        fakeProc.emit("error", new Error("spawn ENOENT"));
+      }, 100);
+
+      await resultPromise;
+
+      // Should have called init without --data-path
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "ad4m-executor",
+        ["init"],
+        expect.any(Object),
+      );
+    } finally {
+      mockExecFileSync.mockReset();
+    }
+  }, 10000);
+
+  it("uses EXECUTOR_STARTUP_WAIT_ITERATIONS constant (90)", () => {
+    expect(EXECUTOR_STARTUP_WAIT_ITERATIONS).toBe(90);
+  });
+
+  it("derives graphqlHttpUrl from wsEndpoint for probes", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url: any) => {
+      // Only respond to the custom port
+      if (String(url).includes(":15000/graphql")) {
+        return Promise.resolve(
+          fakeJsonResponse({ data: { agentStatus: { isInitialized: true } } }),
+        );
+      }
+      if (String(url).includes("/mcp")) {
+        return Promise.reject(new Error("ECONNREFUSED"));
+      }
+      return Promise.reject(new Error("ECONNREFUSED"));
+    });
+
+    const logger = makeMockLogger();
+    const result = await ensureExecutorRunning(
+      "cred",
+      logger,
+      "http://localhost:3001/mcp",
+      "ws://localhost:15000/graphql",
+    );
+
+    // Should detect the executor via GraphQL on port 15000
+    expect(result).toBe("already_running");
+
+    // Verify fetch was called with port 15000
+    const calls = fetchSpy.mock.calls.map((c: any[]) => String(c[0]));
+    expect(calls.some((url: string) => url.includes(":15000/graphql"))).toBe(true);
+  });
+});
 
 describe("parseSSEStream", () => {
   it("parses a valid SSE stream with a JSON-RPC message", async () => {

--- a/plugins/ad4m/index.ts
+++ b/plugins/ad4m/index.ts
@@ -63,6 +63,7 @@ export {
   ensureExecutorRunning,
   stopExecutor,
   downloadExecutor,
+  EXECUTOR_STARTUP_WAIT_ITERATIONS,
 } from "./executor";
 export type { ExecutorStartResult } from "./executor";
 export { ensureAgentReady } from "./agent";

--- a/plugins/ad4m/index.ts
+++ b/plugins/ad4m/index.ts
@@ -913,6 +913,7 @@ Notes:
           binaryPath,
           config.rustLog,
           config.executorLogTarget ?? "file",
+          providedConfig.appDataPath,
         );
         if (!executorStartResult) {
           logger.error(

--- a/plugins/ad4m/index.ts
+++ b/plugins/ad4m/index.ts
@@ -914,6 +914,7 @@ Notes:
           config.rustLog,
           config.executorLogTarget ?? "file",
           providedConfig.appDataPath,
+          config,
         );
         if (!executorStartResult) {
           logger.error(

--- a/plugins/ad4m/openclaw.plugin.json
+++ b/plugins/ad4m/openclaw.plugin.json
@@ -71,6 +71,31 @@
       "appDataPath": {
         "type": "string",
         "description": "Custom data directory for the AD4M executor (passed as --data-path to init and --app-data-path to run). Defaults to ~/.ad4m if not set."
+      },
+      "connectHolochain": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable Holochain DHT connectivity"
+      },
+      "hcUseBootstrap": {
+        "type": "boolean",
+        "default": true,
+        "description": "Use Holochain bootstrap server for peer discovery"
+      },
+      "hcUseProxy": {
+        "type": "boolean",
+        "default": true,
+        "description": "Use Holochain proxy for NAT traversal"
+      },
+      "runDappServer": {
+        "type": "boolean",
+        "default": false,
+        "description": "Run the built-in dapp web server"
+      },
+      "maxRestartAttempts": {
+        "type": "number",
+        "default": 3,
+        "description": "Max auto-restart attempts within 60 seconds"
       }
     },
     "required": [],

--- a/plugins/ad4m/openclaw.plugin.json
+++ b/plugins/ad4m/openclaw.plugin.json
@@ -67,6 +67,10 @@
         "enum": ["file", "openclaw", "both"],
         "default": "file",
         "description": "Where to send executor logs: 'file' = ~/.ad4m/ad4m.log only (default), 'openclaw' = OpenClaw logs only, 'both' = both destinations."
+      },
+      "appDataPath": {
+        "type": "string",
+        "description": "Custom data directory for the AD4M executor (passed as --data-path to init and --app-data-path to run). Defaults to ~/.ad4m if not set."
       }
     },
     "required": [],

--- a/plugins/ad4m/package-lock.json
+++ b/plugins/ad4m/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coasys/openclaw-ad4m",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@coasys/openclaw-ad4m",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.7.10",
@@ -16,6 +16,7 @@
         "ws": "^8.16.0"
       },
       "devDependencies": {
+        "@types/node": "^25.6.0",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
       }
@@ -1044,6 +1045,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
@@ -2664,6 +2675,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/plugins/ad4m/package.json
+++ b/plugins/ad4m/package.json
@@ -5,27 +5,37 @@
   "license": "MIT",
   "main": "index.ts",
   "openclaw": {
-    "extensions": ["./index.ts"]
+    "extensions": [
+      "./index.ts"
+    ]
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/coasys/ad4m",
     "directory": "plugins/ad4m"
   },
-  "keywords": ["openclaw", "ad4m", "mcp", "p2p", "holochain", "neighbourhoods"],
+  "keywords": [
+    "openclaw",
+    "ad4m",
+    "mcp",
+    "p2p",
+    "holochain",
+    "neighbourhoods"
+  ],
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@coasys/ad4m": "0.12.0-rc1-dev.5",
     "@apollo/client": "^3.7.10",
+    "@coasys/ad4m": "0.12.0-rc1-dev.5",
     "graphql": "^15.7.2",
     "graphql-ws": "^5.14.0",
     "ws": "^8.16.0"
   },
   "devDependencies": {
-    "vitest": "^3.0.0",
-    "typescript": "^5.0.0"
+    "@types/node": "^25.6.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/plugins/ad4m/setup.ts
+++ b/plugins/ad4m/setup.ts
@@ -363,11 +363,88 @@ async function setupExternalModeViaGraphQL(
     const client = new Ad4mClient(apollo, false);
     logger.info("[ad4m-setup] Ad4mClient created successfully");
 
+    // Check if this is a multi-user executor by attempting runtimeInfo query
+    let isMultiUser = false;
+    try {
+      const runtimeInfo = await client.runtime.info();
+      // If runtimeInfo returns successfully and has a multi-user indicator
+      if (runtimeInfo && runtimeInfo.isMultiUser) {
+        isMultiUser = true;
+      }
+    } catch {
+      // runtimeInfo failed — likely single-user or auth required
+      // Fall through to single-user flow
+    }
+
+    if (isMultiUser) {
+      // Multi-user executor: email/password login flow
+      logger.info(
+        "[ad4m-setup] Detected multi-user executor. Prompting for credentials...",
+      );
+      logger.info("");
+      logger.info(
+        "[ad4m-setup] ┌─────────────────────────────────────────────────────────┐",
+      );
+      logger.info(
+        "[ad4m-setup] │  This is a multi-user AD4M executor.                   │",
+      );
+      logger.info(
+        "[ad4m-setup] │  Please enter your login credentials below.            │",
+      );
+      logger.info(
+        "[ad4m-setup] └─────────────────────────────────────────────────────────┘",
+      );
+      logger.info("");
+
+      const email = await promptUser("[ad4m-setup] Enter your email: ");
+      const password = await promptUser("[ad4m-setup] Enter your password: ");
+
+      if (!email || !password) {
+        logger.warn("[ad4m-setup] Missing credentials. Setup cancelled.");
+        printConfigSnippet(logger, "external", {
+          executorWsUrl,
+          token: "<paste-your-jwt-here>",
+          wakeToken,
+        });
+        return;
+      }
+
+      try {
+        logger.info("[ad4m-setup] Attempting login...");
+        const jwt = await client.runtime.loginUser(email, password);
+
+        if (jwt) {
+          logger.info("[ad4m-setup] Login successful! JWT obtained.");
+          printConfigSnippet(logger, "external", {
+            executorWsUrl,
+            token: jwt,
+            wakeToken,
+          });
+        } else {
+          logger.warn(
+            "[ad4m-setup] Login returned no token. Check credentials and try again.",
+          );
+          printConfigSnippet(logger, "external", {
+            executorWsUrl,
+            token: "<paste-your-jwt-here>",
+            wakeToken,
+          });
+        }
+      } catch (loginErr: any) {
+        logger.error(
+          `[ad4m-setup] Login failed: ${loginErr.message}`,
+        );
+        printConfigSnippet(logger, "external", {
+          executorWsUrl,
+          token: "<paste-your-jwt-here>",
+          wakeToken,
+        });
+      }
+      return;
+    }
+
+    // Single-user executor: requestCapability + 6-digit code flow
     // Step 1: Request capability — triggers the verification popup in the launcher
-    // Use a plain object rather than `new AuthInfoInput()` — the GraphQL
-    // mutation only needs the correct field names in the variables, and
-    // constructing the class without its positional args can leave fields
-    // undefined depending on how type-graphql decorators serialise.
     const authInfo = {
       appName: "OpenClaw AD4M Plugin",
       appDesc: "OpenClaw agent plugin for AD4M neighbourhoods",

--- a/plugins/ad4m/tsconfig.json
+++ b/plugins/ad4m/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/plugins/ad4m/types.ts
+++ b/plugins/ad4m/types.ts
@@ -33,5 +33,15 @@ export interface PluginConfig {
   rustLog?: string;
   /** Where to send executor logs: "file" (default) = ~/.ad4m/ad4m.log only, "openclaw" = openclaw logs only, "both" = both. */
   executorLogTarget?: "file" | "openclaw" | "both";
+  /** Enable Holochain DHT connectivity (default: true). */
+  connectHolochain?: boolean;
+  /** Use Holochain bootstrap server for peer discovery (default: true). */
+  hcUseBootstrap?: boolean;
+  /** Use Holochain proxy for NAT traversal (default: true). */
+  hcUseProxy?: boolean;
+  /** Run the built-in dapp web server (default: false). */
+  runDappServer?: boolean;
+  /** Max auto-restart attempts within 60 seconds (default: 3). */
+  maxRestartAttempts?: number;
 }
 

--- a/plugins/ad4m/types.ts
+++ b/plugins/ad4m/types.ts
@@ -21,6 +21,8 @@ export interface PluginConfig {
   token?: string;
   agentPassphrase?: string;
   ad4mBinaryPath?: string;
+  /** Custom data directory for the AD4M executor (passed as --data-path to init/run). */
+  appDataPath?: string;
   toolRefreshIntervalMs?: number;
   wakerEnabled?: boolean;
   executorWsUrl?: string;


### PR DESCRIPTION
## Summary

Fixes 5 reliability issues in the OpenClaw AD4M plugin that caused the managed-mode executor to fail on startup with custom port/path configurations.

## Problems Fixed

| # | Issue | Impact |
|---|-------|--------|
| 1 | `init` command ignores custom `--data-path` | Executor panics on first run when using non-default data directory |
| 2 | `isExecutorRunning()` probes wrong GraphQL port | Always reports "not running" when `gqlPort` ≠ 12000 |
| 3 | Startup wait timeout too short (30s) | Times out before Holochain-enabled executors finish initializing (~31s) |
| 4 | `agentStatus` throws "main key not found" when wallet locked | `ensureAgentReady()` retries 10x then gives up — agent never unlocked |
| 5 | MCP probe missing `Accept` header | AD4M MCP server returns 406, probe always fails |

## Changes

### `executor.ts`
- Pass `--data-path <appDataPath>` to `init` when configured
- Derive `graphqlHttpUrl` from `wsEndpoint` (correct port) and pass to `isExecutorRunning()`
- Increase wait loop from 30 to 90 iterations (`EXECUTOR_STARTUP_WAIT_ITERATIONS` constant)
- Log progress every 10 iterations instead of every 1 (reduces spam)
- Add `Accept: application/json, text/event-stream` header to MCP probe
- Accept `appDataPath` parameter in `ensureExecutorRunning()`

### `agent.ts`
- Catch "main key not found" error in the status retry loop
- If passphrase available: attempt direct `unlock()` then get status and return DID
- If no passphrase: fail immediately with clear error message

### `types.ts`
- Add `appDataPath` to `PluginConfig` interface

### `index.ts`
- Re-export `EXECUTOR_STARTUP_WAIT_ITERATIONS` for external configurability

## Testing

9 new test cases added to `index.test.ts` (92 total, all passing):
- "main key not found" with passphrase -> unlock succeeds
- "main key not found" without passphrase -> graceful failure
- Unlock failure after "main key not found" -> graceful failure
- Custom port in `isExecutorRunning()` probing
- `Accept` header included in MCP probe
- `--data-path` passed during init
- `EXECUTOR_STARTUP_WAIT_ITERATIONS` constant value
- `graphqlHttpUrl` derivation from `wsEndpoint`
- Wait loop uses `EXECUTOR_STARTUP_WAIT_ITERATIONS`

## Context

These issues were discovered while setting up the plugin with isolated configuration:
- Custom ports (GQL 12100, MCP 3100) to avoid conflicts with dev executors
- Custom `appDataPath` at `~/.openclaw/plugins/ad4m/.ad4m`
- Holochain-enabled executor with bootstrap + proxy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for custom application data directories in executor configuration.
  * Enhanced agent connection with automatic unlock recovery for wallet-locked scenarios.

* **Improvements**
  * Improved executor startup monitoring with progress tracking and better visibility.
  * Enhanced health probe requests with customizable headers for more robust connectivity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->