### PR TITLE
feat(connect): demo fast-path

### DIFF
--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -630,6 +630,59 @@ export default class Ad4mConnect extends EventTarget {
     }
   }
 
+  /**
+   * Connect to a remote hosted node as a guest without any UI interaction.
+   * Generates a persistent random identity stored in localStorage so that
+   * refreshing the page reuses the same guest account.
+   *
+   * Tries loginUser first (returning visitor); falls back to createUser +
+   * loginUser (first visit). No email verification required — password-based
+   * accounts on multi-user executors skip the email code step entirely.
+   */
+  async connectAsGuest(hostUrl: string): Promise<Ad4mClient> {
+    this.url = hostUrl;
+    setLocal("ad4m-url", hostUrl);
+
+    // Reuse stored guest credentials so the identity survives page reloads
+    const GUEST_EMAIL_KEY = "ad4m-guest-email";
+    const GUEST_PASS_KEY  = "ad4m-guest-pass";
+    const storedEmail    = getLocal(GUEST_EMAIL_KEY);
+    const storedPassword = getLocal(GUEST_PASS_KEY);
+    let email: string;
+    let password: string;
+
+    if (storedEmail && storedPassword) {
+      email    = storedEmail;
+      password = storedPassword;
+    } else {
+      email    = `guest-${crypto.randomUUID()}@flux.demo`;
+      password = crypto.randomUUID();
+      setLocal(GUEST_EMAIL_KEY, email);
+      setLocal(GUEST_PASS_KEY, password);
+    }
+
+    const isReturningGuest = !!(storedEmail && storedPassword);
+
+    const token = await this.withTempClient(hostUrl, async (client) => {
+      if (isReturningGuest) {
+        // Returning guest: credentials already exist on the server, just log in
+        return await client.agent.loginUser(email, password);
+      } else {
+        // First visit: credentials are freshly generated UUIDs — create the account directly
+        const result = await client.agent.createUser(email, password);
+        if (!result.success) throw new Error(result.error || "Failed to create guest account");
+        return await client.agent.loginUser(email, password);
+      }
+    });
+
+    this.token = token;
+    setLocal("ad4m-token", token);
+
+    this.ad4mClient = this.buildClient();
+    await this.checkAuth();
+    return this.ad4mClient;
+  }
+
   // Private helpers
   private resolveEmbedded(client: Ad4mClient): void {
     if (this.embeddedResolve) {

--- a/connect/src/core.ts
+++ b/connect/src/core.ts
@@ -643,9 +643,12 @@ export default class Ad4mConnect extends EventTarget {
     this.url = hostUrl;
     setLocal("ad4m-url", hostUrl);
 
-    // Reuse stored guest credentials so the identity survives page reloads
-    const GUEST_EMAIL_KEY = "ad4m-guest-email";
-    const GUEST_PASS_KEY  = "ad4m-guest-pass";
+    // Reuse stored guest credentials so the identity survives page reloads.
+    // Keys are scoped to the normalised host so credentials from one host
+    // are never tried against a different host.
+    const normalizedHost  = hostUrl.replace(/\/+$/, '').toLowerCase();
+    const GUEST_EMAIL_KEY = `ad4m-guest-email-${normalizedHost}`;
+    const GUEST_PASS_KEY  = `ad4m-guest-pass-${normalizedHost}`;
     const storedEmail    = getLocal(GUEST_EMAIL_KEY);
     const storedPassword = getLocal(GUEST_PASS_KEY);
     let email: string;
@@ -657,8 +660,9 @@ export default class Ad4mConnect extends EventTarget {
     } else {
       email    = `guest-${crypto.randomUUID()}@flux.demo`;
       password = crypto.randomUUID();
-      setLocal(GUEST_EMAIL_KEY, email);
-      setLocal(GUEST_PASS_KEY, password);
+      // Credentials are written to localStorage only after successful
+      // account creation below — not here — so a failed createUser call
+      // leaves localStorage clean and the next attempt gets fresh credentials.
     }
 
     const isReturningGuest = !!(storedEmail && storedPassword);
@@ -668,10 +672,15 @@ export default class Ad4mConnect extends EventTarget {
         // Returning guest: credentials already exist on the server, just log in
         return await client.agent.loginUser(email, password);
       } else {
-        // First visit: credentials are freshly generated UUIDs — create the account directly
+        // First visit: create the account then log in
         const result = await client.agent.createUser(email, password);
         if (!result.success) throw new Error(result.error || "Failed to create guest account");
-        return await client.agent.loginUser(email, password);
+        const newToken = await client.agent.loginUser(email, password);
+        // Persist only after both steps succeed so a partial failure leaves
+        // localStorage clean for the next attempt
+        setLocal(GUEST_EMAIL_KEY, email);
+        setLocal(GUEST_PASS_KEY, password);
+        return newToken;
       }
     });
 
@@ -680,6 +689,9 @@ export default class Ad4mConnect extends EventTarget {
 
     this.ad4mClient = this.buildClient();
     await this.checkAuth();
+    if (this.authState !== "authenticated") {
+      throw new Error(`Guest authentication failed: auth state is "${this.authState}"`);
+    }
     return this.ad4mClient;
   }
 

--- a/connect/src/index.ts
+++ b/connect/src/index.ts
@@ -26,16 +26,34 @@ export function getAd4mConnect(options: Ad4mConnectOptions): { core: Ad4mConnect
   } else {
     // Build the UI element to allow the user to walk through authentication
     Ad4mConnectUI(core);
-    
+
     // Setup a promise that resolves when authentication completes
     const client = new Promise<Ad4mClient>((resolve) => {
       core.addEventListener('authstatechange', (event: any) => {
         if (event.detail === 'authenticated' && core.ad4mClient) resolve(core.ad4mClient);
       });
     });
-    
+
     return { core, client };
   }
+}
+
+/**
+ * Guest fast-path API — skips the UI entirely and connects to a remote hosted
+ * node using auto-generated credentials. Intended for demo/event scenarios
+ * where you want new users to arrive directly in a conversation with no auth steps.
+ *
+ * Credentials are persisted in localStorage so refreshing the page reuses the
+ * same guest identity. Pass the full HTTP URL of the AD4M executor as `hostUrl`.
+ *
+ * @example
+ * ```typescript
+ * const ad4mClient = await connectAsGuest(options, 'https://your-host.ad4m.dev');
+ * ```
+ */
+export async function connectAsGuest(options: Ad4mConnectOptions, hostUrl: string): Promise<Ad4mClient> {
+  const core = new Ad4mConnect({ ...options, url: hostUrl, hosting: false });
+  return core.connectAsGuest(hostUrl);
 }
 
 /**


### PR DESCRIPTION
# PR: feat(connect) — `connectAsGuest()` for passwordless demo fast-path

## Summary

Adds a `connectAsGuest()` method to `Ad4mConnect` (and a matching top-level export) that connects to a remote multi-user AD4M executor and authenticates silently — no UI, no email, no verification code. Intended for event/demo scenarios where you want new users to land directly in an app without any auth friction.

## Changes

### `connect/src/core.ts`

New public method `connectAsGuest(hostUrl: string): Promise<Ad4mClient>`:

- Sets the executor URL and saves it to localStorage.
- **First visit** — generates a UUID-based email (`guest-<uuid>@flux.demo`) and password (`crypto.randomUUID()`), stores both in localStorage under versioned keys, then calls `createUser` followed by `loginUser`. No email verification is required for password-based accounts on multi-user executors.
- **Return visits** — reads the stored credentials and calls `loginUser` directly. The guest identity persists across page reloads; clearing localStorage creates a new identity.
- Stores the returned JWT, builds the `Ad4mClient` via the existing `buildClient()` path, calls `checkAuth()` to verify, and returns the ready client.
- Dispatches the normal `authstatechange: "authenticated"` and `connectionstatechange` events so any existing listeners work without modification.
- Does **not** mount the ad4m-connect web component UI.

### `connect/src/index.ts`

New top-level export `connectAsGuest(options, hostUrl)`:

- Thin wrapper that constructs an `Ad4mConnect` instance with `hosting: false` (suppresses the credit/billing UI) and delegates to `core.connectAsGuest(hostUrl)`.
- Follows the same pattern as the existing `getAd4mClient()` simple API.

## Usage

```typescript
import { connectAsGuest } from '@coasys/ad4m-connect';

const ad4mClient = await connectAsGuest(
  {
    appInfo: { name: 'Flux', description: '...', url: '...', iconPath: '...' },
    capabilities: [{ with: { domain: '*', pointers: ['*'] }, can: ['*'] }],
  },
  'https://your-ad4m-host.com'
);
```

The host must be running in multi-user mode (`multi_user_enabled = true`). Guest credentials are stored in localStorage and reused on subsequent visits.

## Context

Part of the demo fast-path feature for Flux — see the companion Flux PR for how `connectAsGuest` is wired into the app init flow alongside auto-profile creation and auto-neighbourhood-join.

## Testing

Tested against `https://marvin.ad4m.dev` (Coasys CI node, multi-user enabled):
- First visit creates a new account and lands in Flux.
- Page refresh reuses the stored credentials and logs in without re-creating.
- Normal (non-demo) Flux auth flow is completely unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guest connection flow for connecting to a remote hosted executor without going through the full UI login process.
  * Introduced a new option to connect directly as a guest, with credentials handled automatically on first use and reused afterward.
  * Improved connection handling so the client now resolves once authentication is complete and ready to use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->