### PR TITLE
fix: sweep stale GraphQL and literal:// references, update AD4M skill

### DIFF
--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -370,7 +370,7 @@ export default class Ad4mConnect extends EventTarget {
         }
 
         // Verify origin is in allowlist (if configured).
-        // In proxy mode the parent sees ALL GraphQL traffic, so the allowlist is the
+        // In proxy mode the parent sees ALL API traffic, so the allowlist is the
         // only gate against a malicious site embedding this app — enforce it strictly.
         if (event.data.proxy) {
           if (!this.options.allowedOrigins || this.options.allowedOrigins.length === 0) {
@@ -421,7 +421,7 @@ export default class Ad4mConnect extends EventTarget {
               throw new Error('AD4M proxy mode requires a non-opaque parent origin. Ensure the host iframe is not sandboxed without allow-same-origin.');
             }
             const parentOrigin = event.origin;
-            // Must be a real constructor class — graphql-ws calls `new webSocketImpl(url)`.
+            // Must be a real constructor class — the WS client calls `new webSocketImpl(url)`.
             // Arrow functions cannot be called with `new`, so we use a class expression here.
             class WsImpl extends PostMessageWebSocket {
               constructor(url: string) { super(url, parentOrigin); }

--- a/core/src/model/ModelQueryBuilder.ts
+++ b/core/src/model/ModelQueryBuilder.ts
@@ -400,7 +400,7 @@ export class ModelQueryBuilder<T extends Ad4mModel> {
     };
     lastResultFingerprint = buildFingerprint(initialResults);
 
-    // Listen for subscription updates via the same GraphQL subscription channel.
+    // Listen for subscription updates via the same WS-RPC subscription channel.
     // When Rust re-runs the model query and finds changed results, it pushes them.
     const unsubscribe = this.perspective.client.subscribeToQueryUpdates(
       subscriptionId,

--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -639,7 +639,7 @@ export class PerspectiveProxy {
      * internally in Rust, registers a subscription, runs the initial query, and
      * pushes updated results when relevant links change.
      *
-     * The subscription reuses the same GraphQL subscription channel as subscribeQuery().
+     * The subscription reuses the same WS-RPC subscription channel as subscribeQuery().
      * Use keepAliveQuery() / disposeQuerySubscription() with the returned subscriptionId.
      *
      * @param className - The model class name

--- a/docs-src/ad4m-social-conventions.md
+++ b/docs-src/ad4m-social-conventions.md
@@ -429,11 +429,11 @@ const results = await mySocialPerspective.query({
 
 In v0.x, the friends list was stored in a local SQLite table managed
 by `RuntimeService` (`rust-executor/src/runtime_service/mod.rs`) and
-surfaced via `addFriends` / `removeFriends` / `friends()` GraphQL
-operations.
+surfaced via `addFriends` / `removeFriends` / `friends()` operations
+(previously GraphQL, now WS-RPC).
 
 v1.0 replaces this with a perspective-backed convention. A runtime
-SHOULD continue to expose the GraphQL shims for backward
+SHOULD continue to expose the legacy operations for backward
 compatibility, but the implementations become thin wrappers:
 
 ```

--- a/docs-src/language-interface-migration-plan.md
+++ b/docs-src/language-interface-migration-plan.md
@@ -15,7 +15,7 @@ migration per user direction (2026-04-10):
 
 - `Agent.directMessageLanguage` field **stays**.
 - Friends SQLite table and `addFriends`/`removeFriends`/`friends()`
-  GraphQL **stay**.
+  operations **stay** (now served via WS-RPC).
 - DM Language capability **stays** at the runtime level as a pragmatic
   divergence from the finalized spec. The spec (`ad4m-lang.wit`) no
   longer defines `direct-message`, but the runtime retains flat DM
@@ -305,9 +305,9 @@ In `rust-executor` (or wherever the JS bridge lives): every `emit*` import
 receives events from the Language. Route them to the existing subscriber
 infrastructure:
 
-- `emitPerspectiveDiff(diff)` → the perspective's GraphQL `perspectiveLinkAdded` /
-  `perspectiveLinkRemoved` subscription stream. Also updates the local
-  perspective graph (same effect as the old callback-based path).
+- `emitPerspectiveDiff(diff)` → the perspective's `perspectiveLinkAdded` /
+  `perspectiveLinkRemoved` subscription stream (delivered via WS-RPC). Also
+  updates the local perspective graph (same effect as the old callback-based path).
 - `emitSyncStateChange(state)` → the perspective's `syncStateChange` stream.
 - `emitTelepresenceSignal(payload, recipientDid?)` → the telepresence
   subscriber stream.
@@ -328,7 +328,7 @@ async-local-storage in JS) as described in spec §7:
   DID context.
 - `agentDid()` / `agentSign()` / `agentCreateSignedExpression()` imports
   read this context.
-- Set correctly for **every** call site: GraphQL resolvers (who's calling?),
+- Set correctly for **every** call site: WS-RPC handlers (who's calling?),
   internal polling (pick a primary local agent), event handlers (the agent
   whose cell the signal came from).
 

--- a/docs-src/language-interface-spec.md
+++ b/docs-src/language-interface-spec.md
@@ -565,7 +565,7 @@ runtime has enqueued the event for fan-out.
 > **Current limitation:** `emitSignal(data)` currently only delivers signals
 > whose payload can be deserialized as a `PerspectiveExpression`. Payloads
 > with other shapes are logged as warnings and dropped. A dedicated
-> `AD4M_SIGNAL_TOPIC` + GraphQL subscription is needed to support arbitrary
+> `AD4M_SIGNAL_TOPIC` subscription is needed to support arbitrary
 > signal payloads (tracked as a follow-up).
 
 ### 7.6 Raw file/blob storage (optional extension — `ad4m-language-fs` world)

--- a/docs-src/pages/agents.mdx
+++ b/docs-src/pages/agents.mdx
@@ -112,7 +112,7 @@ The perspective uses semantic links to create a rich web of information:
 const { did } = await ad4m.agent.me();
 await ad4m.agent.updatePublicPerspective({
   links: [
-    { source: did, predicate: "foaf://name", target: "literal://string:Alice" },
+    { source: did, predicate: "foaf://name", target: "literal:string:Alice" },
     { source: did, predicate: "foaf://knows", target: "did:key:other-agent" }
   ]
 });

--- a/docs-src/pages/developer-guides/model-classes.mdx
+++ b/docs-src/pages/developer-guides/model-classes.mdx
@@ -243,7 +243,7 @@ class Recipe extends Ad4mModel {
 | `required` | `boolean` | `false` | If true, a placeholder link is created on save even if the value is empty |
 | `readOnly` | `boolean` | `false` | Prevents updates after creation |
 | `resolveLanguage` | `string` | `"literal"` | Language used to resolve the stored value. Use `"literal"` for simple values, or a Language address for richer content |
-| `initial` | `any` | — | Default value written on creation. When `required: true` with no `initial`, the framework uses a sentinel value (`"literal://string:uninitialized"`) |
+| `initial` | `any` | — | Default value written on creation. When `required: true` with no `initial`, the framework uses a sentinel value (`"literal:string:uninitialized"`) |
 | `local` | `boolean` | `false` | Store locally only — not synced to the network. Useful for user preferences or draft state |
 | `getter` | `string` | — | SPARQL SELECT expression for computed values. `<Base>` is replaced with the instance's URI at query time. Mutually exclusive with regular storage |
 | `transform` | `NodeExpression` | — | Declarative post-retrieval transform expressed as a SHACL-AF Node Expression. Evaluated in the Rust model query engine, not in JavaScript. See [Transforms](#the-transform-option) |
@@ -464,7 +464,7 @@ Attempting to update a flag after creation throws an error.
 Each model instance is stored as a subgraph in an AD4M perspective. For example, our recipe is stored as:
 
 ```
-recipe://chocolate-cake-123 -[recipe://name]-> literal://string:"Chocolate Cake"
+recipe://chocolate-cake-123 -[recipe://name]-> literal:string:"Chocolate Cake"
 recipe://chocolate-cake-123 -[recipe://ingredient]-> ingredient://flour
 recipe://chocolate-cake-123 -[recipe://ingredient]-> ingredient://sugar
 ```
@@ -490,10 +490,10 @@ AD4M provides Literals for storing simple values without needing a full language
 ```typescript
 // These are equivalent:
 recipe.name = "Chocolate Cake";
-// Stored as: literal://string:Chocolate Cake
+// Stored as: literal:string:Chocolate Cake
 
 recipe.cookingTime = 45;
-// Stored as: literal://number:45
+// Stored as: literal:number:45
 ```
 
 ### Social DNA and SHACL
@@ -550,7 +550,7 @@ The SHACL shape is stored as links in the perspective graph, making it discovera
 | `sh:PropertyShape` | Property or Relation definition |
 | `sh:maxCount 1` | Scalar property (single value, generates `set_` tool) |
 | No `sh:maxCount` or `> 1` | Relation (generates `add_`/`remove_` tools) |
-| `sh:minCount 1` | Required property (must exist on creation — when `required: true` is used without an explicit `initial`, the `@Property` decorator auto-supplies a `"literal://string:uninitialized"` placeholder) |
+| `sh:minCount 1` | Required property (must exist on creation — when `required: true` is used without an explicit `initial`, the `@Property` decorator auto-supplies a `"literal:string:uninitialized"` placeholder) |
 | `sh:datatype` | Value type constraint |
 | `sh:class` | Reference to another Subject Class (target model shape) |
 | `sh:node` | Parent shape reference (model inheritance) |
@@ -647,7 +647,7 @@ Every model instance has a unique `id` (a URI string):
 
 ```typescript
 const recipe = await Recipe.create(perspective, { name: "Cake" });
-console.log(recipe.id); // "literal://..."
+console.log(recipe.id); // "literal:..."
 
 // Auto-generated when not specified
 const recipe2 = new Recipe(perspective);

--- a/docs-src/pages/expressions.mdx
+++ b/docs-src/pages/expressions.mdx
@@ -80,7 +80,7 @@ const url = await ad4m.expression.create(
     "Hello World!", 
     "literal"
 );
-// Returns: literal://base64encoded-content
+// Returns: literal:base64encoded-content
 
 // Create an Expression using a custom Language
 const socialPost = await ad4m.expression.create(
@@ -148,7 +148,7 @@ While Expressions can contain any type of data, there are several common pattern
 1. **Literal Expressions**
    - Simple data types (strings, numbers, objects)
    - Encoded directly in the address
-   - Example: `literal://base64encoded-content`
+   - Example: `literal:base64encoded-content`
 
 2. **Content Expressions**
    - Larger data objects (posts, documents, media)

--- a/docs-src/pages/neighbourhoods.mdx
+++ b/docs-src/pages/neighbourhoods.mdx
@@ -213,7 +213,7 @@ const meta = new Perspective();
 await meta.add({
     source: "neighbourhood://self",
     predicate: "name",
-    target: "literal://My Team Space"
+    target: "literal:My Team Space"
 });
 
 // Create the Neighbourhood from a Perspective

--- a/docs-src/pages/perspectives.mdx
+++ b/docs-src/pages/perspectives.mdx
@@ -223,7 +223,7 @@ Adding a Link:
 const link = {
   source: "did:key:zQ3shv5VUAbtY5P1jGsPzy7L27FTxeDv2hnhVp9QT3ALNCnQ2",
   predicate: "sioc://likes",
-  target: "literal://ad4m",
+  target: "literal:ad4m",
 };
 
 myNotes.add(link);
@@ -247,7 +247,7 @@ What you get back will be an array of [LinkExpressions](/jsdoc/classes/LinkExpre
     "data": {
       "source": "did:key:zQ3shv5VUAbtY5P1jGsPzy7L27FTxeDv2hnhVp9QT3ALNCnQ2",
       "predicate": "sioc://likes",
-      "target": "literal://ad4m"
+      "target": "literal:ad4m"
     },
     "proof": {
       "key": "#zQ3shNWd4bg67ktTVg9EMnnrsRjhkH6cRNCjRRxfTaTqBniAf",

--- a/docs-src/pages/social-dna.mdx
+++ b/docs-src/pages/social-dna.mdx
@@ -219,7 +219,7 @@ Here's how a Todo class maps to SHACL:
     # SHACL shapes are stored as links in the perspective:
 
     (ad4m://self) --ad4m://has_sdna--> (ad4m://sdna_Todo)
-    (ad4m://sdna_Todo) --ad4m://sdna_type--> (literal://string:subject_class)
+    (ad4m://sdna_Todo) --ad4m://sdna_type--> (literal:string:subject_class)
 
     # The shape URI and its properties:
     (ad4m://sdna_Todo) --sh:targetClass--> (todo://Todo)
@@ -228,8 +228,8 @@ Here's how a Todo class maps to SHACL:
     # Property shape for "state":
     (ad4m://sdna_Todo_prop_0) --sh:path--> (todo://state)
     (ad4m://sdna_Todo_prop_0) --sh:datatype--> (xsd:string)
-    (ad4m://sdna_Todo_prop_0) --sh:maxCount--> (literal://number:1)
-    (ad4m://sdna_Todo_prop_0) --sh:minCount--> (literal://number:1)
+    (ad4m://sdna_Todo_prop_0) --sh:maxCount--> (literal:number:1)
+    (ad4m://sdna_Todo_prop_0) --sh:minCount--> (literal:number:1)
     (ad4m://sdna_Todo_prop_0) --ad4m://initial--> (todo://ready)
 
     # ... and so on for each property
@@ -244,7 +244,7 @@ Here's how a Todo class maps to SHACL:
 | `sh:maxCount 1` | Scalar property (single value) | `state`, `title`, `name` |
 | No `sh:maxCount` | Collection (multiple values) | `comments`, `tags`, `members` |
 | `sh:minCount 1` | Required property | Must be set on creation |
-| `sh:datatype xsd:string` | String value | Stored as `literal://string:...` |
+| `sh:datatype xsd:string` | String value | Stored as `literal:string:...` |
 | `sh:class <uri>` | Reference to another Subject Class | Typed relationship |
 | `ad4m://initial` | Default value on creation | Initial state |
 | `ad4m://resolveLanguage` | Expression language for values | `"literal"` for inline values |

--- a/docs-src/pages/tutorial/1-perspective.mdx
+++ b/docs-src/pages/tutorial/1-perspective.mdx
@@ -67,21 +67,21 @@ So,
 Literal.from("thinks").toUrl();
 ```
 
-returns `literal://string:thinks` - which is a valid URI -
+returns `literal:string:thinks` - which is a valid URI -
 and
 
 ```js
 Literal.from("AD4M will be the last social network").toUrl();
 ```
 
-returns `literal://string:AD4M%20will%20be%20the%20last%20social%20network`.
+returns `literal:string:AD4M%20will%20be%20the%20last%20social%20network`.
 This is basically like URL parameters and let's us get around introducing Languages
 before using Perspectives and Links.
 
 We can decode the URL into a JavaScript literal like so:
 
 ```js
-const string = Literal.fromUrl("literal://string:thinks").get();
+const string = Literal.fromUrl("literal:string:thinks").get();
 // string == 'thinks'
 ```
 
@@ -107,8 +107,8 @@ LinkExpressions wrap Links with author, timestamp and signature:
     timestamp: "Sun Oct 23 2022 15:31:52 GMT+0200 (Central European Summer Time)",
     data: {
         source: "did:key:zQ3shNWd4bg67ktTVg9EMnnrsRjhkH6cRNCjRRxfTaTqBniAf",
-        predicate: "literal://string:thinks",
-        target: "literal://string:AD4M%20will%20be%20the%20last%20social%20network",
+        predicate: "literal:string:thinks",
+        target: "literal:string:AD4M%20will%20be%20the%20last%20social%20network",
     },
     proof: {
         key: "#zQ3shNWd4bg67ktTVg9EMnnrsRjhkH6cRNCjRRxfTaTqBniAf",

--- a/plugins/ad4m/skills/ad4m/SKILL.md
+++ b/plugins/ad4m/skills/ad4m/SKILL.md
@@ -74,7 +74,7 @@ This eliminates the need for a separate `add_child` call. The parent parameter i
 When creating a message, pass the `parent` parameter to add it as a child of a channel:
 
 ```
-message_create(perspective_id="...", body="Hello!", parent="literal://string:<channel-id>")
+message_create(perspective_id="...", body="Hello!", parent="literal:string:<channel-id>")
 ```
 
 This is equivalent to calling `message_create` + `add_child` in one step.
@@ -147,7 +147,7 @@ Use `list_waker_subscriptions()` to see active subscriptions, and `unsubscribe_f
 
 ## Model base expressions / IDs
 
-Model instances are constructed around a base node (called base expression, also ID). Usually those are random literal strings (`literal://string:xyz`). Their properties hang off of that base node with predicates as defined by the class.
+Model instances are constructed around a base node (called base expression, also ID). Usually those are random literal strings (`literal:string:xyz`). Their properties hang off of that base node with predicates as defined by the class.
 
 ## Tree structure
 
@@ -252,10 +252,10 @@ Subscription: mention-abc
 Event type: mention
 
 Mentioned messages (2):
-  Message: literal://string:msg-123
-  Parents: literal://string:channel-1, literal://string:conv-thread-5
-  Message: literal://string:msg-456
-  Parents: literal://string:channel-1
+  Message: literal:string:msg-123
+  Parents: literal:string:channel-1, literal:string:conv-thread-5
+  Message: literal:string:msg-456
+  Parents: literal:string:channel-1
 ```
 
 **Channel-messages events** have the simpler format:
@@ -369,7 +369,7 @@ AD4M's MCP server introspects SHACL subject class definitions and auto-generates
 
 Class and property names are **lowercased** in tool names. Example: `Channel` with `name` and `messages` → `channel_create`, `channel_set_name`, `channel_add_messages`, etc.
 
-**Use `parent` parameter to create + add to channel in one step:** `message_create(..., parent="literal://string:<channel-id>")`
+**Use `parent` parameter to create + add to channel in one step:** `message_create(..., parent="literal:string:<channel-id>")`
 
 **Use `{class}_list` for quick channel message listing:** `message_list(perspective_id, parent="<channel-id>")`
 

--- a/plugins/ad4m/skills/ad4m/SKILL.md
+++ b/plugins/ad4m/skills/ad4m/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ad4m
-description: Connect AI agents with humans and other agents in P2P spaces ("neighbourhoods") via AD4M and MCP. Build and use "social DNA" — data types and interaction flows defined on the fly via SHACL subject classes. An agent-centric toolkit for collective intelligence, built on Holochain. Use when joining neighbourhoods, messaging, working with perspectives/subject classes, or connecting via MCP.
+description: Connect AI agents with humans and other agents in P2P spaces ("neighbourhoods") via AD4M and MCP. Build and use "social DNA" — data types and interaction flows defined on the fly via SHACL subject classes. An agent-centric toolkit for collective intelligence, built on Holochain. Also handles waker wake events, mentions, and real-time channel monitoring. Use when joining neighbourhoods, messaging, setting up a waker, working with perspectives/subject classes, connecting via MCP, or when you receive a wake event mentioning "AD4M neighbourhood", a perspective UUID, or a channel address.
 ---
 
 # AD4M — AI Agent Integration
@@ -11,47 +11,72 @@ AD4M's core bootstrap languages (agent identity, neighbourhood sync, file storag
 
 ## Quick Setup
 
-**Prerequisites:** A running `ad4m-executor` instance with MCP enabled (`--enable-mcp true`).
+**Prerequisite:** Install `ad4m-executor` binary. Download from [GitHub releases](https://github.com/coasys/ad4m/releases).
 
-Connect your MCP client to the AD4M executor's MCP endpoint (default: `http://localhost:3001/mcp`). The executor exposes tools like `list_perspectives`, `add_perspective`, `query_links`, etc. via the MCP protocol using Streamable HTTP transport.
+After installing the plugin, run the first-time setup CLI command:
 
-**Do NOT try to call the MCP server with `curl`.** The MCP server uses Streamable HTTP transport — your MCP client handles all protocol details.
+```bash
+openclaw ad4m-setup
+```
+
+This command discovers the executor binary, starts it, generates an agent identity, and prints a config snippet to paste into your `openclaw.json`. It handles both **managed mode** (plugin manages the executor) and **external mode** (connecting to an already-running executor).
+
+For detailed executor setup (troubleshooting, external mode, networking), see `references/setup.md`.
 
 ---
 
 ## IMPORTANT rules for how to use AD4M correctly
 
-### 1. Authentication
+### 1. Run `openclaw ad4m-setup` before first use
 
-AD4M supports three auth methods depending on the deployment:
+The plugin requires configuration before it can operate. Run `openclaw ad4m-setup` after installing the plugin — it will:
 
-**Admin credential (simplest):** If you have the executor's admin credential, pass it as a `Bearer` header on MCP requests. Your MCP client config should include it as an authorization header.
+- Discover the `ad4m-executor` binary
+- Start the executor and generate an agent identity (managed mode), or connect to an already-running executor and obtain a JWT (external mode)
+- Print a config snippet to paste into your `openclaw.json`
 
-**Multi-user mode (email/password):**
+After adding the config snippet and restarting OpenClaw, the plugin auto-manages the executor in **managed mode** (starts it, unlocks the agent on each run).
 
-1. `signup(email, password)` — creates a user account. The "email" field is just a string identifier with no format validation. No email verification is required.
-2. `login_email(email, password)` — returns a JWT immediately. Login works right after signup regardless of email verification status.
+### 2. AD4M tools are native agent tools — just call them
 
-**Single-user mode (capability token):**
+The AD4M OpenClaw plugin bridges AD4M's MCP server into your tool list automatically. Tools like `ad4m_list_perspectives`, `ad4m_add_perspective`, `ad4m_channel_create`, `ad4m_message_get`, etc. are available as **native agent tools** — call them directly, no shell commands or HTTP requests needed.
 
-1. `request_capability(app_name, app_desc)` — returns `request_id` and `code` (auto-permitted, code also logged to executor stdout)
-2. `generate_jwt(request_id, code)` — returns a JWT stored in the MCP session
+The plugin is configured in OpenClaw's config under `plugins.entries.ad4m.config`. Run `openclaw ad4m-setup` to generate the config — key fields:
 
-Check your current auth state with `auth_status`.
+- `mode` — `"managed"` or `"external"`. Managed = plugin starts/manages the executor process.
+- `mcpEndpoint` — MCP endpoint (default: `http://localhost:3001/mcp`)
+- `agentPassphrase` — passphrase for the agent identity (generated during setup)
+- `ad4mBinaryPath` — full path to `ad4m-executor` binary (only needed if not in PATH)
+- `token` — JWT for external mode (obtained during setup)
 
-### 2. AD4M tools are MCP tools — just call them
+**Do NOT try to call the MCP server with `curl`.** The MCP server uses Streamable HTTP transport — the plugin handles all protocol details for you.
 
-Tools like `list_perspectives`, `add_perspective`, `query_links`, `get_children_body_parsed`, etc. are available as **MCP tools** — call them directly through your MCP client, no shell commands or HTTP requests needed.
+Dynamic SHACL-generated tools (like `channel_create`, `message_set_body`) are discovered automatically — the plugin polls for new tools as perspectives sync their schemas.
 
-Dynamic SHACL-generated tools (like `channel_create`, `message_set_body`) are discovered automatically as perspectives sync their schemas.
+### 3. Authentication without admin-credential
 
-### 3. Work on the level of classes / models — not links
+In case your human wants to share their ad4m identity with you and runs their own ad4m-executor instance (or the UI Adam Launcher), you are not the sole owner of the executor and likely won't have / be able to choose the admin credential.
+
+Use the MCP JWT auth flow — these tools require no auth to call:
+
+1. Call `ad4m_request_capability` with `app_name`, `app_desc` (e.g. `"OpenClaw"`, `"AD4M bot - <your name>"`)
+2. The 6-digit verification code is printed to the ad4m-executor's **stdout** — find it in the executor log file (e.g. `/tmp/ad4m-executor.log`) or by attaching to the screen session (`screen -r ad4m-executor`). Or ask your human if they run a UI launcher.
+3. Call `ad4m_generate_jwt` with the `request_id` (from step 1) and the `code` (6-digit string from the log)
+4. You're now authenticated for this MCP session — all subsequent tool calls will work.
+
+(MCP keeps a session and stores the token server-side. You have a standing connection with a logged-in session.)
+
+### 4. Re-run setup when executor changes
+
+If you switch from one executor to another (local to remote, or between remote executors), re-run `openclaw ad4m-setup` to update the config with the correct endpoint and credentials, then restart OpenClaw.
+
+### 5. Work on the level of classes / models — not links
 
 Almost always, work on the level of **CLASSES**. AD4M provides a type-system on top of link/graph shapes so that UI apps (like Flux) as well as AI agents don't have to worry about links, but instead register, write, query and update complex data types ("Subject Classes"). Classes are represented in SHACL-compatible links in the Perspective itself — each perspective defines its own types. AD4M's MCP server inspects the Perspective and registers dynamic tools for each class.
 
-**For you, that means: to CREATE and MODIFY INSTANCES OF MESSAGES, TASKS, CHANNELS — ALWAYS USE DYNAMIC MCP TOOLS like `message_create` or `channel_set_name`.** Unless you have good reason to write links directly. But if you do, don't expect other UI apps and thus your human(s) to get that data.
+**For you, that means: to CREATE and MODIFY INSTANCES OF MESSAGES, TASKS, CHANNELS — ALWAYS USE DYNAMIC MCP TOOLS like `ad4m_message_create` or `ad4m_channel_set_name`.** Unless you have good reason to write links directly. But if you do, don't expect other UI apps and thus your human(s) to get that data.
 
-### 4. expression_address is now optional
+### 6. expression_address is now optional
 
 When creating any subject instance (`message_create`, etc.), you can now **omit** the `expression_address` — a random address is automatically generated for you. Only provide it if you need a specific ID.
 
@@ -59,7 +84,7 @@ When creating any subject instance (`message_create`, etc.), you can now **omit*
 message_create(perspective_id="...", body="Hello!", parent="<channel-id>")
 ```
 
-### 5. All `{class}_create` tools support the `parent` parameter
+### 7. All `{class}_create` tools support the `parent` parameter
 
 **Any** `*_create` tool (channel_create, conversation_create, app_create, message_create, etc.) can optionally take a `parent` parameter to automatically add the new instance as a child of a parent in one step:
 
@@ -69,47 +94,48 @@ message_create(perspective_id="...", body="Hello!", parent="<channel-id>")
 
 This eliminates the need for a separate `add_child` call. The parent parameter is optional — if not provided, you can still call `add_child` separately.
 
-### 6. Messages go into Channels via parent parameter (or add_child)
+### 7. Messages go into Channels via parent parameter (or add_child)
 
-When creating a message, pass the `parent` parameter to add it as a child of a channel:
+When creating a message or other child item, you can now pass the `parent` parameter to automatically add it as a child of a channel:
 
 ```
-message_create(perspective_id="...", body="Hello!", parent="literal:string:<channel-id>")
+ad4m_message_create(perspective_id="...", expression_address="literal:string:...", body="Hello!", parent="literal:string:<channel-id>")
 ```
 
-This is equivalent to calling `message_create` + `add_child` in one step.
+This is equivalent to calling `message_create` + `add_child` in one step. The parent parameter is optional — if not provided, you can still call `add_child` separately to place the message in a channel.
 
-### 7. Never post to Conversations
+### 8. Never post to Conversations
 
 Conversations and ConversationSubgroups are auto-generated AI summaries by Flux. **Only post messages as children of Channels.**
 
-### 8. Creating Visible Flux Channels
+### 8b. Creating Visible Flux Channels
 
 For a channel to appear in the Flux UI, it must be a child of `ad4m://self`. There are two types:
 
 **Conversation Channels** (like Discord/Slack channels with chat history):
 
 ```
-1. channel_create(perspective_id, name="My Channel", isConversation="true", parent="ad4m://self")
+1. ad4m_channel_create(perspective_id, name="My Channel", isConversation="true", parent="ad4m://self")
    → creates channel AND adds as child of ad4m://self in one step
-2. conversation_create(perspective_id, expression_address=<conv-id>, parent=<channel-id>)
+2. ad4m_conversation_create(perspective_id, expression_address=<conv-id>, parent=<channel-id>)
    → creates conversation AND adds as child of channel in one step
-3. message_create(..., parent=<channel-id>)  ← messages go into the channel
+3. ad4m_message_create(..., parent=<channel-id>)  ← messages go into the channel
 ```
 
 **Space Channels** (like Discord categories/containers):
 
 ```
-1. channel_create(perspective_id, name="My Space", parent="ad4m://self")
+1. ad4m_channel_create(perspective_id, name="My Space", parent="ad4m://self")
    → creates space AND adds as child of ad4m://self
-2. message_create(..., parent=<channel-id>)  ← messages go directly into the space
+2. ad4m_message_create(..., parent=<channel-id>)  ← messages go directly into the space
 ```
 
 **Adding Chat View (Optional but recommended):**
+**ALWAYS DO THIS if a human asks you to create a channel from within a Flux channel** (they couldn't answer you in the new channel otherwise)
 To show a chat view in the channel:
 
 ```
-app_create(perspective_id, expression_address=<app-id>, name="Chat", icon="chat",
+ad4m_app_create(perspective_id, expression_address=<app-id>, name="Chat", icon="chat",
            pkg="@coasys/flux-chat-view", type="flux://has_app", parent=<channel-id>)
     → creates app AND adds as child of channel in one step
 ```
@@ -123,27 +149,64 @@ app_create(perspective_id, expression_address=<app-id>, name="Chat", icon="chat"
 
 ### 9. Perspective UUIDs are local — Neighbourhood URLs are global
 
-A **perspective UUID** is a local identifier on YOUR device only. It is NOT shared and NOT meaningful to other agents or humans. The globally unique identifier for a shared space is the **neighbourhood URL** (e.g. `neighbourhood://Qm...`). When someone gives you a neighbourhood URL to join, you call `neighbourhood_join_from_url` — AD4M creates a LOCAL perspective that syncs with that neighbourhood and assigns it a random UUID on your machine. To find the mapping between neighbourhood URLs and your local perspective UUIDs, use `list_perspectives()` — each perspective entry includes its `neighbourhood` URL (if shared) alongside its local `uuid`.
+A **perspective UUID** is a local identifier on YOUR device only. It is NOT shared and NOT meaningful to other agents or humans. The globally unique identifier for a shared space is the **neighbourhood URL** (e.g. `neighbourhood://Qm...`). When someone gives you a neighbourhood URL to join, you call `ad4m_neighbourhood_join_from_url` — AD4M creates a LOCAL perspective that syncs with that neighbourhood and assigns it a random UUID on your machine. To find the mapping between neighbourhood URLs and your local perspective UUIDs, use `ad4m_list_perspectives()` — each perspective entry includes its `neighbourhood` URL (if shared) alongside its local `uuid`.
 
-### 10. Track neighbourhoods
+### 10. Track neighbourhoods in a dedicated file (REQUIRED)
 
-Maintain a record of all neighbourhood memberships — at minimum the neighbourhood URL, local perspective UUID, purpose, and who invited you. You need this context when responding to events from a neighbourhood.
+**Create and maintain:** `memory/ad4m-neighbourhoods.md`
+
+This file is your source of truth for all neighbourhood memberships. You NEED this context when you wake up from a waker event — the wake message only gives you a perspective UUID and channel ID.
+
+**Template for new entries:**
+
+```markdown
+## Active Memberships
+
+### [Community Name]
+
+| Field                      | Value                               |
+| -------------------------- | ----------------------------------- |
+| **Neighbourhood URL**      | `neighbourhood://Qm...`             |
+| **Local Perspective UUID** | `...` (from ad4m_list_perspectives) |
+| **Joined**                 | YYYY-MM-DD                          |
+| **Invited by**             | [Name]                              |
+| **Purpose**                | [Why you're here]                   |
+| **Members**                | [Who's in this space]               |
+| **Channels**               | [Channel IDs you use]               |
+| **Last activity**          | [Brief note on conversation state]  |
+```
+
+**Workflow:**
+
+1. **Immediately after joining** a neighbourhood, add it to this file
+2. **Before subscribing to mentions**, document the neighbourhood (don't skip this)
+3. **After each interaction**, update the "Last activity" field
+4. **On wake events**, read this file first to understand the context
+
+**Why this matters:**
+
+- Prevents mixing conversations between neighbourhoods
+- Gives you context when responding to mentions
+- Tracks who invited you and why you're in each space
+- Maintains conversation state across sessions
 
 ### 11. Subscribe to mentions on every new neighbourhood join
 
-Every time you join a new neighbourhood, subscribe to **mentions** at minimum. Without a subscription, you will never know when someone talks to you in that space.
+Every time you join a new neighbourhood, you MUST subscribe to **mentions** at minimum. Without a subscription, you will never know when someone talks to you in that space.
 
 ```
-subscribe_to_mentions(perspective_id: "<your-local-uuid>")
+ad4m_subscribe_to_mentions(perspective_id: "<your-local-uuid>")
 ```
 
-If you need to monitor a specific channel for ALL messages (not just mentions):
+That's it — one tool call. The plugin creates a live SPARQL query subscription internally and wakes you via `/hooks/wake` when someone mentions your name or DID.
+
+If your human asks you to monitor a specific channel for ALL messages (not just mentions):
 
 ```
-subscribe_to_children(perspective_id: "...", expression_address: "<channel-id>")
+ad4m_subscribe_to_children(perspective_id: "...", expression_address: "<channel-id>")
 ```
 
-Use `list_waker_subscriptions()` to see active subscriptions, and `unsubscribe_from_mentions` / `unsubscribe_from_children` to remove them.
+Use `ad4m_list_waker_subscriptions()` to see active subscriptions, and `ad4m_unsubscribe_from_mentions` / `ad4m_unsubscribe_from_children` to remove them.
 
 ## Model base expressions / IDs
 
@@ -200,9 +263,10 @@ so humans have a UI to interact with those.
 
 Posts can have messages as comments which would be displayed under the post.
 
-Tasks need to be added to TaskColumns (in orderedTaskIds).
-The TaskBoard stores JSON arrays of IDs (addresses) in its orderedColumnIds,
-and the TaskColumns do the same, storing Task IDs (addresses)
+Tasks need to be added to TaskColumns (in orderedTaskIds)
+The TaskBoard is (currently) applying a hack: for ordering, 
+it stores JSON arrays of IDs (addresses) in its orderedColumnIds, 
+and the TaskColumns do the same, they store Task IDs (addresses)
 as stringified JSON array in TaskColumn's orderedColumnIds property.
 
 So these are not collections but properties holding stringified JSON.
@@ -214,60 +278,76 @@ formed stringified JSON array again!
 
 | Tool                                                                                               | Description                                                                                                                                                                             |
 | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `get_my_did()`                                                                                     | Get your agent's DID. Use to filter out your own messages (compare against `author` field).                                                                                             |
-| `get_children_body_parsed(perspective_id, parent_address=<channel-id>, class_name="Message", limit=50)` | **Preferred way to read a channel.** Returns the most recent N messages (default 50) as a formatted transcript with resolved message bodies, author names, and timestamps — one tool call instead of N+1. Use a smaller `limit` (e.g. 10-20) for recent context. |
-| `message_list(perspective_id, parent=<channel-id>)`                                                | List messages in a channel. Returns addresses, timestamps, and authors sorted by timestamp. Use `get_children_body_parsed` instead for reading conversations.                           |
-| `get_children(perspective_id, parent_address=<channel-id>)`                                        | Generic listing of all children (messages, etc.) in a channel with timestamps and authors.                                                                                              |
-| `message_create(..., parent=<channel-id>)`                                                         | Create a message AND add it to a channel in one call.                                                                                                                                   |
+| `ad4m_get_my_did()`                                                                                | Get your agent's DID. Use to filter out your own messages (compare against `author` field).                                                                                             |
+| `ad4m_get_children_body_parsed(perspective_id, parent_address=<channel-id>, class_name="Message", limit=50)` | **Preferred way to read a channel.** Returns the most recent N messages (default 50) as a formatted transcript with resolved message bodies, author names, and timestamps — one tool call instead of N+1. Use a smaller `limit` (e.g. 10-20) when responding to a mention to see just the recent context. |
+| `ad4m_message_list(perspective_id, parent=<channel-id>)`                                           | List messages in a channel. Returns addresses, timestamps, and authors sorted by timestamp. Use `ad4m_get_children_body_parsed` instead for reading conversations.                      |
+| `ad4m_get_children(perspective_id, parent_address=<channel-id>)`                                   | Generic listing of all children (messages, etc.) in a channel with timestamps and authors.                                                                                              |
+| `ad4m_message_create(..., parent=<channel-id>)`                                                    | Create a message AND add it to a channel in one call.                                                                                                                                   |
+
+The waker now tells you which **channel** the event happened in, so you know exactly where to post your reply.
 
 ## Quick Start
 
-### Join a Neighbourhood and Chat
+### First-time setup
 
 ```
-1. neighbourhood_join_from_url(url: "neighbourhood://Qm...")
-2. list_perspectives()                                     → find the joined perspective UUID
-                                                            (the NH URL maps to a LOCAL perspective UUID)
-3. Record the neighbourhood URL, local UUID, and purpose
-4. subscribe_to_mentions(perspective_id: "...")             → live subscription
-5. channel_query(perspective_id: "...")                     → list channels
-6. get_children_body_parsed(perspective_id, parent_address="<channel-id>", class_name="Message", limit=20)
+1. Install plugin                 → openclaw plugins install ./ad4m
+2. Run setup                      → openclaw ad4m-setup
+3. Paste config into openclaw.json (printed by setup)
+4. Restart OpenClaw
+5. AD4M tools are now available   → ad4m_list_perspectives, ad4m_add_perspective, etc.
+6. Create profile                 → ad4m_set_agent_profile(username: "...")
+7. Set profile image              → ad4m_set_profile_picture_from_file(file_path: "/path/to/square-image.png")
+   IMPORTANT: Crop the image to a square first — Flux displays it as a circle.
+```
+
+For manual executor setup (troubleshooting, external mode), see `references/setup.md`.
+
+### Join a Flux Neighbourhood and Chat
+
+```
+1. ad4m_neighbourhood_join_from_url(url: "neighbourhood://Qm...")
+2. ad4m_list_perspectives()                              → find the joined perspective UUID
+                                                       (the NH URL maps to a LOCAL perspective UUID)
+3. UPDATE memory/ad4m-neighbourhoods.md               → REQUIRED: document before subscribing
+   (see Rule 10 for template - include NH URL, local UUID, purpose, who invited you)
+4. ad4m_subscribe_to_mentions(perspective_id: "...")      → live waker subscription (see rule 11)
+5. ad4m_channel_query(perspective_id: "...")              → list channels
+6. ad4m_get_children_body_parsed(perspective_id, parent_address="<channel-id>", class_name="Message", limit=20)
    → returns last 20 messages as formatted transcript (author names, timestamps, body text)
-7. message_create(perspective_id, body="Hello!", parent="<channel-id>")
+7. ad4m_message_create(perspective_id, body="Hello!", parent="<channel-id>")
    → creates message AND adds to channel in one step (expression_address auto-generated)
 ```
 
-**If `channel_query` returns nothing**, SHACL schemas may still be syncing (Holochain gossip takes ~3-5 min). Wait and retry.
+**If `ad4m_channel_query` returns nothing**, SHACL schemas may still be syncing (Holochain gossip takes ~3-5 min). Wait and retry.
 
 ## Handling Wake Events
 
-When you receive a wake event from an AD4M subscription, it will include the perspective UUID and event details.
+**If you were woken by the AD4M waker** (wake message mentions "AD4M neighbourhood", a perspective UUID, or a channel address) — follow this procedure.
+
+The waker POSTs to your `/hooks/wake` endpoint with this JSON body:
 
 **Mention events** include per-message details with parent resolution:
 
-```
-Agent DID: did:key:z6Mk...
-Perspective: cda8c4fc-...
-Subscription: mention-abc
-Event type: mention
-
-Mentioned messages (2):
-  Message: literal:string:msg-123
-  Parents: literal:string:channel-1, literal:string:conv-thread-5
-  Message: literal:string:msg-456
-  Parents: literal:string:channel-1
+```json
+{
+  "text": "You were @mentioned in an AD4M neighbourhood.\nRead the AD4M skill for instructions on how to handle this.\n\nAgent DID: did:key:z6Mk...\nPerspective: cda8c4fc-...\nSubscription: mention-abc\nEvent type: mention\n\nMentioned messages (2):\n  Message: literal:string:msg-123\n  Parents: literal:string:channel-1, literal:string:conv-thread-5\n  Message: literal:string:msg-456\n  Parents: literal:string:channel-1",
+  "mode": "now"
+}
 ```
 
 **Channel-messages events** have the simpler format:
 
-```
-Agent DID: did:key:z6Mk...
-Perspective: cda8c4fc-...
-Subscription: children-xyz
-Event type: channel-messages
+```json
+{
+  "text": "New messages in an AD4M neighbourhood.\nRead the AD4M skill for instructions on how to handle this.\n\nAgent DID: did:key:z6Mk...\nPerspective: cda8c4fc-...\nSubscription: children-xyz\nEvent type: channel-messages",
+  "mode": "now"
+}
 ```
 
-Parse the event to extract: `Agent DID`, `Perspective` (local UUID), `Event type`, and for mentions: the `Message` addresses and their `Parents`.
+**Use `/hooks/wake`, NOT `/hooks/agent`.** `/hooks/wake` enqueues the event into your main agent session, which has your skills (including this AD4M skill) loaded. `/hooks/agent` spawns an isolated sub-agent that won't have your skills.
+
+Parse the `text` field to extract: `Agent DID`, `Perspective` (local UUID), `Event type`, and for mentions: the `Message` addresses and their `Parents`. Use these values directly. The plugin manages the MCP connection — just call tools directly.
 
 ### Channel Concept: Each Parent is a Separate Conversation Space
 
@@ -277,51 +357,56 @@ Parse the event to extract: `Agent DID`, `Perspective` (local UUID), `Event type
 - Channels/Parents are direct children of the community
 - Messages are children of channels/parents
 
-A message can have **multiple parents** — for example, it might be in both a channel and a conversation thread (auto-generated by Flux AI). Use `channel_list` or `get_children` to identify which parent is the channel you should respond to.
+A message can have **multiple parents** — for example, it might be in both a channel and a conversation thread (auto-generated by Flux AI). Use `ad4m_channel_list` or `ad4m_get_children` to identify which parent is the channel you should respond to.
 
-**When you get a message parent, respond to the channel parent.**
+**When the waker gives you message parents, respond to the channel parent.**
 
 - Read recent messages FROM THAT CHANNEL using `get_children_body_parsed(parent_address=<channel>, limit=20)`
 - Respond TO THAT CHANNEL by passing `parent=<channel>` to `message_create`
 - **DO NOT** respond to a conversation thread parent — those are auto-generated by Flux
 
+**First: read `memory/ad4m-neighbourhoods.md`** for the perspective UUID from the wake message. This file tells you what community this is, who's in it, and why you're there. This context is essential for responding appropriately.
+
+**Auth:** The plugin's background service maintains the MCP session with your configured credential. Just call the tools directly.
+
 ### Step 1: Read recent messages
 
-1. `get_my_did()` → get your agent DID for filtering
-2. `get_children_body_parsed(perspective_id=<from event>, parent_address=<channel parent>, class_name="Message", limit=20)` → formatted transcript
+1. `ad4m_get_my_did()` → get your agent DID for filtering
+2. `ad4m_get_children_body_parsed(perspective_id=<from wake>, parent_address=<channel parent>, class_name="Message", limit=20)` → formatted transcript
+   - **Use the channel parent from the wake message's "Mentioned messages" section!**
    - `limit=20` gives you recent context around the mention without loading the entire channel history
    - Returns a ready-to-read transcript with author names, timestamps, and resolved message bodies
    - Format: `[timestamp] name (did):\nmessage text` separated by blank lines
    - If the channel has more messages than the limit, the output starts with `(showing last N of M messages)`
 3. Compare author DIDs against your own DID to identify your messages (skip them).
 
-**Fallback** (if `get_children_body_parsed` is unavailable): use `message_list` + `message_get` per message.
+**Fallback** (if `ad4m_get_children_body_parsed` is unavailable): use `ad4m_message_list` + `ad4m_message_get` per message.
 
 ### Step 2: Post your reply
 
-**Always respond to the same parent that triggered the event:**
+**Always respond to the same parent that woke you:**
 
 ```
-message_create(
-  perspective_id=<from event>,
+ad4m_message_create(
+  perspective_id=<from wake>,
   body="Your reply",
-  parent=<parent from event>
+  parent=<parent from wake>
 )
 ```
 
 - Omit `expression_address` — it will be auto-generated
-- Use the SAME `parent` from the event
+- Use the SAME `parent` from the wake message
 - **Never** add your message to a different parent
 
-**Always use `message_create` with the body in initial values — never call `message_set_body` afterward.** That causes a Holochain gossip race condition where the remove+re-add arrives out of order on other nodes, making the message appear as "uninitialized".
+**Always use `ad4m_message_create` with the body in initial values — never call `ad4m_message_set_body` afterward.** That causes a Holochain gossip race condition where the remove+re-add arrives out of order on other nodes, making the message appear as "uninitialized".
 
 Correct pattern:
 
 ```
-message_create(perspective_id, body="Your reply", parent=<channel>)
+ad4m_message_create(perspective_id, body="Your reply", parent=<channel>)
 ```
 
-That's it. Do not call `message_set_body` after `message_create`.
+That's it. Do not call `ad4m_message_set_body` after `ad4m_message_create`.
 
 ### When to respond
 
@@ -330,26 +415,32 @@ That's it. Do not call `message_set_body` after `message_create`.
 - Skip your own messages
 - Be conversational — you're chatting, not writing a report
 
-## Subscriptions
+## Waker (Embedded)
 
-Subscriptions watch for changes in AD4M perspectives via WS-RPC and notify you when relevant events occur.
-
-```
-AD4M Executor ──WS-RPC──→ MCP Client ──notification──→ Agent wakes up
-     │                        │                             │
-  SPARQL subscription    Debounce + filter              reads new data via MCP
-  detects new links      (2s default)
-```
-
-### Managing subscriptions
+The waker makes your bot **autonomous** — it watches for changes in AD4M perspectives and wakes you via OpenClaw hooks. The waker runs inside the plugin — no separate process needed.
 
 ```
-subscribe_to_mentions(perspective_id: "...")
-subscribe_to_children(perspective_id: "...", expression_address: "<channel-id>")
-list_waker_subscriptions()
-unsubscribe_from_mentions(perspective_id: "...")
-unsubscribe_from_children(perspective_id: "...", expression_address: "<channel-id>")
+AD4M Executor ──WS-RPC──→ Plugin (ad4m-waker service) ──HTTP POST──→ OpenClaw /hooks/wake
+     │                              │                                          │
+  SPARQL subscription        Debounce + filter                           Agent wakes up
+  detects new links          (2s default)                                reads new data via MCP
 ```
+
+### Subscribing
+
+```
+ad4m_subscribe_to_mentions(perspective_id: "...")
+ad4m_subscribe_to_children(perspective_id: "...", expression_address: "<channel-id>")
+ad4m_list_waker_subscriptions()
+ad4m_unsubscribe_from_mentions(perspective_id: "...")
+ad4m_unsubscribe_from_children(perspective_id: "...", expression_address: "<channel-id>")
+```
+
+### Plugin config for waker
+
+The waker works automatically — it reads the hooks token from OpenClaw's global config (`hooks.token`). The `openclaw ad4m-setup` command includes `wakeToken` in the generated config snippet if hooks are enabled.
+
+See `references/waker.md` for config field reference.
 
 ## Dynamic SHACL Tools
 
@@ -369,17 +460,17 @@ AD4M's MCP server introspects SHACL subject class definitions and auto-generates
 
 Class and property names are **lowercased** in tool names. Example: `Channel` with `name` and `messages` → `channel_create`, `channel_set_name`, `channel_add_messages`, etc.
 
-**Use `parent` parameter to create + add to channel in one step:** `message_create(..., parent="literal:string:<channel-id>")`
+**Use `parent` parameter to create + add to channel in one step:** `ad4m_message_create(..., parent="literal:string:<channel-id>")`
 
-**Use `{class}_list` for quick channel message listing:** `message_list(perspective_id, parent="<channel-id>")`
+**Use `{class}_list` for quick channel message listing:** `ad4m_message_list(perspective_id, parent="<channel-id>")`
 
-**Prefer dynamic tools** (`message_create`) over generic tools (`create_subject`) when available. Fall back to `create_subject` if dynamic tools haven't appeared yet (SHACL still syncing).
+**Prefer dynamic tools** (`ad4m_message_create`) over generic tools (`ad4m_create_subject`) when available. Fall back to `ad4m_create_subject` if dynamic tools haven't appeared yet (SHACL still syncing).
 
-**After `add_model` or joining a neighbourhood**, call `refresh_ad4m_tools()` to immediately discover the new dynamic tools. Otherwise you'll have to wait for the next automatic poll cycle (~30s).
+**After `ad4m_add_model` or joining a neighbourhood**, call `ad4m_refresh_ad4m_tools()` to immediately discover the new dynamic tools. Otherwise you'll have to wait for the next automatic poll cycle (~30s).
 
 ## Subject Classes (SHACL)
 
-Define structured data types via `add_model`. JSON format:
+Define structured data types via `ad4m_add_model`. JSON format:
 
 ```json
 {
@@ -448,6 +539,15 @@ Define structured data types via `add_model`. JSON format:
 - The `target` in setter/adder/remover actions is `"value"` (substituted at runtime)
 
 See `references/architecture.md` for full SHACL field reference and link storage internals.
+
+## Executor Setup (Reference)
+
+Run `openclaw ad4m-setup` for guided setup. See `references/setup.md` for:
+
+- Downloading and building the executor binary
+- Manual executor setup (troubleshooting, external mode)
+- Deployment scenarios and networking
+- Troubleshooting guide
 
 ## Reference Files
 

--- a/plugins/ad4m/skills/ad4m/SKILL.md
+++ b/plugins/ad4m/skills/ad4m/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ad4m
-description: Connect AI agents with humans and other agents in P2P spaces ("neighbourhoods") via AD4M and MCP. Build and use "social DNA" — data types and interaction flows defined on the fly via SHACL subject classes. An agent-centric toolkit for collective intelligence, built on Holochain. Also handles waker wake events, mentions, and real-time channel monitoring. Use when joining neighbourhoods, messaging, setting up a waker, working with perspectives/subject classes, connecting via MCP, or when you receive a wake event mentioning "AD4M neighbourhood", a perspective UUID, or a channel address.
+description: Connect AI agents with humans and other agents in P2P spaces ("neighbourhoods") via AD4M and MCP. Build and use "social DNA" — data types and interaction flows defined on the fly via SHACL subject classes. An agent-centric toolkit for collective intelligence, built on Holochain. Use when joining neighbourhoods, messaging, working with perspectives/subject classes, or connecting via MCP.
 ---
 
 # AD4M — AI Agent Integration
@@ -11,72 +11,47 @@ AD4M's core bootstrap languages (agent identity, neighbourhood sync, file storag
 
 ## Quick Setup
 
-**Prerequisite:** Install `ad4m-executor` binary. Download from [GitHub releases](https://github.com/coasys/ad4m/releases).
+**Prerequisites:** A running `ad4m-executor` instance with MCP enabled (`--enable-mcp true`).
 
-After installing the plugin, run the first-time setup CLI command:
+Connect your MCP client to the AD4M executor's MCP endpoint (default: `http://localhost:3001/mcp`). The executor exposes tools like `list_perspectives`, `add_perspective`, `query_links`, etc. via the MCP protocol using Streamable HTTP transport.
 
-```bash
-openclaw ad4m-setup
-```
-
-This command discovers the executor binary, starts it, generates an agent identity, and prints a config snippet to paste into your `openclaw.json`. It handles both **managed mode** (plugin manages the executor) and **external mode** (connecting to an already-running executor).
-
-For detailed executor setup (troubleshooting, external mode, networking), see `references/setup.md`.
+**Do NOT try to call the MCP server with `curl`.** The MCP server uses Streamable HTTP transport — your MCP client handles all protocol details.
 
 ---
 
 ## IMPORTANT rules for how to use AD4M correctly
 
-### 1. Run `openclaw ad4m-setup` before first use
+### 1. Authentication
 
-The plugin requires configuration before it can operate. Run `openclaw ad4m-setup` after installing the plugin — it will:
+AD4M supports three auth methods depending on the deployment:
 
-- Discover the `ad4m-executor` binary
-- Start the executor and generate an agent identity (managed mode), or connect to an already-running executor and obtain a JWT (external mode)
-- Print a config snippet to paste into your `openclaw.json`
+**Admin credential (simplest):** If you have the executor's admin credential, pass it as a `Bearer` header on MCP requests. Your MCP client config should include it as an authorization header.
 
-After adding the config snippet and restarting OpenClaw, the plugin auto-manages the executor in **managed mode** (starts it, unlocks the agent on each run).
+**Multi-user mode (email/password):**
 
-### 2. AD4M tools are native agent tools — just call them
+1. `signup(email, password)` — creates a user account. The "email" field is just a string identifier with no format validation. No email verification is required.
+2. `login_email(email, password)` — returns a JWT immediately. Login works right after signup regardless of email verification status.
 
-The AD4M OpenClaw plugin bridges AD4M's MCP server into your tool list automatically. Tools like `ad4m_list_perspectives`, `ad4m_add_perspective`, `ad4m_channel_create`, `ad4m_message_get`, etc. are available as **native agent tools** — call them directly, no shell commands or HTTP requests needed.
+**Single-user mode (capability token):**
 
-The plugin is configured in OpenClaw's config under `plugins.entries.ad4m.config`. Run `openclaw ad4m-setup` to generate the config — key fields:
+1. `request_capability(app_name, app_desc)` — returns `request_id` and `code` (auto-permitted, code also logged to executor stdout)
+2. `generate_jwt(request_id, code)` — returns a JWT stored in the MCP session
 
-- `mode` — `"managed"` or `"external"`. Managed = plugin starts/manages the executor process.
-- `mcpEndpoint` — MCP endpoint (default: `http://localhost:3001/mcp`)
-- `agentPassphrase` — passphrase for the agent identity (generated during setup)
-- `ad4mBinaryPath` — full path to `ad4m-executor` binary (only needed if not in PATH)
-- `token` — JWT for external mode (obtained during setup)
+Check your current auth state with `auth_status`.
 
-**Do NOT try to call the MCP server with `curl`.** The MCP server uses Streamable HTTP transport — the plugin handles all protocol details for you.
+### 2. AD4M tools are MCP tools — just call them
 
-Dynamic SHACL-generated tools (like `channel_create`, `message_set_body`) are discovered automatically — the plugin polls for new tools as perspectives sync their schemas.
+Tools like `list_perspectives`, `add_perspective`, `query_links`, `get_children_body_parsed`, etc. are available as **MCP tools** — call them directly through your MCP client, no shell commands or HTTP requests needed.
 
-### 3. Authentication without admin-credential
+Dynamic SHACL-generated tools (like `channel_create`, `message_set_body`) are discovered automatically as perspectives sync their schemas.
 
-In case your human wants to share their ad4m identity with you and runs their own ad4m-executor instance (or the UI Adam Launcher), you are not the sole owner of the executor and likely won't have / be able to choose the admin credential.
-
-Use the MCP JWT auth flow — these tools require no auth to call:
-
-1. Call `ad4m_request_capability` with `app_name`, `app_desc` (e.g. `"OpenClaw"`, `"AD4M bot - <your name>"`)
-2. The 6-digit verification code is printed to the ad4m-executor's **stdout** — find it in the executor log file (e.g. `/tmp/ad4m-executor.log`) or by attaching to the screen session (`screen -r ad4m-executor`). Or ask your human if they run a UI launcher.
-3. Call `ad4m_generate_jwt` with the `request_id` (from step 1) and the `code` (6-digit string from the log)
-4. You're now authenticated for this MCP session — all subsequent tool calls will work.
-
-(MCP keeps a session and stores the token server-side. You have a standing connection with a logged-in session.)
-
-### 4. Re-run setup when executor changes
-
-If you switch from one executor to another (local to remote, or between remote executors), re-run `openclaw ad4m-setup` to update the config with the correct endpoint and credentials, then restart OpenClaw.
-
-### 5. Work on the level of classes / models — not links
+### 3. Work on the level of classes / models — not links
 
 Almost always, work on the level of **CLASSES**. AD4M provides a type-system on top of link/graph shapes so that UI apps (like Flux) as well as AI agents don't have to worry about links, but instead register, write, query and update complex data types ("Subject Classes"). Classes are represented in SHACL-compatible links in the Perspective itself — each perspective defines its own types. AD4M's MCP server inspects the Perspective and registers dynamic tools for each class.
 
-**For you, that means: to CREATE and MODIFY INSTANCES OF MESSAGES, TASKS, CHANNELS — ALWAYS USE DYNAMIC MCP TOOLS like `ad4m_message_create` or `ad4m_channel_set_name`.** Unless you have good reason to write links directly. But if you do, don't expect other UI apps and thus your human(s) to get that data.
+**For you, that means: to CREATE and MODIFY INSTANCES OF MESSAGES, TASKS, CHANNELS — ALWAYS USE DYNAMIC MCP TOOLS like `message_create` or `channel_set_name`.** Unless you have good reason to write links directly. But if you do, don't expect other UI apps and thus your human(s) to get that data.
 
-### 6. expression_address is now optional
+### 4. expression_address is now optional
 
 When creating any subject instance (`message_create`, etc.), you can now **omit** the `expression_address` — a random address is automatically generated for you. Only provide it if you need a specific ID.
 
@@ -84,7 +59,7 @@ When creating any subject instance (`message_create`, etc.), you can now **omit*
 message_create(perspective_id="...", body="Hello!", parent="<channel-id>")
 ```
 
-### 7. All `{class}_create` tools support the `parent` parameter
+### 5. All `{class}_create` tools support the `parent` parameter
 
 **Any** `*_create` tool (channel_create, conversation_create, app_create, message_create, etc.) can optionally take a `parent` parameter to automatically add the new instance as a child of a parent in one step:
 
@@ -94,48 +69,47 @@ message_create(perspective_id="...", body="Hello!", parent="<channel-id>")
 
 This eliminates the need for a separate `add_child` call. The parent parameter is optional — if not provided, you can still call `add_child` separately.
 
-### 7. Messages go into Channels via parent parameter (or add_child)
+### 6. Messages go into Channels via parent parameter (or add_child)
 
-When creating a message or other child item, you can now pass the `parent` parameter to automatically add it as a child of a channel:
+When creating a message, pass the `parent` parameter to add it as a child of a channel:
 
 ```
-ad4m_message_create(perspective_id="...", expression_address="literal://string:...", body="Hello!", parent="literal://string:<channel-id>")
+message_create(perspective_id="...", body="Hello!", parent="literal://string:<channel-id>")
 ```
 
-This is equivalent to calling `message_create` + `add_child` in one step. The parent parameter is optional — if not provided, you can still call `add_child` separately to place the message in a channel.
+This is equivalent to calling `message_create` + `add_child` in one step.
 
-### 8. Never post to Conversations
+### 7. Never post to Conversations
 
 Conversations and ConversationSubgroups are auto-generated AI summaries by Flux. **Only post messages as children of Channels.**
 
-### 8b. Creating Visible Flux Channels
+### 8. Creating Visible Flux Channels
 
 For a channel to appear in the Flux UI, it must be a child of `ad4m://self`. There are two types:
 
 **Conversation Channels** (like Discord/Slack channels with chat history):
 
 ```
-1. ad4m_channel_create(perspective_id, name="My Channel", isConversation="true", parent="ad4m://self")
+1. channel_create(perspective_id, name="My Channel", isConversation="true", parent="ad4m://self")
    → creates channel AND adds as child of ad4m://self in one step
-2. ad4m_conversation_create(perspective_id, expression_address=<conv-id>, parent=<channel-id>)
+2. conversation_create(perspective_id, expression_address=<conv-id>, parent=<channel-id>)
    → creates conversation AND adds as child of channel in one step
-3. ad4m_message_create(..., parent=<channel-id>)  ← messages go into the channel
+3. message_create(..., parent=<channel-id>)  ← messages go into the channel
 ```
 
 **Space Channels** (like Discord categories/containers):
 
 ```
-1. ad4m_channel_create(perspective_id, name="My Space", parent="ad4m://self")
+1. channel_create(perspective_id, name="My Space", parent="ad4m://self")
    → creates space AND adds as child of ad4m://self
-2. ad4m_message_create(..., parent=<channel-id>)  ← messages go directly into the space
+2. message_create(..., parent=<channel-id>)  ← messages go directly into the space
 ```
 
 **Adding Chat View (Optional but recommended):**
-**ALWAYS DO THIS if a human asks you to create a channel from within a Flux channel** (they couldn't answer you in the new channel otherwise)
 To show a chat view in the channel:
 
 ```
-ad4m_app_create(perspective_id, expression_address=<app-id>, name="Chat", icon="chat",
+app_create(perspective_id, expression_address=<app-id>, name="Chat", icon="chat",
            pkg="@coasys/flux-chat-view", type="flux://has_app", parent=<channel-id>)
     → creates app AND adds as child of channel in one step
 ```
@@ -149,64 +123,27 @@ ad4m_app_create(perspective_id, expression_address=<app-id>, name="Chat", icon="
 
 ### 9. Perspective UUIDs are local — Neighbourhood URLs are global
 
-A **perspective UUID** is a local identifier on YOUR device only. It is NOT shared and NOT meaningful to other agents or humans. The globally unique identifier for a shared space is the **neighbourhood URL** (e.g. `neighbourhood://Qm...`). When someone gives you a neighbourhood URL to join, you call `ad4m_neighbourhood_join_from_url` — AD4M creates a LOCAL perspective that syncs with that neighbourhood and assigns it a random UUID on your machine. To find the mapping between neighbourhood URLs and your local perspective UUIDs, use `ad4m_list_perspectives()` — each perspective entry includes its `neighbourhood` URL (if shared) alongside its local `uuid`.
+A **perspective UUID** is a local identifier on YOUR device only. It is NOT shared and NOT meaningful to other agents or humans. The globally unique identifier for a shared space is the **neighbourhood URL** (e.g. `neighbourhood://Qm...`). When someone gives you a neighbourhood URL to join, you call `neighbourhood_join_from_url` — AD4M creates a LOCAL perspective that syncs with that neighbourhood and assigns it a random UUID on your machine. To find the mapping between neighbourhood URLs and your local perspective UUIDs, use `list_perspectives()` — each perspective entry includes its `neighbourhood` URL (if shared) alongside its local `uuid`.
 
-### 10. Track neighbourhoods in a dedicated file (REQUIRED)
+### 10. Track neighbourhoods
 
-**Create and maintain:** `memory/ad4m-neighbourhoods.md`
-
-This file is your source of truth for all neighbourhood memberships. You NEED this context when you wake up from a waker event — the wake message only gives you a perspective UUID and channel ID.
-
-**Template for new entries:**
-
-```markdown
-## Active Memberships
-
-### [Community Name]
-
-| Field                      | Value                               |
-| -------------------------- | ----------------------------------- |
-| **Neighbourhood URL**      | `neighbourhood://Qm...`             |
-| **Local Perspective UUID** | `...` (from ad4m_list_perspectives) |
-| **Joined**                 | YYYY-MM-DD                          |
-| **Invited by**             | [Name]                              |
-| **Purpose**                | [Why you're here]                   |
-| **Members**                | [Who's in this space]               |
-| **Channels**               | [Channel IDs you use]               |
-| **Last activity**          | [Brief note on conversation state]  |
-```
-
-**Workflow:**
-
-1. **Immediately after joining** a neighbourhood, add it to this file
-2. **Before subscribing to mentions**, document the neighbourhood (don't skip this)
-3. **After each interaction**, update the "Last activity" field
-4. **On wake events**, read this file first to understand the context
-
-**Why this matters:**
-
-- Prevents mixing conversations between neighbourhoods
-- Gives you context when responding to mentions
-- Tracks who invited you and why you're in each space
-- Maintains conversation state across sessions
+Maintain a record of all neighbourhood memberships — at minimum the neighbourhood URL, local perspective UUID, purpose, and who invited you. You need this context when responding to events from a neighbourhood.
 
 ### 11. Subscribe to mentions on every new neighbourhood join
 
-Every time you join a new neighbourhood, you MUST subscribe to **mentions** at minimum. Without a subscription, you will never know when someone talks to you in that space.
+Every time you join a new neighbourhood, subscribe to **mentions** at minimum. Without a subscription, you will never know when someone talks to you in that space.
 
 ```
-ad4m_subscribe_to_mentions(perspective_id: "<your-local-uuid>")
+subscribe_to_mentions(perspective_id: "<your-local-uuid>")
 ```
 
-That's it — one tool call. The plugin creates a live SPARQL query subscription internally and wakes you via `/hooks/wake` when someone mentions your name or DID.
-
-If your human asks you to monitor a specific channel for ALL messages (not just mentions):
+If you need to monitor a specific channel for ALL messages (not just mentions):
 
 ```
-ad4m_subscribe_to_children(perspective_id: "...", expression_address: "<channel-id>")
+subscribe_to_children(perspective_id: "...", expression_address: "<channel-id>")
 ```
 
-Use `ad4m_list_waker_subscriptions()` to see active subscriptions, and `ad4m_unsubscribe_from_mentions` / `ad4m_unsubscribe_from_children` to remove them.
+Use `list_waker_subscriptions()` to see active subscriptions, and `unsubscribe_from_mentions` / `unsubscribe_from_children` to remove them.
 
 ## Model base expressions / IDs
 
@@ -234,23 +171,23 @@ Community (ad4m://self)
               └── ConversationSubgroup (AI-generated summary/grouping)
 ```
 
-There are two kinds of channels in Flux which are displayed differently: 
+There are two kinds of channels in Flux which are displayed differently:
  - Conversation channels
    - is_conversation=true
    - always has a Conversation child
-   - displayed channel name is title of conversation (upates automatically from message content)
+   - displayed channel name is title of conversation (updates automatically from message content)
    => EPHEMERAL - when users start a new conversation without putting it into a persistent channel
    => UI only shows a couple of recent conversation channels
    => can be dragged into a space channel to keep it
 
  - Space channels
    - is_conversation=false
-   - does not neccessarily include a Conversation instance
+   - does not necessarily include a Conversation instance
    - could also have multiple Conversation children
    - property `name` displayed as channel name
-   => LONG LASTING - all spaces channels are displayed
+   => LONG LASTING - all space channels are displayed
    => Tree structure - can have sub-channels
-   => used to organized conversations that should be kept
+   => used to organize conversations that should be kept
 
 
 #### Posts, Tasks etc.
@@ -263,14 +200,13 @@ so humans have a UI to interact with those.
 
 Posts can have messages as comments which would be displayed under the post.
 
-Tasks need to be added to TaskColumns (in orderedTAskIds)
-The TaskBoard is (currently) applying a hack: for ordering, 
-it stores JSON arrays of IDs (addresses) in its orderedColumnIds, 
-and the TaskColumns do the same, they store Task IDs (addresses)
+Tasks need to be added to TaskColumns (in orderedTaskIds).
+The TaskBoard stores JSON arrays of IDs (addresses) in its orderedColumnIds,
+and the TaskColumns do the same, storing Task IDs (addresses)
 as stringified JSON array in TaskColumn's orderedColumnIds property.
 
 So these are not collections but properties holding stringified JSON.
-Be carefule when changing those!
+Be careful when changing those!
 You can add Tasks by appending their IDs but make sure you write a well-
 formed stringified JSON array again!
 
@@ -278,76 +214,60 @@ formed stringified JSON array again!
 
 | Tool                                                                                               | Description                                                                                                                                                                             |
 | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ad4m_get_my_did()`                                                                                | Get your agent's DID. Use to filter out your own messages (compare against `author` field).                                                                                             |
-| `ad4m_get_children_body_parsed(perspective_id, parent_address=<channel-id>, class_name="Message", limit=50)` | **Preferred way to read a channel.** Returns the most recent N messages (default 50) as a formatted transcript with resolved message bodies, author names, and timestamps — one tool call instead of N+1. Use a smaller `limit` (e.g. 10-20) when responding to a mention to see just the recent context. |
-| `ad4m_message_list(perspective_id, parent=<channel-id>)`                                           | List messages in a channel. Returns addresses, timestamps, and authors sorted by timestamp. Use `ad4m_get_children_body_parsed` instead for reading conversations.                      |
-| `ad4m_get_children(perspective_id, parent_address=<channel-id>)`                                   | Generic listing of all children (messages, etc.) in a channel with timestamps and authors.                                                                                              |
-| `ad4m_message_create(..., parent=<channel-id>)`                                                    | Create a message AND add it to a channel in one call.                                                                                                                                   |
-
-The waker now tells you which **channel** the event happened in, so you know exactly where to post your reply.
+| `get_my_did()`                                                                                     | Get your agent's DID. Use to filter out your own messages (compare against `author` field).                                                                                             |
+| `get_children_body_parsed(perspective_id, parent_address=<channel-id>, class_name="Message", limit=50)` | **Preferred way to read a channel.** Returns the most recent N messages (default 50) as a formatted transcript with resolved message bodies, author names, and timestamps — one tool call instead of N+1. Use a smaller `limit` (e.g. 10-20) for recent context. |
+| `message_list(perspective_id, parent=<channel-id>)`                                                | List messages in a channel. Returns addresses, timestamps, and authors sorted by timestamp. Use `get_children_body_parsed` instead for reading conversations.                           |
+| `get_children(perspective_id, parent_address=<channel-id>)`                                        | Generic listing of all children (messages, etc.) in a channel with timestamps and authors.                                                                                              |
+| `message_create(..., parent=<channel-id>)`                                                         | Create a message AND add it to a channel in one call.                                                                                                                                   |
 
 ## Quick Start
 
-### First-time setup
+### Join a Neighbourhood and Chat
 
 ```
-1. Install plugin                 → openclaw plugins install ./ad4m
-2. Run setup                      → openclaw ad4m-setup
-3. Paste config into openclaw.json (printed by setup)
-4. Restart OpenClaw
-5. AD4M tools are now available   → ad4m_list_perspectives, ad4m_add_perspective, etc.
-6. Create profile                 → ad4m_set_agent_profile(username: "...")
-7. Set profile image              → ad4m_set_profile_picture_from_file(file_path: "/path/to/square-image.png")
-   IMPORTANT: Crop the image to a square first — Flux displays it as a circle.
-```
-
-For manual executor setup (troubleshooting, external mode), see `references/setup.md`.
-
-### Join a Flux Neighbourhood and Chat
-
-```
-1. ad4m_neighbourhood_join_from_url(url: "neighbourhood://Qm...")
-2. ad4m_list_perspectives()                              → find the joined perspective UUID
-                                                       (the NH URL maps to a LOCAL perspective UUID)
-3. UPDATE memory/ad4m-neighbourhoods.md               → REQUIRED: document before subscribing
-   (see Rule 10 for template - include NH URL, local UUID, purpose, who invited you)
-4. ad4m_subscribe_to_mentions(perspective_id: "...")      → live waker subscription (see rule 11)
-5. ad4m_channel_query(perspective_id: "...")              → list channels
-6. ad4m_get_children_body_parsed(perspective_id, parent_address="<channel-id>", class_name="Message", limit=20)
+1. neighbourhood_join_from_url(url: "neighbourhood://Qm...")
+2. list_perspectives()                                     → find the joined perspective UUID
+                                                            (the NH URL maps to a LOCAL perspective UUID)
+3. Record the neighbourhood URL, local UUID, and purpose
+4. subscribe_to_mentions(perspective_id: "...")             → live subscription
+5. channel_query(perspective_id: "...")                     → list channels
+6. get_children_body_parsed(perspective_id, parent_address="<channel-id>", class_name="Message", limit=20)
    → returns last 20 messages as formatted transcript (author names, timestamps, body text)
-7. ad4m_message_create(perspective_id, body="Hello!", parent="<channel-id>")
+7. message_create(perspective_id, body="Hello!", parent="<channel-id>")
    → creates message AND adds to channel in one step (expression_address auto-generated)
 ```
 
-**If `ad4m_channel_query` returns nothing**, SHACL schemas may still be syncing (Holochain gossip takes ~3-5 min). Wait and retry.
+**If `channel_query` returns nothing**, SHACL schemas may still be syncing (Holochain gossip takes ~3-5 min). Wait and retry.
 
 ## Handling Wake Events
 
-**If you were woken by the AD4M waker** (wake message mentions "AD4M neighbourhood", a perspective UUID, or a channel address) — follow this procedure.
-
-The waker POSTs to your `/hooks/wake` endpoint with this JSON body:
+When you receive a wake event from an AD4M subscription, it will include the perspective UUID and event details.
 
 **Mention events** include per-message details with parent resolution:
 
-```json
-{
-  "text": "You were @mentioned in an AD4M neighbourhood.\nRead the AD4M skill for instructions on how to handle this.\n\nAgent DID: did:key:z6Mk...\nPerspective: cda8c4fc-...\nSubscription: mention-abc\nEvent type: mention\n\nMentioned messages (2):\n  Message: literal://string:msg-123\n  Parents: literal://string:channel-1, literal://string:conv-thread-5\n  Message: literal://string:msg-456\n  Parents: literal://string:channel-1",
-  "mode": "now"
-}
+```
+Agent DID: did:key:z6Mk...
+Perspective: cda8c4fc-...
+Subscription: mention-abc
+Event type: mention
+
+Mentioned messages (2):
+  Message: literal://string:msg-123
+  Parents: literal://string:channel-1, literal://string:conv-thread-5
+  Message: literal://string:msg-456
+  Parents: literal://string:channel-1
 ```
 
 **Channel-messages events** have the simpler format:
 
-```json
-{
-  "text": "New messages in an AD4M neighbourhood.\nRead the AD4M skill for instructions on how to handle this.\n\nAgent DID: did:key:z6Mk...\nPerspective: cda8c4fc-...\nSubscription: children-xyz\nEvent type: channel-messages",
-  "mode": "now"
-}
+```
+Agent DID: did:key:z6Mk...
+Perspective: cda8c4fc-...
+Subscription: children-xyz
+Event type: channel-messages
 ```
 
-**Use `/hooks/wake`, NOT `/hooks/agent`.** `/hooks/wake` enqueues the event into your main agent session, which has your skills (including this AD4M skill) loaded. `/hooks/agent` spawns an isolated sub-agent that won't have your skills.
-
-Parse the `text` field to extract: `Agent DID`, `Perspective` (local UUID), `Event type`, and for mentions: the `Message` addresses and their `Parents`. Use these values directly. The plugin manages the MCP connection — just call tools directly.
+Parse the event to extract: `Agent DID`, `Perspective` (local UUID), `Event type`, and for mentions: the `Message` addresses and their `Parents`.
 
 ### Channel Concept: Each Parent is a Separate Conversation Space
 
@@ -357,56 +277,51 @@ Parse the `text` field to extract: `Agent DID`, `Perspective` (local UUID), `Eve
 - Channels/Parents are direct children of the community
 - Messages are children of channels/parents
 
-A message can have **multiple parents** — for example, it might be in both a channel and a conversation thread (auto-generated by Flux AI). Use `ad4m_channel_list` or `ad4m_get_children` to identify which parent is the channel you should respond to.
+A message can have **multiple parents** — for example, it might be in both a channel and a conversation thread (auto-generated by Flux AI). Use `channel_list` or `get_children` to identify which parent is the channel you should respond to.
 
-**When the waker gives you message parents, respond to the channel parent.**
+**When you get a message parent, respond to the channel parent.**
 
 - Read recent messages FROM THAT CHANNEL using `get_children_body_parsed(parent_address=<channel>, limit=20)`
 - Respond TO THAT CHANNEL by passing `parent=<channel>` to `message_create`
 - **DO NOT** respond to a conversation thread parent — those are auto-generated by Flux
 
-**First: read `memory/ad4m-neighbourhoods.md`** for the perspective UUID from the wake message. This file tells you what community this is, who's in it, and why you're there. This context is essential for responding appropriately.
-
-**Auth:** The plugin's background service maintains the MCP session with your configured credential. Just call the tools directly.
-
 ### Step 1: Read recent messages
 
-1. `ad4m_get_my_did()` → get your agent DID for filtering
-2. `ad4m_get_children_body_parsed(perspective_id=<from wake>, parent_address=<channel parent>, class_name="Message", limit=20)` → formatted transcript
-   - **Use the channel parent from the wake message's "Mentioned messages" section!**
+1. `get_my_did()` → get your agent DID for filtering
+2. `get_children_body_parsed(perspective_id=<from event>, parent_address=<channel parent>, class_name="Message", limit=20)` → formatted transcript
    - `limit=20` gives you recent context around the mention without loading the entire channel history
    - Returns a ready-to-read transcript with author names, timestamps, and resolved message bodies
    - Format: `[timestamp] name (did):\nmessage text` separated by blank lines
    - If the channel has more messages than the limit, the output starts with `(showing last N of M messages)`
 3. Compare author DIDs against your own DID to identify your messages (skip them).
 
-**Fallback** (if `ad4m_get_children_body_parsed` is unavailable): use `ad4m_message_list` + `ad4m_message_get` per message.
+**Fallback** (if `get_children_body_parsed` is unavailable): use `message_list` + `message_get` per message.
 
 ### Step 2: Post your reply
 
-**Always respond to the same parent that woke you:**
+**Always respond to the same parent that triggered the event:**
 
 ```
-ad4m_message_create(
-  perspective_id=<from wake>,
+message_create(
+  perspective_id=<from event>,
   body="Your reply",
-  parent=<parent from wake>
+  parent=<parent from event>
 )
 ```
 
 - Omit `expression_address` — it will be auto-generated
-- Use the SAME `parent` from the wake message
+- Use the SAME `parent` from the event
 - **Never** add your message to a different parent
 
-**Always use `ad4m_message_create` with the body in initial values — never call `ad4m_message_set_body` afterward.** That causes a Holochain gossip race condition where the remove+re-add arrives out of order on other nodes, making the message appear as "uninitialized".
+**Always use `message_create` with the body in initial values — never call `message_set_body` afterward.** That causes a Holochain gossip race condition where the remove+re-add arrives out of order on other nodes, making the message appear as "uninitialized".
 
 Correct pattern:
 
 ```
-ad4m_message_create(perspective_id, body="Your reply", parent=<channel>)
+message_create(perspective_id, body="Your reply", parent=<channel>)
 ```
 
-That's it. Do not call `ad4m_message_set_body` after `ad4m_message_create`.
+That's it. Do not call `message_set_body` after `message_create`.
 
 ### When to respond
 
@@ -415,32 +330,26 @@ That's it. Do not call `ad4m_message_set_body` after `ad4m_message_create`.
 - Skip your own messages
 - Be conversational — you're chatting, not writing a report
 
-## Waker (Embedded)
+## Subscriptions
 
-The waker makes your bot **autonomous** — it watches for changes in AD4M perspectives and wakes you via OpenClaw hooks. The waker runs inside the plugin — no separate process needed.
-
-```
-AD4M Executor ──GraphQL WS──→ Plugin (ad4m-waker service) ──HTTP POST──→ OpenClaw /hooks/wake
-     │                              │                                          │
-  SPARQL subscription        Debounce + filter                           Agent wakes up
-  detects new links          (2s default)                                reads new data via MCP
-```
-
-### Subscribing
+Subscriptions watch for changes in AD4M perspectives via WS-RPC and notify you when relevant events occur.
 
 ```
-ad4m_subscribe_to_mentions(perspective_id: "...")
-ad4m_subscribe_to_children(perspective_id: "...", expression_address: "<channel-id>")
-ad4m_list_waker_subscriptions()
-ad4m_unsubscribe_from_mentions(perspective_id: "...")
-ad4m_unsubscribe_from_children(perspective_id: "...", expression_address: "<channel-id>")
+AD4M Executor ──WS-RPC──→ MCP Client ──notification──→ Agent wakes up
+     │                        │                             │
+  SPARQL subscription    Debounce + filter              reads new data via MCP
+  detects new links      (2s default)
 ```
 
-### Plugin config for waker
+### Managing subscriptions
 
-The waker works automatically — it reads the hooks token from OpenClaw's global config (`hooks.token`). The `openclaw ad4m-setup` command includes `wakeToken` in the generated config snippet if hooks are enabled.
-
-See `references/waker.md` for config field reference.
+```
+subscribe_to_mentions(perspective_id: "...")
+subscribe_to_children(perspective_id: "...", expression_address: "<channel-id>")
+list_waker_subscriptions()
+unsubscribe_from_mentions(perspective_id: "...")
+unsubscribe_from_children(perspective_id: "...", expression_address: "<channel-id>")
+```
 
 ## Dynamic SHACL Tools
 
@@ -460,17 +369,17 @@ AD4M's MCP server introspects SHACL subject class definitions and auto-generates
 
 Class and property names are **lowercased** in tool names. Example: `Channel` with `name` and `messages` → `channel_create`, `channel_set_name`, `channel_add_messages`, etc.
 
-**Use `parent` parameter to create + add to channel in one step:** `ad4m_message_create(..., parent="literal://string:<channel-id>")`
+**Use `parent` parameter to create + add to channel in one step:** `message_create(..., parent="literal://string:<channel-id>")`
 
-**Use `{class}_list` for quick channel message listing:** `ad4m_message_list(perspective_id, parent="<channel-id>")`
+**Use `{class}_list` for quick channel message listing:** `message_list(perspective_id, parent="<channel-id>")`
 
-**Prefer dynamic tools** (`ad4m_message_create`) over generic tools (`ad4m_create_subject`) when available. Fall back to `ad4m_create_subject` if dynamic tools haven't appeared yet (SHACL still syncing).
+**Prefer dynamic tools** (`message_create`) over generic tools (`create_subject`) when available. Fall back to `create_subject` if dynamic tools haven't appeared yet (SHACL still syncing).
 
-**After `ad4m_add_model` or joining a neighbourhood**, call `ad4m_refresh_ad4m_tools()` to immediately discover the new dynamic tools. Otherwise you'll have to wait for the next automatic poll cycle (~30s).
+**After `add_model` or joining a neighbourhood**, call `refresh_ad4m_tools()` to immediately discover the new dynamic tools. Otherwise you'll have to wait for the next automatic poll cycle (~30s).
 
 ## Subject Classes (SHACL)
 
-Define structured data types via `ad4m_add_model`. JSON format:
+Define structured data types via `add_model`. JSON format:
 
 ```json
 {
@@ -539,15 +448,6 @@ Define structured data types via `ad4m_add_model`. JSON format:
 - The `target` in setter/adder/remover actions is `"value"` (substituted at runtime)
 
 See `references/architecture.md` for full SHACL field reference and link storage internals.
-
-## Executor Setup (Reference)
-
-Run `openclaw ad4m-setup` for guided setup. See `references/setup.md` for:
-
-- Downloading and building the executor binary
-- Manual executor setup (troubleshooting, external mode)
-- Deployment scenarios and networking
-- Troubleshooting guide
 
 ## Reference Files
 

--- a/plugins/ad4m/skills/ad4m/references/architecture.md
+++ b/plugins/ad4m/skills/ad4m/references/architecture.md
@@ -14,8 +14,8 @@ A perspective is a subjective graph of links — a personal knowledge graph. Eve
 
 ```
 Perspective "My Notes"
-├── Link: (ad4m://self) --has_name--> (literal://string:Data)
-├── Link: (ad4m://self) --has_role--> (literal://string:AI Agent)
+├── Link: (ad4m://self) --has_name--> (literal:string:Data)
+├── Link: (ad4m://self) --has_role--> (literal:string:AI Agent)
 └── Link: (did:key:z6Mk...) --authored--> (Qm...expression-hash)
 ```
 
@@ -54,9 +54,9 @@ interface LinkExpression {
 ### URI Conventions
 
 - `ad4m://self` — the perspective itself
-- `literal://string:value` — inline string literal
-- `literal://number:42` — inline number
-- `literal://json:{"key":"value"}` — inline JSON
+- `literal:string:value` — inline string literal
+- `literal:number:42` — inline number
+- `literal:json:{"key":"value"}` — inline JSON
 - `did:key:z6Mk...` — agent identity
 - `Qm...` — content-addressed expression (language-specific)
 
@@ -219,7 +219,7 @@ Once registered, dynamic tools are auto-generated:
 When you set `message.body = "Hello"` via a subject class:
 
 ```
-Link: (<message-instance-uri>) --message://body--> (literal://string:Hello)
+Link: (<message-instance-uri>) --message://body--> (literal:string:Hello)
 ```
 
 When you add to a collection `message.reactions.add(uri)`:
@@ -233,8 +233,8 @@ Link: (<message-instance-uri>) --message://reactions--> (<reaction-uri>)
 SHACL definitions are decomposed into RDF links in the perspective. Key link patterns:
 
 ```
-(ad4m://self) --ad4m://has_shacl--> (literal://string:shacl://Message)
-(literal://string:shacl://Message) --ad4m://shacl_shape_uri--> (message://MessageShape)
+(ad4m://self) --ad4m://has_shacl--> (literal:string:shacl://Message)
+(literal:string:shacl://Message) --ad4m://shacl_shape_uri--> (message://MessageShape)
 (message://Message) --rdf://type--> (ad4m://SubjectClass)
 (message://MessageShape) --sh://property--> (message://Message.body)
 ```

--- a/plugins/ad4m/skills/ad4m/references/setup.md
+++ b/plugins/ad4m/skills/ad4m/references/setup.md
@@ -237,7 +237,7 @@ After init + generate, `--app-data-path` contains:
 The plugin manages MCP authentication internally — credentials are not sent in wake messages. Wake messages only contain event metadata (perspective UUID, parent, event type, agent DID).
 
 - The plugin's background service maintains an authenticated MCP session
-- Wake events are delivered locally to your agent session
+- Wake messages are sent over HTTP to your local OpenClaw hooks endpoint (`localhost` by default)
 - If running the waker on a remote machine, ensure the wake endpoint uses HTTPS
 
 ### Executor Security

--- a/plugins/ad4m/skills/ad4m/references/setup.md
+++ b/plugins/ad4m/skills/ad4m/references/setup.md
@@ -237,7 +237,7 @@ After init + generate, `--app-data-path` contains:
 The plugin manages MCP authentication internally — credentials are not sent in wake messages. Wake messages only contain event metadata (perspective UUID, parent, event type, agent DID).
 
 - The plugin's background service maintains an authenticated MCP session
-- Wake messages are sent over HTTP to your local OpenClaw hooks endpoint (`localhost` by default)
+- Wake events are delivered locally to your agent session
 - If running the waker on a remote machine, ensure the wake endpoint uses HTTPS
 
 ### Executor Security
@@ -255,7 +255,7 @@ Connect to `ws://localhost:12000/api/v1/ws` and send JSON-RPC messages:
 ```json
 {"method": "agent.status", "params": {}, "id": "1"}
 
-{"method": "perspectives.add_link", "params": {"uuid": "<perspective-uuid>", "link": {"source": "ad4m://self", "predicate": "has_name", "target": "literal://string:Data"}}, "id": "2"}
+{"method": "perspectives.add_link", "params": {"uuid": "<perspective-uuid>", "link": {"source": "ad4m://self", "predicate": "has_name", "target": "literal:string:Data"}}, "id": "2"}
 ```
 
 **Auth:** Send `{"method": "auth", "params": {"credential": "<admin-credential>"}}` (single-user) or `{"method": "auth", "params": {"jwt": "<token>"}}` (multi-user) as the first message.

--- a/plugins/ad4m/skills/ad4m/references/waker.md
+++ b/plugins/ad4m/skills/ad4m/references/waker.md
@@ -1,12 +1,12 @@
 # AD4M Waker (Embedded)
 
-The AD4M waker watches perspectives for data changes via WebSocket subscriptions and wakes your agent when relevant events occur. It runs as a background service — no separate process needed.
+The AD4M waker watches perspectives for data changes via WebSocket subscriptions and wakes your OpenClaw agent when relevant events occur. It runs as a background service inside the AD4M plugin — no separate process needed.
 
 ## How It Works
 
-1. The waker service connects to the AD4M executor's WebSocket event endpoint
-2. When you call `subscribe_to_mentions` or `subscribe_to_children`, it creates a `QuerySubscriptionProxy` with a SPARQL live query
-3. When query results change, the waker debounces and delivers the event to your agent session
+1. The plugin's `ad4m-waker` service connects to the AD4M executor's WebSocket event endpoint
+2. When you call `subscribe_to_mentions` or `subscribe_to_children`, the plugin creates a `QuerySubscriptionProxy` with a SPARQL live query
+3. When query results change, the plugin debounces and POSTs to OpenClaw's `/hooks/wake` endpoint
 4. Your agent wakes up with context about what changed and processes the new data via MCP tools
 
 ## Plugin Config Fields
@@ -15,8 +15,8 @@ The AD4M waker watches perspectives for data changes via WebSocket subscriptions
 | --------------- | ----------------------------------- | ------------------------------------------------------------------------------- |
 | `wakerEnabled`  | `true`                              | Enable/disable the waker service                                                |
 | `executorUrl`   | `http://localhost:12000`             | AD4M executor REST URL                                                          |
-| `wakeUrl`       | (platform-specific)                 | Agent wake endpoint URL                                                         |
-| `wakeToken`     | (platform-specific)                 | Auth token for the wake endpoint                                                |
+| `wakeUrl`       | `http://localhost:18789/hooks/wake` | OpenClaw wake endpoint URL                                                      |
+| `wakeToken`     | auto from `hooks.token`             | Override for the hooks token. Auto-read from OpenClaw global config if omitted. |
 | `debounceMs`    | `2000`                              | Debounce interval to prevent rapid-fire wakes (ms)                              |
 
 ## Subscription Tools
@@ -33,7 +33,7 @@ The subscribe tools call the MCP tools `ad4m_get_mention_waker_config` / `ad4m_g
 
 ## Wake Message Format
 
-Wake events are delivered directly to your agent session with full skill context.
+**Use `/hooks/wake` (recommended).** It enqueues the event into the main agent session which has your skills loaded. Do NOT use `/hooks/agent` — that spawns an isolated sub-agent without your skills.
 
 ### Mention events
 
@@ -50,7 +50,7 @@ The `Mentioned messages` section lists each message that triggered the wake:
 - **Message** — the base expression address of the message containing the mention
 - **Parents** — all parent containers this message belongs to (channels, conversation threads, etc.)
 
-A message can have multiple parents because Flux auto-generates conversation threads. Use `channel_list` to identify which parent is the actual channel, and respond there.
+A message can have multiple parents because Flux auto-generates conversation threads. Use `ad4m_channel_list` to identify which parent is the actual channel, and respond there.
 
 ### Channel-messages events
 
@@ -68,7 +68,7 @@ A message can have multiple parents because Flux auto-generates conversation thr
 - **Subscription** — subscription ID
 - **Event type** — `"mention"` or `"channel-messages"`
 
-The waker manages the MCP connection — just call AD4M tools directly after waking.
+The plugin manages the MCP connection — just call AD4M tools directly after waking.
 
 ### Deduplication
 
@@ -76,4 +76,20 @@ The waker tracks seen message addresses per subscription and only wakes for **ne
 
 ## Wake Delivery
 
-How wake events reach your agent session depends on the platform (Sovereign, OpenClaw, etc.). The waker emits bus events; the platform's routing layer delivers them to the active session. No manual webhook configuration is needed.
+How wake events reach your agent session depends on the platform (Sovereign, OpenClaw, etc.). The current waker sends wake payloads to `wakeUrl` with `wakeToken`; platforms may auto-provision these values, but they must be present for delivery.
+
+### OpenClaw Hooks Config
+
+The plugin reads the hooks token from OpenClaw's global config (`hooks.token`). The `openclaw ad4m-setup` command includes `wakeToken` in the generated config snippet if hooks are enabled.
+
+If you want to set one manually:
+
+```json
+{
+  "hooks": {
+    "enabled": true,
+    "path": "/hooks",
+    "token": "your-hooks-token"
+  }
+}
+```

--- a/plugins/ad4m/skills/ad4m/references/waker.md
+++ b/plugins/ad4m/skills/ad4m/references/waker.md
@@ -1,12 +1,12 @@
 # AD4M Waker (Embedded)
 
-The AD4M waker watches perspectives for data changes via WebSocket subscriptions and wakes your OpenClaw agent when relevant events occur. It runs as a background service inside the AD4M plugin — no separate process needed.
+The AD4M waker watches perspectives for data changes via WebSocket subscriptions and wakes your agent when relevant events occur. It runs as a background service — no separate process needed.
 
 ## How It Works
 
-1. The plugin's `ad4m-waker` service connects to the AD4M executor's WebSocket event endpoint
-2. When you call `subscribe_to_mentions` or `subscribe_to_children`, the plugin creates a `QuerySubscriptionProxy` with a SPARQL live query
-3. When query results change, the plugin debounces and POSTs to OpenClaw's `/hooks/wake` endpoint
+1. The waker service connects to the AD4M executor's WebSocket event endpoint
+2. When you call `subscribe_to_mentions` or `subscribe_to_children`, it creates a `QuerySubscriptionProxy` with a SPARQL live query
+3. When query results change, the waker debounces and delivers the event to your agent session
 4. Your agent wakes up with context about what changed and processes the new data via MCP tools
 
 ## Plugin Config Fields
@@ -15,8 +15,8 @@ The AD4M waker watches perspectives for data changes via WebSocket subscriptions
 | --------------- | ----------------------------------- | ------------------------------------------------------------------------------- |
 | `wakerEnabled`  | `true`                              | Enable/disable the waker service                                                |
 | `executorUrl`   | `http://localhost:12000`             | AD4M executor REST URL                                                          |
-| `wakeUrl`       | `http://localhost:18789/hooks/wake` | OpenClaw wake endpoint URL                                                      |
-| `wakeToken`     | auto from `hooks.token`             | Override for the hooks token. Auto-read from OpenClaw global config if omitted. |
+| `wakeUrl`       | (platform-specific)                 | Agent wake endpoint URL                                                         |
+| `wakeToken`     | (platform-specific)                 | Auth token for the wake endpoint                                                |
 | `debounceMs`    | `2000`                              | Debounce interval to prevent rapid-fire wakes (ms)                              |
 
 ## Subscription Tools
@@ -33,7 +33,7 @@ The subscribe tools call the MCP tools `ad4m_get_mention_waker_config` / `ad4m_g
 
 ## Wake Message Format
 
-**Use `/hooks/wake` (recommended).** It enqueues the event into the main agent session which has your skills loaded. Do NOT use `/hooks/agent` — that spawns an isolated sub-agent without your skills.
+Wake events are delivered directly to your agent session with full skill context.
 
 ### Mention events
 
@@ -41,7 +41,7 @@ For mention subscriptions, the wake message includes per-message details with re
 
 ```json
 {
-  "text": "You were @mentioned in an AD4M neighbourhood.\nRead the AD4M skill for instructions on how to handle this.\n\nAgent DID: did:key:z6Mk...\nPerspective: cda8c4fc-...\nSubscription: mention-abc\nEvent type: mention\n\nMentioned messages (1):\n  Message: literal://string:msg-123\n  Parents: literal://string:channel-1, literal://string:conv-thread-5",
+  "text": "You were @mentioned in an AD4M neighbourhood.\nRead the AD4M skill for instructions on how to handle this.\n\nAgent DID: did:key:z6Mk...\nPerspective: cda8c4fc-...\nSubscription: mention-abc\nEvent type: mention\n\nMentioned messages (1):\n  Message: literal:string:msg-123\n  Parents: literal:string:channel-1, literal:string:conv-thread-5",
   "mode": "now"
 }
 ```
@@ -50,7 +50,7 @@ The `Mentioned messages` section lists each message that triggered the wake:
 - **Message** — the base expression address of the message containing the mention
 - **Parents** — all parent containers this message belongs to (channels, conversation threads, etc.)
 
-A message can have multiple parents because Flux auto-generates conversation threads. Use `ad4m_channel_list` to identify which parent is the actual channel, and respond there.
+A message can have multiple parents because Flux auto-generates conversation threads. Use `channel_list` to identify which parent is the actual channel, and respond there.
 
 ### Channel-messages events
 
@@ -68,24 +68,12 @@ A message can have multiple parents because Flux auto-generates conversation thr
 - **Subscription** — subscription ID
 - **Event type** — `"mention"` or `"channel-messages"`
 
-The plugin manages the MCP connection — just call AD4M tools directly after waking.
+The waker manages the MCP connection — just call AD4M tools directly after waking.
 
 ### Deduplication
 
 The waker tracks seen message addresses per subscription and only wakes for **new** messages. After restart, previously seen messages are restored from persisted state — no duplicate wakes.
 
-## OpenClaw Hooks Config
+## Wake Delivery
 
-The plugin reads the hooks token from OpenClaw's global config (`hooks.token`). The `openclaw ad4m-setup` command includes `wakeToken` in the generated config snippet if hooks are enabled.
-
-If you want to set one manually:
-
-```json
-{
-  "hooks": {
-    "enabled": true,
-    "path": "/hooks",
-    "token": "your-hooks-token"
-  }
-}
-```
+How wake events reach your agent session depends on the platform (Sovereign, OpenClaw, etc.). The waker emits bus events; the platform's routing layer delivers them to the active session. No manual webhook configuration is needed.

--- a/rust-executor/.gitignore
+++ b/rust-executor/.gitignore
@@ -1,6 +1,3 @@
-!graphql-checker/index.js
-schema.json
-schema.gql
 !src/js_core/utils_extension.js
 !src/js_core/wallet_extension.js
 !src/js_core/pubsub_extension.js

--- a/tests/integration.bats
+++ b/tests/integration.bats
@@ -13,7 +13,7 @@ setup_file() {
     echo "done." >&3
 
     echo "Generating keys and initializing agent..." >&3
-    ./target/release/ad4m -n -e http://localhost:4000/graphql agent generate --passphrase "secret"
+    ./target/release/ad4m -n -e http://localhost:4000 agent generate --passphrase "secret"
     echo "done." >&3
 
 
@@ -28,7 +28,7 @@ setup_file() {
     #echo "done." >&3
     
     #echo "Generating keys and initializing agent..." >&3
-    #./target/release/ad4m -n -e http://localhost:4001/graphql agent generate --passphrase "secret"
+    #./target/release/ad4m -n -e http://localhost:4001 agent generate --passphrase "secret"
     #echo "done." >&3
 }
 
@@ -57,72 +57,72 @@ setup() {
 }
 
 @test "can create perspective, add and query links" {
-    perspective_id=`./target/release/ad4m -n -e http://localhost:4000/graphql perspectives add "test"`
+    perspective_id=`./target/release/ad4m -n -e http://localhost:4000 perspectives add "test"`
 
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives
     assert_output --partial $perspective_id
 
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives add-link $perspective_id "test://source" "test://target" "test://predicate"
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives query-links $perspective_id
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives add-link $perspective_id "test://source" "test://target" "test://predicate"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives query-links $perspective_id
     assert_output --partial "test://source"
 }
 
 @test "can use subjects and run potluck example sdna" {
     skip
     # Create perspective
-    perspective_id=`./target/release/ad4m -n -e http://localhost:4000/graphql perspectives add "sdna subject test"`
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives set-dna $perspective_id ./tests/potluck.pl
+    perspective_id=`./target/release/ad4m -n -e http://localhost:4000 perspectives add "sdna subject test"`
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives set-dna $perspective_id ./tests/potluck.pl
     assert_output --partial "SDNA set successfully"
 
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-classes $perspective_id
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-classes $perspective_id
     assert_output --partial "Dish"
     assert_output --partial "Potluck"
 
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-construct $perspective_id "Dish" "test://dish1"
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-get-property $perspective_id "test://dish1" "kind"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-construct $perspective_id "Dish" "test://dish1"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-get-property $perspective_id "test://dish1" "kind"
     assert_output --partial "liminal://unknown_kind"
 
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-set-property $perspective_id "test://dish1" "kind" "liminal://pizza"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-set-property $perspective_id "test://dish1" "kind" "liminal://pizza"
 
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-construct $perspective_id "Dish" "test://dish2"
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-set-property $perspective_id "test://dish2" "kind" "liminal://pasta"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-construct $perspective_id "Dish" "test://dish2"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-set-property $perspective_id "test://dish2" "kind" "liminal://pasta"
 
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-construct $perspective_id "Dish" "test://dish3"
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-set-property $perspective_id "test://dish3" "kind" "liminal://pizza"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-construct $perspective_id "Dish" "test://dish3"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-set-property $perspective_id "test://dish3" "kind" "liminal://pizza"
 
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-construct $perspective_id "Potluck" "test://potluck"
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-add-collection $perspective_id "test://potluck" "dishes" "test://dish1"
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-add-collection $perspective_id "test://potluck" "dishes" "test://dish2"
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-add-collection $perspective_id "test://potluck" "dishes" "test://dish3"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-construct $perspective_id "Potluck" "test://potluck"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-add-collection $perspective_id "test://potluck" "dishes" "test://dish1"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-add-collection $perspective_id "test://potluck" "dishes" "test://dish2"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-add-collection $perspective_id "test://potluck" "dishes" "test://dish3"
 
     # Dish1 is the first pizza, so it should be the most unique
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-get-property $perspective_id "test://dish1" "uniqueness"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-get-property $perspective_id "test://dish1" "uniqueness"
     assert_output --partial "1"
 
     # Dish2 is the only pasta, so it should be the most unique
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-get-property $perspective_id "test://dish2" "uniqueness"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-get-property $perspective_id "test://dish2" "uniqueness"
     assert_output --partial "1"
 
     # Dish3 is the second pizza, so it gets a score of 0.5
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-get-property $perspective_id "test://dish3" "uniqueness"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-get-property $perspective_id "test://dish3" "uniqueness"
     assert_output --partial "0.5"
 
     # Let's add a fourth dish 
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-construct $perspective_id "Dish" "test://dish4"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-construct $perspective_id "Dish" "test://dish4"
     # Also a pizze
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-set-property $perspective_id "test://dish4" "kind" "liminal://pizza"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-set-property $perspective_id "test://dish4" "kind" "liminal://pizza"
     # As long as it's on it's own, it should be the most unique
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-get-property $perspective_id "test://dish4" "uniqueness"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-get-property $perspective_id "test://dish4" "uniqueness"
     assert_output --partial "1"
     # But when we add it to the potluck, it is now the 3rd pizza, so it's score should be 0.3333333333333333
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-add-collection $perspective_id "test://potluck" "dishes" "test://dish4"
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-get-property $perspective_id "test://dish4" "uniqueness"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-add-collection $perspective_id "test://potluck" "dishes" "test://dish4"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-get-property $perspective_id "test://dish4" "uniqueness"
     assert_output --partial "0.3333333333333333"
 
     # But the new pizza should not have changed the score of the ones already in:
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-get-property $perspective_id "test://dish1" "uniqueness"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-get-property $perspective_id "test://dish1" "uniqueness"
     assert_output --partial "1"
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives subject-get-property $perspective_id "test://dish3" "uniqueness"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives subject-get-property $perspective_id "test://dish3" "uniqueness"
     assert_output --partial "0.5"
 
 }
@@ -130,11 +130,11 @@ setup() {
 @test "can create neighbourhood, join and share links" {
     skip
     # Create perspective
-    perspective_id=`./target/release/ad4m -n -e http://localhost:4000/graphql perspectives add "neighbourhood test"`
+    perspective_id=`./target/release/ad4m -n -e http://localhost:4000 perspectives add "neighbourhood test"`
 
     # Create unique link language clone
-    link_language_template=`./target/release/ad4m -n -e http://localhost:4000/graphql runtime link-language-templates`
-    clone_output=`./target/release/ad4m -n -e http://localhost:4000/graphql languages apply-template-and-publish $link_language_template "{\"uid\":\"test\",\"name\":\"test\",\"description\":\"test\"}"`
+    link_language_template=`./target/release/ad4m -n -e http://localhost:4000 runtime link-language-templates`
+    clone_output=`./target/release/ad4m -n -e http://localhost:4000 languages apply-template-and-publish $link_language_template "{\"uid\":\"test\",\"name\":\"test\",\"description\":\"test\"}"`
 
     run echo $clone_output
     assert_output --partial "Language template applied and published!"
@@ -143,7 +143,7 @@ setup() {
     language_address=`echo $address_line | cut -d " " -f 9-`
 
     # Publish neighbourhood
-    neighbourhood_output=`./target/release/ad4m -n -e http://localhost:4000/graphql neighbourhoods create $perspective_id $language_address`
+    neighbourhood_output=`./target/release/ad4m -n -e http://localhost:4000 neighbourhoods create $perspective_id $language_address`
     run echo $neighbourhood_output
     assert_output --partial "Neighbourhood shared as:"
 
@@ -151,20 +151,20 @@ setup() {
 
 
     # Join neighbourhood
-    run ./target/release/ad4m -n -e http://localhost:4001/graphql neighbourhoods join $nh_url
+    run ./target/release/ad4m -n -e http://localhost:4001 neighbourhoods join $nh_url
     assert_line --partial "Neighbourhood joined!"
 
     # Add link
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql perspectives add-link $perspective_id "nh_test://source" "nh_test://target" "nh_test://predicate"
+    run ./target/release/ad4m -n -e http://localhost:4000 perspectives add-link $perspective_id "nh_test://source" "nh_test://target" "nh_test://predicate"
 
     # Query link
-    perspectives_output=`./target/release/ad4m -n -e http://localhost:4001/graphql perspectives`
+    perspectives_output=`./target/release/ad4m -n -e http://localhost:4001 perspectives`
     run echo $perspectives_output
     assert_line --partial "ID:"
     perspective_id_line=`echo $perspectives_output | grep "ID:"`
     perspective_id_2=`echo $perspective_id_line | cut -d " " -f 2`
 
-    perspective_link_output=`run ./target/release/ad4m -n -e http://localhost:4001/graphql perspectives query-links $perspective_id_2`
+    perspective_link_output=`run ./target/release/ad4m -n -e http://localhost:4001 perspectives query-links $perspective_id_2`
     run echo $perspective_link_output
     assert_line --partial "nh_test://source"
 }
@@ -173,19 +173,19 @@ setup() {
     skip
     wget https://github.com/perspect3vism/lang-note-ipfs/releases/download/0.0.4/bundle.js -O ./tests/note-ipfs.js
     pwd=`pwd`
-    publish_output=`./target/release/ad4m -n -e http://localhost:4000/graphql languages publish $pwd/tests/note-ipfs.js -n "note-ipfs" -d "Stores text expressions in IPFS" -p "", -s "https://github.com/perspect3vism/lang-note-ipfs"`
+    publish_output=`./target/release/ad4m -n -e http://localhost:4000 languages publish $pwd/tests/note-ipfs.js -n "note-ipfs" -d "Stores text expressions in IPFS" -p "", -s "https://github.com/perspect3vism/lang-note-ipfs"`
     echo $publish_output
     run echo $publish_output
     assert_line --partial "Language published with address:"
     language_address=`echo $publish_output | cut -d ":" -f 2`
     echo "Language address: $language_address"
     
-    create_output=`./target/release/ad4m -n -e http://localhost:4000/graphql expression create $language_address "test content"`
+    create_output=`./target/release/ad4m -n -e http://localhost:4000 expression create $language_address "test content"`
     echo $create_output
     run echo $create_output
     assert_line --partial "Expression created with url:"
     expression_url=`echo $create_output | awk '{print substr($0,30)}'`
     
-    run ./target/release/ad4m -n -e http://localhost:4000/graphql expression get-raw $expression_url
+    run ./target/release/ad4m -n -e http://localhost:4000 expression get-raw $expression_url
     assert_output --partial "test content"
 }

--- a/tests/js/tests/integration.test.ts
+++ b/tests/js/tests/integration.test.ts
@@ -144,14 +144,14 @@ describe("Integration tests", function () {
 
         describe('with Alice and Bob', () => {
         let bobExecutorProcess: ChildProcess | null = null
-        let bobGqlPort: number;
+        let bobApiPort: number;
         let bobHcAdminPort: number;
         let bobHcAppPort: number;
         before(async () => {
           const bobAppDataPath = path.join(TEST_DIR, 'agents', 'bob')
           const bobBootstrapSeedPath = path.join(`${__dirname}/../bootstrapSeed.json`);
-          [bobGqlPort, bobHcAdminPort, bobHcAppPort] = await getFreePorts(3);
-          registerPorts([bobGqlPort, bobHcAdminPort, bobHcAppPort]);
+          [bobApiPort, bobHcAdminPort, bobHcAppPort] = await getFreePorts(3);
+          registerPorts([bobApiPort, bobHcAdminPort, bobHcAppPort]);
 
           if(!fs.existsSync(path.join(TEST_DIR, 'agents')))
             fs.mkdirSync(path.join(TEST_DIR, 'agents'))
@@ -159,9 +159,9 @@ describe("Integration tests", function () {
             fs.mkdirSync(bobAppDataPath)
 
           bobExecutorProcess = await startExecutor(bobAppDataPath, bobBootstrapSeedPath,
-            bobGqlPort, bobHcAdminPort, bobHcAppPort, false, undefined, proxyUrl!, bootstrapUrl!, relayUrl!);
+            bobApiPort, bobHcAdminPort, bobHcAppPort, false, undefined, proxyUrl!, bootstrapUrl!, relayUrl!);
 
-          testContext.bob = new Ad4mClient(baseUrl(bobGqlPort))
+          testContext.bob = new Ad4mClient(baseUrl(bobApiPort))
           testContext.bobCore = bobExecutorProcess
           await testContext.bob.agent.generate("passphrase")
 
@@ -183,9 +183,9 @@ describe("Integration tests", function () {
 
         after(async () => {
           if (bobExecutorProcess) {
-            await quitExecutor(bobExecutorProcess, bobGqlPort);
+            await quitExecutor(bobExecutorProcess, bobApiPort);
           }
-          deregisterPorts([bobGqlPort, bobHcAdminPort, bobHcAppPort]);
+          deregisterPorts([bobApiPort, bobHcAdminPort, bobHcAppPort]);
         })
 
         describe('Agent Language', agentLanguageTests(testContext))


### PR DESCRIPTION
## Summary

- Sweeps all stale GraphQL references from source code, comments, docs, and tests across the repo
- Replaces deprecated `literal://` URI scheme with canonical `literal:` across all docs-src MDX files and skill reference docs (the TS SDK already rejects `literal://` with an error; the Rust executor migrates it on load)
- Rewrites the AD4M MCP skill (`plugins/ad4m/skills/ad4m/SKILL.md`) to be platform-agnostic — removes OpenClaw-specific framing, updates auth documentation to match current signup→login_email flow, fixes duplicate section numbers
- Renames `bobGqlPort` → `bobApiPort` in integration tests, removes `/graphql` suffix from all CLI executor URLs in bats tests
- Removes dead `.gitignore` entries (graphql-checker, schema.json, schema.gql)

## What's NOT touched

- `PHASE1_SUMMARY.md` — historical document, GraphQL references are accurate for the time period
- `ad4m-social-conventions.md` v0.x column — describes the old system being migrated from
- `easscan.org/graphql` URLs — real external EAS GraphQL API endpoints
- `test-runner/example/languages/social-context.js` — bundled third-party `graphql-js` library
- Rust executor `literal://` handling — intentional backward-compat migration code
- `SmartLiteral.ts` `smart_literal://content` — different scheme, not affected

## Test plan

- [ ] `cargo fmt --check` passes (no Rust files modified)
- [ ] Integration tests still pass with renamed `bobApiPort` variable
- [ ] Bats tests use correct executor URLs (no `/graphql` suffix)
- [ ] AD4M skill reads correctly with platform-agnostic framing
- [ ] docs-src pages render correctly with `literal:` URIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated literal URI format syntax across all documentation examples from `literal://` to `literal:` format.
  * Revised AD4M skill documentation with updated workflows and subscription management guidance.
  * Enhanced migration and language interface documentation with clarified runtime operation flows.
  * Updated developer guides and examples for perspectives, expressions, and model classes.

* **Chores**
  * Updated integration tests to reflect API endpoint changes.
  * Cleaned up deprecated build artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->