### PR TITLE
Feature: Ad4m model OR, AND, NOT

### DIFF
--- a/core/src/model/query-sparql.test.ts
+++ b/core/src/model/query-sparql.test.ts
@@ -374,3 +374,144 @@ describe('buildSPARQLQuery — RDF 1.2 reifier patterns', () => {
   });
 
 });
+
+// ──────────────────────────────────────────────────────────
+// OR / AND / NOT logical combinators
+// ──────────────────────────────────────────────────────────
+
+describe('hasJsOnlyWhereFilters — OR/AND/NOT combinators', () => {
+  it('returns false for OR with no JS-only conditions in any branch', () => {
+    // Both branches are simple non-literal equality (SPARQL-pushable)
+    const where = {
+      OR: [
+        { category: 'some://uri' },
+        { category: 'other://uri' },
+      ],
+    };
+    expect(hasJsOnlyWhereFilters(richMetadata, emptyRelations, where)).toBe(false);
+  });
+
+  it('returns true for OR when any branch contains a JS-only filter', () => {
+    // Second branch has author → JS-only
+    const where = {
+      OR: [
+        { category: 'some://uri' },
+        { author: 'did:key:abc' },
+      ],
+    };
+    expect(hasJsOnlyWhereFilters(richMetadata, emptyRelations, where)).toBe(true);
+  });
+
+  it('returns true for OR when any branch contains a contains operator', () => {
+    const where = {
+      OR: [
+        { name: { contains: 'foo' } },
+        { description: { contains: 'foo' } },
+      ],
+    };
+    expect(hasJsOnlyWhereFilters(richMetadata, emptyRelations, where)).toBe(true);
+  });
+
+  it('returns false for AND with no JS-only conditions in any branch', () => {
+    const where = {
+      AND: [
+        { category: 'some://uri' },
+        { category: 'other://uri' },
+      ],
+    };
+    expect(hasJsOnlyWhereFilters(richMetadata, emptyRelations, where)).toBe(false);
+  });
+
+  it('returns true for AND when any branch contains a JS-only filter', () => {
+    const where = {
+      AND: [
+        { category: 'some://uri' },
+        { name: { gt: 5 } },
+      ],
+    };
+    expect(hasJsOnlyWhereFilters(richMetadata, emptyRelations, where)).toBe(true);
+  });
+
+  it('returns false for NOT with no JS-only conditions', () => {
+    const where = { NOT: { category: 'some://uri' } };
+    expect(hasJsOnlyWhereFilters(richMetadata, emptyRelations, where)).toBe(false);
+  });
+
+  it('returns true for NOT when the negated clause contains a JS-only filter', () => {
+    const where = { NOT: { author: 'did:key:abc' } };
+    expect(hasJsOnlyWhereFilters(richMetadata, emptyRelations, where)).toBe(true);
+  });
+
+  it('returns true for nested OR inside OR when inner branch is JS-only', () => {
+    const where = {
+      OR: [
+        { OR: [{ author: 'did:key:abc' }] },
+        { category: 'some://uri' },
+      ],
+    };
+    expect(hasJsOnlyWhereFilters(richMetadata, emptyRelations, where)).toBe(true);
+  });
+});
+
+describe('buildSPARQLQuery — OR/AND/NOT not emitted as SPARQL (handled Rust-side)', () => {
+  const modelClass: any = {};
+
+  it('does not emit OR key as a SPARQL triple pattern', () => {
+    const query = {
+      where: {
+        OR: [
+          { name: 'Alice' },
+          { name: 'Bob' },
+        ],
+      },
+    };
+    const sparql = buildSPARQLQuery(richMetadata, emptyRelations, query, modelClass);
+    // OR should not appear as a predicate in the SPARQL
+    expect(sparql).not.toContain('"OR"');
+    expect(sparql).not.toContain('<OR>');
+    // Valid SPARQL structure still present
+    expect(sparql).toContain('SELECT ?source ?predicate ?target');
+  });
+
+  it('does not emit AND or NOT as SPARQL patterns', () => {
+    const query = {
+      where: {
+        AND: [{ category: 'some://uri' }],
+        NOT: { category: 'other://uri' },
+      },
+    };
+    const sparql = buildSPARQLQuery(richMetadata, emptyRelations, query, modelClass);
+    expect(sparql).not.toContain('"AND"');
+    expect(sparql).not.toContain('"NOT"');
+  });
+
+  it('does NOT include LIMIT when OR contains JS-only filters', () => {
+    // OR with contains → hasJsOnlyWhereFilters true → no SPARQL pagination
+    const query = {
+      limit: 10,
+      where: {
+        OR: [
+          { name: { contains: 'foo' } },
+          { description: { contains: 'foo' } },
+        ],
+      },
+    };
+    const sparql = buildSPARQLQuery(richMetadata, emptyRelations, query, modelClass);
+    expect(sparql).not.toContain('LIMIT');
+  });
+
+  it('still pushes LIMIT to SPARQL when OR contains only SPARQL-pushable conditions', () => {
+    // Both OR branches are simple non-literal equality — no JS-only filters
+    const query = {
+      limit: 5,
+      where: {
+        OR: [
+          { category: 'some://uri' },
+          { category: 'other://uri' },
+        ],
+      },
+    };
+    const sparql = buildSPARQLQuery(richMetadata, emptyRelations, query, modelClass);
+    expect(sparql).toContain('LIMIT 5');
+  });
+});

--- a/core/src/model/query-sparql.ts
+++ b/core/src/model/query-sparql.ts
@@ -39,6 +39,24 @@ export function hasJsOnlyWhereFilters(
   for (const [propertyName, condition] of Object.entries(where)) {
     if (propertyName === "base" || propertyName === "id") continue;
 
+    // OR/AND: recurse into each branch; if any branch has JS-only filters,
+    // the whole combinator cannot be pushed to SPARQL.
+    if (propertyName === "OR" || propertyName === "AND") {
+      const branches = condition as Where[];
+      if (Array.isArray(branches)) {
+        for (const branch of branches) {
+          if (hasJsOnlyWhereFilters(metadata, allRelationsMetadata, branch)) return true;
+        }
+      }
+      continue;
+    }
+
+    // NOT: recurse into the single negated clause.
+    if (propertyName === "NOT") {
+      if (hasJsOnlyWhereFilters(metadata, allRelationsMetadata, condition as Where)) return true;
+      continue;
+    }
+
     // author/timestamp filters are handled in JS
     if (propertyName === "author" || propertyName === "timestamp") return true;
 
@@ -387,6 +405,11 @@ function buildSPARQLWhereFilters(
   const filters: string[] = [];
 
   for (const [propertyName, condition] of Object.entries(where)) {
+    // OR/AND/NOT are evaluated Rust-side after hydration; no SPARQL emission needed.
+    if (propertyName === "OR" || propertyName === "AND" || propertyName === "NOT") {
+      continue;
+    }
+
     // 'base' maps to ?source
     if (propertyName === "base" || propertyName === "id") {
       if (Array.isArray(condition)) {

--- a/core/src/model/types.ts
+++ b/core/src/model/types.ts
@@ -25,8 +25,25 @@ export type WhereOps = {
   gte: number; // greater than or equal to
   contains: string | number; // substring/element check
 };
-export type WhereCondition = string | number | boolean | string[] | number[] | { [K in keyof WhereOps]?: WhereOps[K] };
-export type Where = { [propertyName: string]: WhereCondition };
+export type WhereCondition =
+  | string
+  | number
+  | boolean
+  | string[]
+  | number[]
+  | { [K in keyof WhereOps]?: WhereOps[K] }
+  | Where[]
+  | Where;
+
+export type Where = {
+  /** Logical OR: instance must satisfy at least one of the given sub-clauses. */
+  OR?: Where[];
+  /** Logical AND: instance must satisfy all of the given sub-clauses. */
+  AND?: Where[];
+  /** Logical NOT: instance must NOT satisfy the given sub-clause. */
+  NOT?: Where;
+  [propertyName: string]: WhereCondition | undefined;
+};
 export type Order = { [propertyName: string]: "ASC" | "DESC" };
 
 /**
@@ -282,7 +299,7 @@ export type TypedWhereCondition<V> =
   : WhereCondition;
 
 /** Strict Where: keys constrained to T's properties, plus the well-known
- *  link-metadata fields (`id`/`author`/`timestamp`). */
+ *  link-metadata fields (`id`/`author`/`timestamp`) and logical combinators. */
 type StrictTypedWhere<T extends Ad4mModel> =
   & { [K in PropertyKeysOf<T>]?: TypedWhereCondition<T[K]> }
   & {
@@ -290,6 +307,9 @@ type StrictTypedWhere<T extends Ad4mModel> =
       id?: string | string[];
       author?: WhereCondition;
       timestamp?: WhereCondition;
+      OR?: StrictTypedWhere<T>[];
+      AND?: StrictTypedWhere<T>[];
+      NOT?: StrictTypedWhere<T>;
     };
 
 /** Public typed `where` for a model class. Falls back to the loose `Where`

--- a/rust-executor/src/perspectives/model_query/filtering.rs
+++ b/rust-executor/src/perspectives/model_query/filtering.rs
@@ -25,6 +25,47 @@ pub(super) fn matches_where(
     shape: &ModelShape,
 ) -> bool {
     for (prop_name, condition) in where_clause {
+        // --- Logical combinators ---
+
+        // OR: instance must match at least one branch.
+        if prop_name == "OR" {
+            if let WhereCondition::SubClauses(branches) = condition {
+                if branches.is_empty() {
+                    return false;
+                }
+                if !branches
+                    .iter()
+                    .any(|branch| matches_where(instance, branch, shape))
+                {
+                    return false;
+                }
+            }
+            continue;
+        }
+
+        // AND: instance must match every branch.
+        if prop_name == "AND" {
+            if let WhereCondition::SubClauses(branches) = condition {
+                if !branches
+                    .iter()
+                    .all(|branch| matches_where(instance, branch, shape))
+                {
+                    return false;
+                }
+            }
+            continue;
+        }
+
+        // NOT: instance must NOT match the branch.
+        if prop_name == "NOT" {
+            if let WhereCondition::SubClause(branch) = condition {
+                if matches_where(instance, branch, shape) {
+                    return false;
+                }
+            }
+            continue;
+        }
+
         if prop_name == "base" || prop_name == "id" {
             // String and StringArray id conditions are pushed to SPARQL.
             // Complex ops (Ops, NumberArray, etc.) still need post-hydration.
@@ -103,6 +144,9 @@ pub(super) fn matches_condition(val: &Value, condition: &WhereCondition) -> bool
             }
         }
         WhereCondition::Ops(ops) => matches_ops(val, ops),
+        // SubClauses/SubClause are handled at the where-clause level (matches_where),
+        // not per-value — reaching here means an unexpected field structure.
+        WhereCondition::SubClauses(_) | WhereCondition::SubClause(_) => false,
     }
 }
 
@@ -990,5 +1034,205 @@ mod tests {
             .map(|i| i["score"].as_i64().unwrap())
             .collect();
         assert_eq!(scores, vec![1, 5, 10]);
+    }
+
+    // ---- OR / AND / NOT combinator tests ------------------------------------
+
+    fn empty_shape() -> ModelShape {
+        ModelShape {
+            target_class: "Test".to_string(),
+            shape_uri: "".to_string(),
+            properties: vec![],
+            include_relations: vec![],
+        }
+    }
+
+    fn make_where(entries: Vec<(&str, WhereCondition)>) -> BTreeMap<String, WhereCondition> {
+        entries
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect()
+    }
+
+    #[test]
+    fn test_or_matches_when_any_branch_passes() {
+        let shape = empty_shape();
+        let instance = json!({ "status": "active", "name": "Alice" });
+
+        // OR: status == "active" OR name == "Bob"
+        // "active" matches first branch → passes
+        let wc = make_where(vec![(
+            "OR",
+            WhereCondition::SubClauses(vec![
+                make_where(vec![(
+                    "status",
+                    WhereCondition::String("active".to_string()),
+                )]),
+                make_where(vec![("name", WhereCondition::String("Bob".to_string()))]),
+            ]),
+        )]);
+        assert!(matches_where(&instance, &wc, &shape));
+    }
+
+    #[test]
+    fn test_or_fails_when_no_branch_passes() {
+        let shape = empty_shape();
+        let instance = json!({ "status": "inactive", "name": "Alice" });
+
+        // OR: status == "active" OR name == "Bob"
+        // neither matches → fails
+        let wc = make_where(vec![(
+            "OR",
+            WhereCondition::SubClauses(vec![
+                make_where(vec![(
+                    "status",
+                    WhereCondition::String("active".to_string()),
+                )]),
+                make_where(vec![("name", WhereCondition::String("Bob".to_string()))]),
+            ]),
+        )]);
+        assert!(!matches_where(&instance, &wc, &shape));
+    }
+
+    #[test]
+    fn test_or_empty_branches_fails() {
+        let shape = empty_shape();
+        let instance = json!({ "status": "active" });
+        let wc = make_where(vec![("OR", WhereCondition::SubClauses(vec![]))]);
+        assert!(!matches_where(&instance, &wc, &shape));
+    }
+
+    #[test]
+    fn test_and_passes_when_all_branches_pass() {
+        let shape = empty_shape();
+        let instance = json!({ "status": "active", "role": "admin" });
+
+        let wc = make_where(vec![(
+            "AND",
+            WhereCondition::SubClauses(vec![
+                make_where(vec![(
+                    "status",
+                    WhereCondition::String("active".to_string()),
+                )]),
+                make_where(vec![("role", WhereCondition::String("admin".to_string()))]),
+            ]),
+        )]);
+        assert!(matches_where(&instance, &wc, &shape));
+    }
+
+    #[test]
+    fn test_and_fails_when_any_branch_fails() {
+        let shape = empty_shape();
+        let instance = json!({ "status": "active", "role": "viewer" });
+
+        let wc = make_where(vec![(
+            "AND",
+            WhereCondition::SubClauses(vec![
+                make_where(vec![(
+                    "status",
+                    WhereCondition::String("active".to_string()),
+                )]),
+                make_where(vec![("role", WhereCondition::String("admin".to_string()))]),
+            ]),
+        )]);
+        assert!(!matches_where(&instance, &wc, &shape));
+    }
+
+    #[test]
+    fn test_and_empty_branches_passes() {
+        let shape = empty_shape();
+        let instance = json!({ "status": "active" });
+        let wc = make_where(vec![("AND", WhereCondition::SubClauses(vec![]))]);
+        // all() on empty iterator is true
+        assert!(matches_where(&instance, &wc, &shape));
+    }
+
+    #[test]
+    fn test_not_passes_when_branch_does_not_match() {
+        let shape = empty_shape();
+        let instance = json!({ "status": "active" });
+
+        // NOT { status: "deleted" } — instance has "active", so NOT matches
+        let wc = make_where(vec![(
+            "NOT",
+            WhereCondition::SubClause(make_where(vec![(
+                "status",
+                WhereCondition::String("deleted".to_string()),
+            )])),
+        )]);
+        assert!(matches_where(&instance, &wc, &shape));
+    }
+
+    #[test]
+    fn test_not_fails_when_branch_matches() {
+        let shape = empty_shape();
+        let instance = json!({ "status": "deleted" });
+
+        let wc = make_where(vec![(
+            "NOT",
+            WhereCondition::SubClause(make_where(vec![(
+                "status",
+                WhereCondition::String("deleted".to_string()),
+            )])),
+        )]);
+        assert!(!matches_where(&instance, &wc, &shape));
+    }
+
+    #[test]
+    fn test_or_combined_with_top_level_condition() {
+        let shape = empty_shape();
+
+        // { role: "admin", OR: [{ name: "Alice" }, { name: "Bob" }] }
+        // role must be "admin" AND (name is Alice or Bob)
+        let instance_pass = json!({ "role": "admin", "name": "Alice" });
+        let instance_fail_role = json!({ "role": "viewer", "name": "Alice" });
+        let instance_fail_name = json!({ "role": "admin", "name": "Charlie" });
+
+        let wc = {
+            let mut m = BTreeMap::new();
+            m.insert(
+                "role".to_string(),
+                WhereCondition::String("admin".to_string()),
+            );
+            m.insert(
+                "OR".to_string(),
+                WhereCondition::SubClauses(vec![
+                    make_where(vec![("name", WhereCondition::String("Alice".to_string()))]),
+                    make_where(vec![("name", WhereCondition::String("Bob".to_string()))]),
+                ]),
+            );
+            m
+        };
+
+        assert!(matches_where(&instance_pass, &wc, &shape));
+        assert!(!matches_where(&instance_fail_role, &wc, &shape));
+        assert!(!matches_where(&instance_fail_name, &wc, &shape));
+    }
+
+    #[test]
+    fn test_nested_or_inside_or() {
+        let shape = empty_shape();
+        // OR: [{ OR: [{ a: "1" }, { a: "2" }] }, { b: "x" }]
+        // matches when a is "1" or "2", OR b is "x"
+        let inner_or = WhereCondition::SubClauses(vec![
+            make_where(vec![("a", WhereCondition::String("1".to_string()))]),
+            make_where(vec![("a", WhereCondition::String("2".to_string()))]),
+        ]);
+        let wc = make_where(vec![(
+            "OR",
+            WhereCondition::SubClauses(vec![
+                {
+                    let mut m = BTreeMap::new();
+                    m.insert("OR".to_string(), inner_or);
+                    m
+                },
+                make_where(vec![("b", WhereCondition::String("x".to_string()))]),
+            ]),
+        )]);
+
+        assert!(matches_where(&json!({ "a": "1" }), &wc, &shape));
+        assert!(matches_where(&json!({ "a": "2" }), &wc, &shape));
+        assert!(matches_where(&json!({ "b": "x" }), &wc, &shape));
+        assert!(!matches_where(&json!({ "a": "3", "b": "y" }), &wc, &shape));
     }
 }

--- a/rust-executor/src/perspectives/model_query/projection.rs
+++ b/rust-executor/src/perspectives/model_query/projection.rs
@@ -518,9 +518,15 @@ pub(super) fn build_projection_where_patterns(
     // pred_lookup would drop those filters and unexpectedly broaden the
     // projection results.
     if resolution_failed {
-        let has_property_filters = wc
-            .keys()
-            .any(|k| k != "id" && k != "base" && k != "author" && k != "timestamp");
+        let has_property_filters = wc.keys().any(|k| {
+            k != "id"
+                && k != "base"
+                && k != "author"
+                && k != "timestamp"
+                && k != "OR"
+                && k != "AND"
+                && k != "NOT"
+        });
         if has_property_filters {
             return "    FILTER(false)\n".to_string();
         }
@@ -530,6 +536,12 @@ pub(super) fn build_projection_where_patterns(
     let mut filter_idx = 0usize;
 
     for (prop_name, condition) in wc {
+        // OR/AND/NOT combinators are not supported in projection where clauses
+        // (projections use SPARQL, not the Rust post-filter path); skip silently.
+        if prop_name == "OR" || prop_name == "AND" || prop_name == "NOT" {
+            continue;
+        }
+
         if prop_name == "id" || prop_name == "base" {
             match condition {
                 WhereCondition::String(val) => {

--- a/rust-executor/src/perspectives/model_query/sparql_builder.rs
+++ b/rust-executor/src/perspectives/model_query/sparql_builder.rs
@@ -469,6 +469,9 @@ pub(super) fn where_clause_max_source_count(query: &ModelQueryInput) -> Option<u
             WhereCondition::NumberArray(arr) => Some(arr.len()),
             // `Ops` (gt/lt/between/contains/not) can match an unbounded set.
             WhereCondition::Ops(_) => None,
+            // SubClauses/SubClause are combinators handled Rust-side; they
+            // don't cap the id/base source count.
+            WhereCondition::SubClauses(_) | WhereCondition::SubClause(_) => None,
         };
         if let Some(cap) = cap {
             min = Some(min.map(|m| m.min(cap)).unwrap_or(cap));
@@ -489,6 +492,12 @@ pub(super) fn all_where_pushable(query: &ModelQueryInput, shape: &ModelShape) ->
         return true;
     };
     for (prop_name, condition) in wc {
+        // OR/AND/NOT are always evaluated Rust-side; SPARQL-level pagination
+        // cannot be applied when they are present.
+        if prop_name == "OR" || prop_name == "AND" || prop_name == "NOT" {
+            return false;
+        }
+
         if prop_name == "base" || prop_name == "id" {
             match condition {
                 WhereCondition::String(_)
@@ -496,7 +505,9 @@ pub(super) fn all_where_pushable(query: &ModelQueryInput, shape: &ModelShape) ->
                 | WhereCondition::Number(_)
                 | WhereCondition::Bool(_)
                 | WhereCondition::NumberArray(_)
-                | WhereCondition::Ops(_) => continue,
+                | WhereCondition::Ops(_)
+                | WhereCondition::SubClauses(_)
+                | WhereCondition::SubClause(_) => continue,
             }
         }
         if shape
@@ -677,6 +688,11 @@ pub(super) fn build_query_patterns(
     let mut where_patterns = Vec::new();
     if let Some(ref wc) = query.where_clause {
         for (prop_name, condition) in wc {
+            // OR/AND/NOT are evaluated Rust-side after hydration; skip SPARQL emission.
+            if prop_name == "OR" || prop_name == "AND" || prop_name == "NOT" {
+                continue;
+            }
+
             if prop_name == "base" || prop_name == "id" {
                 match condition {
                     WhereCondition::String(val) => {
@@ -741,6 +757,10 @@ pub(super) fn build_query_patterns(
                                 .push(format!("    FILTER(STR(?source) IN ({}))", ids.join(", ")));
                         }
                     }
+                    // SubClauses/SubClause are OR/AND/NOT combinators; they are
+                    // never stored under "id"/"base" keys and are handled
+                    // Rust-side, so nothing to emit here.
+                    WhereCondition::SubClauses(_) | WhereCondition::SubClause(_) => {}
                     WhereCondition::Ops(ops) => {
                         // Operate on the IRI's string form so range / contains
                         // comparisons work uniformly regardless of whether the
@@ -1165,6 +1185,9 @@ pub(super) fn build_query_patterns(
                             where_patterns.push(format!("    FILTER({})", filters.join(" && ")));
                         }
                     }
+                    // SubClauses/SubClause are OR/AND/NOT combinators evaluated
+                    // Rust-side; the outer loop skips them before reaching here.
+                    WhereCondition::SubClauses(_) | WhereCondition::SubClause(_) => {}
                 }
                 continue;
             }

--- a/rust-executor/src/perspectives/model_query/types.rs
+++ b/rust-executor/src/perspectives/model_query/types.rs
@@ -19,7 +19,12 @@ use std::collections::{BTreeMap, HashMap};
 /// Used inside [`WhereCondition::Ops`] to express range queries, negation,
 /// and substring matching.  Multiple fields can be combined (e.g. `gt` + `lt`
 /// for an open range).
+///
+/// `deny_unknown_fields` ensures that when `#[serde(untagged)]` tries this
+/// variant, objects that contain non-WhereOps keys (e.g. a nested where clause
+/// like `{"name": "Alice"}`) are rejected and fall through to `SubClause`.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct WhereOps {
     #[serde(default)]
     pub not: Option<Value>,
@@ -61,15 +66,34 @@ impl Default for WhereOps {
 /// - `["a","b"]` → [`StringArray`](WhereCondition::StringArray) (IN operator)
 /// - `[1,2,3]` → [`NumberArray`](WhereCondition::NumberArray) (IN operator)
 /// - `{"gt": 5, "lt": 10}` → [`Ops`](WhereCondition::Ops)
+/// - `[{"name":"Alice"},{"name":"Bob"}]` → [`SubClauses`](WhereCondition::SubClauses) (OR / AND)
+/// - `{"name":"Alice","status":"active"}` → [`SubClause`](WhereCondition::SubClause) (NOT)
+///
+/// **Variant ordering** is significant for `#[serde(untagged)]`:
+/// - `Bool` before `Number` so JSON booleans don't coerce to `f64`.
+/// - `StringArray` / `NumberArray` before `SubClauses` so empty arrays `[]`
+///   become `StringArray([])` rather than `SubClauses([])`.
+/// - `Ops` (with `deny_unknown_fields`) before `SubClause` so operator objects
+///   like `{"gt": 5}` match `Ops` and where-clause objects like `{"name":"Alice"}`
+///   fall through to `SubClause`.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum WhereCondition {
-    String(String),
-    Number(f64),
     Bool(bool),
+    Number(f64),
+    String(String),
     StringArray(Vec<String>),
     NumberArray(Vec<f64>),
+    /// Array of nested where clauses used for OR and AND combinators.
+    /// The key name in the parent `BTreeMap` determines the semantic:
+    /// `"OR"` → any branch must pass; `"AND"` → all branches must pass.
+    SubClauses(Vec<BTreeMap<String, WhereCondition>>),
+    /// Operator-based condition (`gt`, `lt`, `contains`, `not`, etc.).
+    /// `WhereOps` uses `deny_unknown_fields` so objects whose keys are not
+    /// WhereOps fields are rejected here and fall through to `SubClause`.
     Ops(WhereOps),
+    /// Single nested where clause used for the NOT combinator.
+    SubClause(BTreeMap<String, WhereCondition>),
 }
 
 /// Sort direction for ORDER BY clauses.
@@ -542,6 +566,125 @@ impl InstanceQueryPlan {
                 panic!("Expected Single query plan, got TwoPhase")
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod where_condition_deser_tests {
+    use super::*;
+    use serde_json::from_value;
+
+    #[test]
+    fn deser_string() {
+        let v: WhereCondition = from_value(serde_json::json!("hello")).unwrap();
+        assert!(matches!(v, WhereCondition::String(s) if s == "hello"));
+    }
+
+    #[test]
+    fn deser_number() {
+        let v: WhereCondition = from_value(serde_json::json!(42.0)).unwrap();
+        assert!(matches!(v, WhereCondition::Number(n) if (n - 42.0).abs() < f64::EPSILON));
+    }
+
+    #[test]
+    fn deser_bool() {
+        let v: WhereCondition = from_value(serde_json::json!(true)).unwrap();
+        assert!(matches!(v, WhereCondition::Bool(true)));
+    }
+
+    #[test]
+    fn deser_string_array() {
+        let v: WhereCondition = from_value(serde_json::json!(["a", "b", "c"])).unwrap();
+        assert!(matches!(v, WhereCondition::StringArray(arr) if arr == vec!["a", "b", "c"]));
+    }
+
+    #[test]
+    fn deser_number_array() {
+        let v: WhereCondition = from_value(serde_json::json!([1.0, 2.0, 3.0])).unwrap();
+        assert!(matches!(v, WhereCondition::NumberArray(_)));
+    }
+
+    #[test]
+    fn deser_empty_array_is_string_array() {
+        // Empty arrays land on StringArray (first Vec variant), not SubClauses.
+        let v: WhereCondition = from_value(serde_json::json!([])).unwrap();
+        assert!(matches!(v, WhereCondition::StringArray(arr) if arr.is_empty()));
+    }
+
+    #[test]
+    fn deser_ops_with_known_fields() {
+        let v: WhereCondition = from_value(serde_json::json!({ "gt": 5, "lt": 10 })).unwrap();
+        assert!(
+            matches!(v, WhereCondition::Ops(ops) if ops.gt == Some(5.0) && ops.lt == Some(10.0))
+        );
+    }
+
+    #[test]
+    fn deser_sub_clauses_for_or_and() {
+        // Array of objects → SubClauses (used as OR/AND value)
+        let v: WhereCondition =
+            from_value(serde_json::json!([{"name": "Alice"}, {"name": "Bob"}])).unwrap();
+        match v {
+            WhereCondition::SubClauses(branches) => {
+                assert_eq!(branches.len(), 2);
+                assert!(branches[0].contains_key("name"));
+            }
+            other => panic!("expected SubClauses, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deser_sub_clause_for_not() {
+        // Object with non-WhereOps keys → SubClause (used as NOT value)
+        let v: WhereCondition =
+            from_value(serde_json::json!({"name": "Alice", "status": "active"})).unwrap();
+        match v {
+            WhereCondition::SubClause(map) => {
+                assert_eq!(map.len(), 2);
+                assert!(map.contains_key("name"));
+                assert!(map.contains_key("status"));
+            }
+            other => panic!("expected SubClause, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deser_where_clause_with_or() {
+        // Full where-clause map with OR key
+        let json = serde_json::json!({
+            "OR": [
+                { "name": { "contains": "foo" } },
+                { "description": { "contains": "foo" } }
+            ]
+        });
+        let wc: BTreeMap<String, WhereCondition> = serde_json::from_value(json).unwrap();
+        assert!(wc.contains_key("OR"));
+        let or_val = wc.get("OR").unwrap();
+        assert!(matches!(or_val, WhereCondition::SubClauses(b) if b.len() == 2));
+    }
+
+    #[test]
+    fn deser_where_clause_with_not() {
+        let json = serde_json::json!({ "NOT": { "status": "deleted" } });
+        let wc: BTreeMap<String, WhereCondition> = serde_json::from_value(json).unwrap();
+        assert!(wc.contains_key("NOT"));
+        let not_val = wc.get("NOT").unwrap();
+        assert!(matches!(not_val, WhereCondition::SubClause(_)));
+    }
+
+    #[test]
+    fn deser_model_query_with_or_where() {
+        let json = serde_json::json!({
+            "where": {
+                "OR": [
+                    { "name": "Alice" },
+                    { "name": "Bob" }
+                ]
+            }
+        });
+        let mq: ModelQueryInput = serde_json::from_value(json).unwrap();
+        let wc = mq.where_clause.unwrap();
+        assert!(matches!(wc.get("OR"), Some(WhereCondition::SubClauses(b)) if b.len() == 2));
     }
 }
 


### PR DESCRIPTION
# feat: OR/AND/NOT logical combinators for model query where clauses

## Summary

Adds three logical combinators to the AD4M model query `where` clause, following Prisma-style uppercase naming, nestable inside `where` at any depth:

```ts
// Text search across multiple fields
Space.findAll(perspective, {
  where: {
    OR: [
      { name: { contains: searchText } },
      { description: { contains: searchText } },
    ]
  }
})

// AND is useful nested inside OR to group multi-field sub-conditions
// (at the top level, listing fields is already implicit AND)
User.findAll(perspective, {
  where: {
    OR: [
      { AND: [{ firstName: { contains: searchText } }, { lastName: { contains: searchText } }] },
      { bio: { contains: searchText } },
    ]
  }
})

// Exclusion — negates an entire sub-clause, including multi-field conditions
// (single-field negation already existed as: { status: { not: 'banned' } })
User.findAll(perspective, {
  where: {
    NOT: { OR: [{ status: 'banned' }, { status: 'deleted' }] }
  }
})

// Combinators mix freely with top-level conditions and nest arbitrarily
User.findAll(perspective, {
  where: {
    role: 'admin',
    OR: [
      { name: { contains: searchText } },
      { bio: { contains: searchText } },
      { AND: [{ firstName: { contains: searchText } }, { lastName: { contains: searchText } }] },
    ]
  }
})
```

All combinators work in the top-level `where`, in relation sub-queries inside `include`, and in `IncludeProjection.where`.

## Motivation

The primary use case is multi-field text search. Without OR, matching a query string against more than one property requires two separate queries whose results then need to be merged client-side. More broadly, any situation where results should satisfy one of several alternative conditions — across different fields or different value ranges — previously had no clean expression in the `where` DSL.

## How it works

OR/AND/NOT are evaluated **Rust-side as post-SPARQL filters**, not pushed to SPARQL. This is consistent with how `contains` and comparison operators already work — SPARQL returns all conforming candidates, then `matches_where` applies the remaining conditions in Rust. For the primary use case (text search with `contains`), this is already the code path, so OR adds no extra cost.

When any branch of an OR or AND contains a JS-only condition (e.g. `contains`, `author`, `gt`/`lt`), `hasJsOnlyWhereFilters` propagates that upward and SPARQL-level LIMIT/OFFSET is suppressed for the full query, matching the existing behaviour for JS-only top-level conditions.

### Rust post-filter (`matches_where`)

```
OR  key → SubClauses(Vec<Where>) → passes if any branch matches_where returns true
AND key → SubClauses(Vec<Where>) → passes only if all branches match
NOT key → SubClause(Where)       → passes only if the sub-clause does NOT match
```

All three recurse back into `matches_where`, so combinators can be nested to arbitrary depth.

**AND vs implicit top-level AND:** Multiple fields in a single `where` are already implicitly ANDed (`{ status: 'published', category: 'some://uri' }` is equivalent to `AND: [...]` with the same fields). The `AND` combinator's value is when used *nested inside OR* to group a multi-field sub-condition: `OR: [{ AND: [{ a: x }, { b: y }] }, { c: z }]`.

**NOT vs field-level `not`:** The existing `{ status: { not: 'banned' } }` (`WhereOps.not`) negates a single property value and is still the right choice for that case. The new `NOT` combinator negates an entire sub-clause — its value is in negating multi-field conditions (`NOT: { status: 'banned', role: 'user' }`) and in negating nested combinators (`NOT: { OR: [...] }`).

### Serde deserialization

`WhereCondition` is an untagged enum. Adding the new variants required careful ordering to preserve existing deserialization:

```
Bool        → JSON boolean
Number      → JSON number
String      → JSON string
StringArray → JSON array of strings   (empty [] lands here, not SubClauses)
NumberArray → JSON array of numbers
SubClauses  → JSON array of objects   (OR/AND values)
Ops         → JSON object with WhereOps keys only (deny_unknown_fields added)
SubClause   → JSON object with any keys (NOT value; fallback after Ops fails)
```

Adding `#[serde(deny_unknown_fields)]` to `WhereOps` is the key that makes the discrimination work: `{"gt": 5}` succeeds as `Ops`; `{"name": "Alice"}` fails at `Ops` (unknown field) and falls through to `SubClause`.

## Files changed

| File | Change |
|------|--------|
| `core/src/model/types.ts` | `WhereCondition` widened to include `Where[]` and `Where`; `Where` gets `OR?`, `AND?`, `NOT?` named keys; `StrictTypedWhere<T>` gains the same three combinator keys |
| `core/src/model/query-sparql.ts` | `hasJsOnlyWhereFilters` recurses into OR/AND branches and NOT clause; `buildSPARQLWhereFilters` skips OR/AND/NOT keys |
| `core/src/model/query-sparql.test.ts` | 13 new Jest tests |
| `rust-executor/src/perspectives/model_query/types.rs` | `WhereOps` gains `deny_unknown_fields`; `WhereCondition` gains `SubClauses` and `SubClause` variants; 11 new deser unit tests |
| `rust-executor/src/perspectives/model_query/filtering.rs` | `matches_where` handles OR/AND/NOT; `matches_condition` gets catch-all arms for new variants; 11 new unit tests |
| `rust-executor/src/perspectives/model_query/sparql_builder.rs` | `all_where_pushable` returns false when OR/AND/NOT present; `build_query_patterns` skips them in WHERE emission; missing match arms added |
| `rust-executor/src/perspectives/model_query/projection.rs` | Skips OR/AND/NOT in SPARQL projection where-pattern builder; fixes `has_property_filters` guard to exclude combinator keys |

## Tests

**TypeScript (`query-sparql.test.ts`):**
- `hasJsOnlyWhereFilters` — OR with no JS-only branches → false
- `hasJsOnlyWhereFilters` — OR with author branch → true
- `hasJsOnlyWhereFilters` — OR with contains branch → true
- `hasJsOnlyWhereFilters` — AND with no JS-only branches → false
- `hasJsOnlyWhereFilters` — AND with gt operator branch → true
- `hasJsOnlyWhereFilters` — NOT with no JS-only conditions → false
- `hasJsOnlyWhereFilters` — NOT with author → true
- `hasJsOnlyWhereFilters` — nested OR inside OR propagates JS-only
- `buildSPARQLQuery` — OR key not emitted as SPARQL predicate
- `buildSPARQLQuery` — AND/NOT not emitted as SPARQL patterns
- `buildSPARQLQuery` — LIMIT suppressed when OR contains JS-only filters
- `buildSPARQLQuery` — LIMIT still pushed when OR branches are all SPARQL-safe
- Structural validity of emitted SPARQL

**Rust (`types.rs` deser tests):**
- `String`, `Number`, `Bool`, `StringArray`, `NumberArray` deserialise unchanged
- Empty array `[]` → `StringArray([])`, not `SubClauses([])`
- `{"gt": 5, "lt": 10}` → `Ops`
- `[{"name":"Alice"},{"name":"Bob"}]` → `SubClauses`
- `{"name":"Alice","status":"active"}` → `SubClause`
- Full where-clause map with OR key deserialises correctly
- Full where-clause map with NOT key deserialises correctly
- `ModelQueryInput` with OR in where deserialises end-to-end

**Rust (`filtering.rs` unit tests):**
- OR passes when any branch matches
- OR fails when no branch matches
- OR with empty branches → fails
- AND passes when all branches match
- AND fails when any branch fails
- AND with empty branches → vacuously true
- NOT passes when branch does not match
- NOT fails when branch matches
- OR combined with top-level condition (all three cases)
- Nested OR inside OR

## Known limitation

OR/AND/NOT in a **projection's** `where` clause are silently skipped — projections use SPARQL for filtering and don't run `matches_where`. This covers the common case (filter projection targets by a known property value). Combinator support in projections would require wiring the Rust post-filter into the projection pipeline, which is a follow-up.

## Branch

Based on `feat/model-query-sort-extensions`.
