### PR TITLE
feat(executor): sort model queries by projection count and relation p…

### DIFF
--- a/core/src/model/types.ts
+++ b/core/src/model/types.ts
@@ -256,9 +256,11 @@ export type TypedWhere<T extends Ad4mModel> =
 
 // ---- Typed order -------------------------------------------------------------
 
-type StrictTypedOrder<T extends Ad4mModel> = {
-  [K in PropertyKeysOf<T> | 'timestamp' | 'author' | 'createdAt' | 'updatedAt']?: 'ASC' | 'DESC';
-};
+type StrictTypedOrder<T extends Ad4mModel> =
+  & { [K in PropertyKeysOf<T> | 'timestamp' | 'author' | 'createdAt' | 'updatedAt']?: 'ASC' | 'DESC' }
+  // $-prefixed projection count keys (e.g. "$likeCount") — typed at the
+  // include map level but accepted here so callers can sort by them.
+  & { [K in `$${string}`]?: 'ASC' | 'DESC' };
 
 export type TypedOrder<T extends Ad4mModel> =
   HasNoTypedFields<T> extends true ? Order : StrictTypedOrder<T>;

--- a/rust-executor/src/perspectives/model_query/filtering.rs
+++ b/rust-executor/src/perspectives/model_query/filtering.rs
@@ -285,13 +285,18 @@ pub(super) fn matches_ops(val: &Value, ops: &WhereOps) -> bool {
 ///
 /// Each key is evaluated in order; ties on the first key fall through to
 /// the second, and so on.  Uses [`compare_values`] for type-aware comparison.
+///
+/// Keys may be dotted paths (`"location.name"`) for relation-property sorts.
+/// When the intermediate value is an array (a forward collection relation),
+/// the first element is used.  Unknown or missing paths compare as `Null`
+/// (sorted to end), which preserves SPARQL-side ordering for pushed sorts.
 pub(super) fn sort_instances(instances: &mut [Value], order: &[(String, OrderDirection)]) {
     instances.sort_by(|a, b| {
         for (prop, dir) in order {
-            let av = &a[prop];
-            let bv = &b[prop];
+            let av = extract_sort_value(a, prop);
+            let bv = extract_sort_value(b, prop);
 
-            let cmp = compare_values(av, bv);
+            let cmp = compare_values(&av, &bv);
 
             if cmp != Ordering::Equal {
                 return if *dir == OrderDirection::DESC {
@@ -303,6 +308,30 @@ pub(super) fn sort_instances(instances: &mut [Value], order: &[(String, OrderDir
         }
         Ordering::Equal
     });
+}
+
+/// Resolve a sort key against a JSON instance, supporting dotted paths.
+///
+/// A plain key (`"name"`) clones the direct field value.  A dotted path
+/// (`"location.name"`) traverses nested objects — if an intermediate value
+/// is an array, the first element is used for sort purposes.  Returns
+/// `Value::Null` for any missing step so unknown paths sort to the end.
+fn extract_sort_value(instance: &Value, key: &str) -> Value {
+    if let Some(dot_pos) = key.find('.') {
+        let head = &key[..dot_pos];
+        let tail = &key[dot_pos + 1..];
+        let intermediate = &instance[head];
+        match intermediate {
+            Value::Object(_) => extract_sort_value(intermediate, tail),
+            Value::Array(arr) => arr
+                .first()
+                .map(|v| extract_sort_value(v, tail))
+                .unwrap_or(Value::Null),
+            _ => Value::Null,
+        }
+    } else {
+        instance[key].clone()
+    }
 }
 
 /// Compare two JSON values with type-aware ordering.
@@ -827,5 +856,139 @@ mod tests {
             ),
             Ordering::Equal
         );
+    }
+
+    // ---- extract_sort_value tests ------------------------------------------
+
+    #[test]
+    fn test_extract_sort_value_plain_key() {
+        let inst = json!({"name": "Alice", "age": 30});
+        assert_eq!(extract_sort_value(&inst, "name"), json!("Alice"));
+        assert_eq!(extract_sort_value(&inst, "age"), json!(30));
+        assert_eq!(extract_sort_value(&inst, "missing"), Value::Null);
+    }
+
+    #[test]
+    fn test_extract_sort_value_dotted_path_object() {
+        let inst = json!({
+            "location": { "name": "London", "country": "UK" }
+        });
+        assert_eq!(extract_sort_value(&inst, "location.name"), json!("London"));
+        assert_eq!(extract_sort_value(&inst, "location.country"), json!("UK"));
+        assert_eq!(extract_sort_value(&inst, "location.missing"), Value::Null);
+    }
+
+    #[test]
+    fn test_extract_sort_value_dotted_path_array_uses_first() {
+        // Forward collection relation: "location" is an array of objects;
+        // only the first element's property is used for sorting.
+        let inst = json!({
+            "location": [
+                { "name": "Alpha" },
+                { "name": "Zeta" }
+            ]
+        });
+        assert_eq!(
+            extract_sort_value(&inst, "location.name"),
+            json!("Alpha"),
+            "should use first element of array for dotted sort"
+        );
+    }
+
+    #[test]
+    fn test_extract_sort_value_dotted_path_empty_array() {
+        let inst = json!({ "tags": [] });
+        assert_eq!(
+            extract_sort_value(&inst, "tags.name"),
+            Value::Null,
+            "empty array should give Null"
+        );
+    }
+
+    #[test]
+    fn test_extract_sort_value_dotted_path_scalar_intermediate() {
+        // Intermediate value is a plain string, not an object or array.
+        let inst = json!({ "title": "hello" });
+        assert_eq!(
+            extract_sort_value(&inst, "title.something"),
+            Value::Null,
+            "scalar intermediate should give Null"
+        );
+    }
+
+    // ---- sort_instances dotted-path tests -----------------------------------
+
+    #[test]
+    fn test_sort_instances_dotted_path_asc() {
+        let mut instances = vec![
+            json!({ "id": "c", "location": { "name": "Zebra" } }),
+            json!({ "id": "a", "location": { "name": "Alpha" } }),
+            json!({ "id": "b", "location": { "name": "Middle" } }),
+        ];
+        sort_instances(
+            &mut instances,
+            &[("location.name".to_string(), OrderDirection::ASC)],
+        );
+        let names: Vec<&str> = instances
+            .iter()
+            .map(|i| i["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_sort_instances_dotted_path_desc() {
+        let mut instances = vec![
+            json!({ "id": "a", "author": { "name": "Alice" } }),
+            json!({ "id": "c", "author": { "name": "Charlie" } }),
+            json!({ "id": "b", "author": { "name": "Bob" } }),
+        ];
+        sort_instances(
+            &mut instances,
+            &[("author.name".to_string(), OrderDirection::DESC)],
+        );
+        let names: Vec<&str> = instances
+            .iter()
+            .map(|i| i["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["c", "b", "a"]);
+    }
+
+    #[test]
+    fn test_sort_instances_dotted_path_nulls_to_end() {
+        // Instances missing the nested path sort to the end.
+        let mut instances = vec![
+            json!({ "id": "no-location" }),
+            json!({ "id": "b", "location": { "name": "Beta" } }),
+            json!({ "id": "a", "location": { "name": "Alpha" } }),
+        ];
+        sort_instances(
+            &mut instances,
+            &[("location.name".to_string(), OrderDirection::ASC)],
+        );
+        let ids: Vec<&str> = instances
+            .iter()
+            .map(|i| i["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(ids, vec!["a", "b", "no-location"]);
+    }
+
+    #[test]
+    fn test_sort_instances_plain_key_unchanged() {
+        // Verify that introducing extract_sort_value didn't break plain key sorts.
+        let mut instances = vec![
+            json!({ "score": 10 }),
+            json!({ "score": 1 }),
+            json!({ "score": 5 }),
+        ];
+        sort_instances(
+            &mut instances,
+            &[("score".to_string(), OrderDirection::ASC)],
+        );
+        let scores: Vec<i64> = instances
+            .iter()
+            .map(|i| i["score"].as_i64().unwrap())
+            .collect();
+        assert_eq!(scores, vec![1, 5, 10]);
     }
 }

--- a/rust-executor/src/perspectives/model_query/integration_tests.rs
+++ b/rust-executor/src/perspectives/model_query/integration_tests.rs
@@ -7,7 +7,9 @@ use super::projection::{
 };
 use super::shape::parse_shape_from_json;
 use super::sparql_builder::build_instance_sparql;
-use super::test_helpers::{evaluate_getters_batch_from_json, execute_model_query_from_json};
+use super::test_helpers::{
+    evaluate_getters_batch_from_json, execute_model_query_from_json, StaticShapeResolver,
+};
 use super::types::{ModelShape, ShapeProperty};
 use super::utils::literal_percent_encode;
 use super::*;
@@ -4197,5 +4199,528 @@ async fn test_resolve_projections_where_filter_via_target_shape_property() {
         got["id"].as_str().unwrap_or(""),
         like_signal,
         "list with limit:1 should return the hydrated like signal id, got {got}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sort extension (projection count / relation property) integration tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_sort_by_projection_count_desc() {
+    // Three posts with 0, 2, and 5 likes respectively.
+    // Query with order: [["$likeCount", "DESC"]] + limit to trigger TwoPhase.
+    // Expected order: 5 likes → 2 likes → 0 likes.
+    let store = SparqlStore::new(None).unwrap();
+    let ts = "1700000000000";
+
+    struct Post<'a> {
+        id: &'a str,
+        likes: usize,
+    }
+    let posts = [
+        Post {
+            id: "test://post/zero",
+            likes: 0,
+        },
+        Post {
+            id: "test://post/five",
+            likes: 5,
+        },
+        Post {
+            id: "test://post/two",
+            likes: 2,
+        },
+    ];
+
+    for post in &posts {
+        // Conformance flag
+        store
+            .add_link(&make_link(post.id, "ns://type", "ns://post", ts))
+            .unwrap();
+        // Likes
+        for i in 0..post.likes {
+            let like = format!("{}like{}", post.id, i);
+            store
+                .add_link(&make_link(post.id, "ns://has-like", &like, ts))
+                .unwrap();
+        }
+    }
+
+    let post_shape_json = r#"{
+        "className": "Post",
+        "properties": {
+            "type": { "predicate": "ns://type", "required": true, "flag": true, "initial": "ns://post" }
+        },
+        "relations": {
+            "likes": { "predicate": "ns://has-like" }
+        }
+    }"#;
+
+    // Build a projection: $likeCount = count of "likes" relation
+    let mut projections = HashMap::new();
+    projections.insert(
+        "$likeCount".to_string(),
+        ProjectionInput {
+            from: "likes".to_string(),
+            count: true,
+            target_class_name: None,
+            where_clause: None,
+            limit: None,
+            order: None,
+        },
+    );
+
+    let result = execute_model_query_from_json(
+        &store,
+        "Post",
+        &ModelQueryInput {
+            projections: Some(projections),
+            order: Some(vec![("$likeCount".to_string(), OrderDirection::DESC)]),
+            limit: Some(10),
+            ..Default::default()
+        },
+        post_shape_json,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.instances.len(), 3, "should return all 3 posts");
+
+    let like_counts: Vec<u64> = result
+        .instances
+        .iter()
+        .map(|i| i["$likeCount"].as_u64().unwrap_or(0))
+        .collect();
+    assert_eq!(
+        like_counts,
+        vec![5, 2, 0],
+        "posts should be ordered by like count DESC: got {like_counts:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_sort_by_projection_count_asc() {
+    // Same data as above; ascending order should give 0 → 2 → 5.
+    let store = SparqlStore::new(None).unwrap();
+    let ts = "1700000000000";
+
+    let data = [("test://p/a", 3usize), ("test://p/b", 0), ("test://p/c", 7)];
+    for (id, count) in &data {
+        store
+            .add_link(&make_link(id, "ns://type", "ns://post", ts))
+            .unwrap();
+        for i in 0..*count {
+            store
+                .add_link(&make_link(id, "ns://has-like", &format!("{id}like{i}"), ts))
+                .unwrap();
+        }
+    }
+
+    let shape_json = r#"{
+        "className": "Post",
+        "properties": {
+            "type": { "predicate": "ns://type", "required": true, "flag": true, "initial": "ns://post" }
+        },
+        "relations": { "likes": { "predicate": "ns://has-like" } }
+    }"#;
+
+    let mut projections = HashMap::new();
+    projections.insert(
+        "$likeCount".to_string(),
+        ProjectionInput {
+            from: "likes".to_string(),
+            count: true,
+            target_class_name: None,
+            where_clause: None,
+            limit: None,
+            order: None,
+        },
+    );
+
+    let result = execute_model_query_from_json(
+        &store,
+        "Post",
+        &ModelQueryInput {
+            projections: Some(projections),
+            order: Some(vec![("$likeCount".to_string(), OrderDirection::ASC)]),
+            limit: Some(10),
+            ..Default::default()
+        },
+        shape_json,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.instances.len(), 3);
+    let like_counts: Vec<u64> = result
+        .instances
+        .iter()
+        .map(|i| i["$likeCount"].as_u64().unwrap_or(0))
+        .collect();
+    assert_eq!(
+        like_counts,
+        vec![0, 3, 7],
+        "ASC count sort: got {like_counts:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_sort_by_projection_count_with_pagination() {
+    // Verify that LIMIT + offset are respected when sorting by projection count.
+    let store = SparqlStore::new(None).unwrap();
+    let ts = "1700000000000";
+
+    let data = [
+        ("test://p/1", 10usize),
+        ("test://p/2", 1),
+        ("test://p/3", 5),
+        ("test://p/4", 3),
+        ("test://p/5", 8),
+    ];
+    for (id, count) in &data {
+        store
+            .add_link(&make_link(id, "ns://type", "ns://post", ts))
+            .unwrap();
+        for i in 0..*count {
+            store
+                .add_link(&make_link(id, "ns://has-like", &format!("{id}like{i}"), ts))
+                .unwrap();
+        }
+    }
+
+    let shape_json = r#"{
+        "className": "Post",
+        "properties": {
+            "type": { "predicate": "ns://type", "required": true, "flag": true, "initial": "ns://post" }
+        },
+        "relations": { "likes": { "predicate": "ns://has-like" } }
+    }"#;
+
+    let mut projections = HashMap::new();
+    projections.insert(
+        "$likeCount".to_string(),
+        ProjectionInput {
+            from: "likes".to_string(),
+            count: true,
+            target_class_name: None,
+            where_clause: None,
+            limit: None,
+            order: None,
+        },
+    );
+
+    // Ask for page 1 (top-2 by likes DESC): should be 10 and 8
+    let result = execute_model_query_from_json(
+        &store,
+        "Post",
+        &ModelQueryInput {
+            projections: Some(projections.clone()),
+            order: Some(vec![("$likeCount".to_string(), OrderDirection::DESC)]),
+            limit: Some(2),
+            offset: None,
+            count: Some(true),
+            ..Default::default()
+        },
+        shape_json,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.instances.len(), 2, "page size should be 2");
+    assert_eq!(result.total_count, 5, "total should be 5");
+    let page1: Vec<u64> = result
+        .instances
+        .iter()
+        .map(|i| i["$likeCount"].as_u64().unwrap_or(0))
+        .collect();
+    assert_eq!(page1, vec![10, 8], "page 1 DESC: got {page1:?}");
+}
+
+// ── Sort by relation property ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_sort_by_relation_property_asc() {
+    // Three posts each linked to a location with a different name.
+    // Query posts ordered by location.name ASC.
+    let store = SparqlStore::new(None).unwrap();
+    let ts = "1700000000000";
+
+    struct Fixture<'a> {
+        post_id: &'a str,
+        loc_id: &'a str,
+        loc_name: &'a str,
+    }
+    let fixtures = [
+        Fixture {
+            post_id: "test://post/c",
+            loc_id: "test://loc/c",
+            loc_name: "Zebra City",
+        },
+        Fixture {
+            post_id: "test://post/a",
+            loc_id: "test://loc/a",
+            loc_name: "Alpha Town",
+        },
+        Fixture {
+            post_id: "test://post/b",
+            loc_id: "test://loc/b",
+            loc_name: "Middle Place",
+        },
+    ];
+
+    for f in &fixtures {
+        // Post conformance flag
+        store
+            .add_link(&make_link(f.post_id, "ns://type", "ns://post", ts))
+            .unwrap();
+        // Post → location relation
+        store
+            .add_link(&make_link(f.post_id, "ns://has-location", f.loc_id, ts))
+            .unwrap();
+        // Location conformance flag
+        store
+            .add_link(&make_link(f.loc_id, "ns://type", "ns://location", ts))
+            .unwrap();
+        // Location name property (stored as a literal IRI)
+        let name_iri = format!("literal:string:{}", literal_percent_encode(f.loc_name));
+        store
+            .add_link(&make_link(f.loc_id, "ns://loc-name", &name_iri, ts))
+            .unwrap();
+    }
+
+    // Register both shapes in a shared resolver.
+    let resolver = StaticShapeResolver::new();
+
+    let post_shape_json = r#"{
+        "className": "Post",
+        "properties": {
+            "type": { "predicate": "ns://type", "required": true, "flag": true, "initial": "ns://post" }
+        },
+        "relations": {
+            "location": {
+                "predicate": "ns://has-location",
+                "targetClassName": "Location",
+                "kind": "hasOne"
+            }
+        }
+    }"#;
+    let loc_shape_json = r#"{
+        "className": "Location",
+        "properties": {
+            "type":    { "predicate": "ns://type",     "required": true, "flag": true, "initial": "ns://location" },
+            "name":    { "predicate": "ns://loc-name", "resolveLanguage": "literal" }
+        },
+        "relations": {}
+    }"#;
+
+    let post_shape = parse_shape_from_json(post_shape_json, "Post").unwrap();
+    let loc_shape = parse_shape_from_json(loc_shape_json, "Location").unwrap();
+    resolver.register("Post", post_shape.clone());
+    resolver.register("Location", loc_shape);
+
+    let result = super::query::execute_model_query(
+        &store,
+        &post_shape,
+        &ModelQueryInput {
+            order: Some(vec![("location.name".to_string(), OrderDirection::ASC)]),
+            limit: Some(10),
+            ..Default::default()
+        },
+        &resolver,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.instances.len(), 3, "should return all 3 posts");
+    let ids: Vec<&str> = result
+        .instances
+        .iter()
+        .map(|i| i["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        ids,
+        vec!["test://post/a", "test://post/b", "test://post/c"],
+        "posts should be ordered by location name ASC: got {ids:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_sort_by_relation_property_desc() {
+    let store = SparqlStore::new(None).unwrap();
+    let ts = "1700000000000";
+
+    let fixtures = [
+        ("test://post/x", "test://loc/x", "Cherry"),
+        ("test://post/y", "test://loc/y", "Apple"),
+        ("test://post/z", "test://loc/z", "Mango"),
+    ];
+    for (post_id, loc_id, loc_name) in &fixtures {
+        store
+            .add_link(&make_link(post_id, "ns://type", "ns://post2", ts))
+            .unwrap();
+        store
+            .add_link(&make_link(post_id, "ns://has-location", loc_id, ts))
+            .unwrap();
+        store
+            .add_link(&make_link(loc_id, "ns://type", "ns://location2", ts))
+            .unwrap();
+        let name_iri = format!("literal:string:{}", literal_percent_encode(loc_name));
+        store
+            .add_link(&make_link(loc_id, "ns://loc-name2", &name_iri, ts))
+            .unwrap();
+    }
+
+    let resolver = StaticShapeResolver::new();
+    let post_shape_json = r#"{
+        "className": "Post2",
+        "properties": {
+            "type": { "predicate": "ns://type", "required": true, "flag": true, "initial": "ns://post2" }
+        },
+        "relations": {
+            "location": { "predicate": "ns://has-location", "targetClassName": "Location2", "kind": "hasOne" }
+        }
+    }"#;
+    let loc_shape_json = r#"{
+        "className": "Location2",
+        "properties": {
+            "type": { "predicate": "ns://type", "required": true, "flag": true, "initial": "ns://location2" },
+            "name": { "predicate": "ns://loc-name2", "resolveLanguage": "literal" }
+        },
+        "relations": {}
+    }"#;
+    let post_shape = parse_shape_from_json(post_shape_json, "Post2").unwrap();
+    let loc_shape = parse_shape_from_json(loc_shape_json, "Location2").unwrap();
+    resolver.register("Post2", post_shape.clone());
+    resolver.register("Location2", loc_shape);
+
+    let result = super::query::execute_model_query(
+        &store,
+        &post_shape,
+        &ModelQueryInput {
+            order: Some(vec![("location.name".to_string(), OrderDirection::DESC)]),
+            limit: Some(10),
+            ..Default::default()
+        },
+        &resolver,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.instances.len(), 3);
+    let ids: Vec<&str> = result
+        .instances
+        .iter()
+        .map(|i| i["id"].as_str().unwrap())
+        .collect();
+    // DESC: Mango > Cherry > Apple
+    assert_eq!(
+        ids,
+        vec!["test://post/z", "test://post/x", "test://post/y"],
+        "posts should be ordered by location name DESC: got {ids:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_sort_by_relation_property_with_missing_relation() {
+    // Some posts lack a location. They should sort to the end (null last).
+    let store = SparqlStore::new(None).unwrap();
+    let ts = "1700000000000";
+
+    // post/a: has location "Beta"
+    // post/b: has location "Alpha"
+    // post/c: no location
+    store
+        .add_link(&make_link("test://post3/a", "ns://type", "ns://post3", ts))
+        .unwrap();
+    store
+        .add_link(&make_link(
+            "test://post3/a",
+            "ns://has-location3",
+            "test://loc3/a",
+            ts,
+        ))
+        .unwrap();
+    store
+        .add_link(&make_link(
+            "test://loc3/a",
+            "ns://loc-name3",
+            &format!("literal:string:{}", literal_percent_encode("Beta")),
+            ts,
+        ))
+        .unwrap();
+
+    store
+        .add_link(&make_link("test://post3/b", "ns://type", "ns://post3", ts))
+        .unwrap();
+    store
+        .add_link(&make_link(
+            "test://post3/b",
+            "ns://has-location3",
+            "test://loc3/b",
+            ts,
+        ))
+        .unwrap();
+    store
+        .add_link(&make_link(
+            "test://loc3/b",
+            "ns://loc-name3",
+            &format!("literal:string:{}", literal_percent_encode("Alpha")),
+            ts,
+        ))
+        .unwrap();
+
+    store
+        .add_link(&make_link("test://post3/c", "ns://type", "ns://post3", ts))
+        .unwrap();
+    // post3/c deliberately has no has-location3 link
+
+    let resolver = StaticShapeResolver::new();
+    let post_shape_json = r#"{
+        "className": "Post3",
+        "properties": {
+            "type": { "predicate": "ns://type", "required": true, "flag": true, "initial": "ns://post3" }
+        },
+        "relations": {
+            "location": { "predicate": "ns://has-location3", "targetClassName": "Location3", "kind": "hasOne" }
+        }
+    }"#;
+    let loc_shape_json = r#"{
+        "className": "Location3",
+        "properties": {
+            "type": { "predicate": "ns://type", "required": true, "flag": true, "initial": "ns://location" },
+            "name": { "predicate": "ns://loc-name3", "resolveLanguage": "literal" }
+        },
+        "relations": {}
+    }"#;
+    let post_shape = parse_shape_from_json(post_shape_json, "Post3").unwrap();
+    let loc_shape = parse_shape_from_json(loc_shape_json, "Location3").unwrap();
+    resolver.register("Post3", post_shape.clone());
+    resolver.register("Location3", loc_shape);
+
+    let result = super::query::execute_model_query(
+        &store,
+        &post_shape,
+        &ModelQueryInput {
+            order: Some(vec![("location.name".to_string(), OrderDirection::ASC)]),
+            limit: Some(10),
+            ..Default::default()
+        },
+        &resolver,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.instances.len(), 3);
+    let ids: Vec<&str> = result
+        .instances
+        .iter()
+        .map(|i| i["id"].as_str().unwrap())
+        .collect();
+    // Alpha < Beta < (no location → null → end)
+    assert_eq!(
+        ids,
+        vec!["test://post3/b", "test://post3/a", "test://post3/c"],
+        "post without location should sort to end: got {ids:?}"
     );
 }

--- a/rust-executor/src/perspectives/model_query/integration_tests.rs
+++ b/rust-executor/src/perspectives/model_query/integration_tests.rs
@@ -3357,9 +3357,20 @@ async fn test_full_model_query_ops_contains_with_pagination() {
 /// Helper: create a signed-envelope literal IRI (mimics what expression.create("literal", value)
 /// produces in production). The signed envelope is JSON with {author, timestamp, data, proof}.
 fn signed_envelope_literal(value: &str) -> String {
+    signed_envelope_literal_with_ts(value, "2024-01-01T00:00:00.000Z")
+}
+
+/// Same as [`signed_envelope_literal`] but with a caller-supplied embedded
+/// envelope timestamp. Needed for sort regression tests: `signed_envelope_literal`
+/// hardcodes the same timestamp for every call, so fixtures built from it never
+/// actually diverge on that field — which would mask a bug where sort extraction
+/// accidentally reads the envelope's `timestamp` instead of its `data` value
+/// (since a *shared* timestamp prefix contributes nothing to string comparison,
+/// real-world envelopes have distinct per-write timestamps).
+fn signed_envelope_literal_with_ts(value: &str, timestamp: &str) -> String {
     let envelope = serde_json::json!({
         "author": "did:key:zQ3shTestAgent",
-        "timestamp": "2024-01-01T00:00:00.000Z",
+        "timestamp": timestamp,
         "data": value,
         "proof": {
             "key": "#zQ3shTestAgent",
@@ -3982,6 +3993,64 @@ async fn test_full_model_query_order_by_property_string() {
     assert_eq!(result.instances.len(), 2);
     // First 2 reverse alphabetically: Charlie, Bob
     assert_eq!(result.instances[0]["name"].as_str().unwrap(), "Charlie");
+    assert_eq!(result.instances[1]["name"].as_str().unwrap(), "Bob");
+}
+
+/// Regression test: same as `test_full_model_query_order_by_property_string`
+/// but with values stored as signed expression envelopes (the real-world
+/// storage format), not bare `literal:string:<value>`. See
+/// `test_sort_by_relation_property_with_signed_envelope_literal` for the
+/// analogous RelationProperty-sort regression and full explanation.
+#[tokio::test]
+async fn test_full_model_query_order_by_property_string_signed_envelope() {
+    let store = SparqlStore::new(None).unwrap();
+    let ts = "1700000000000";
+
+    // Insertion order (and embedded envelope timestamp order) is Charlie, Alice,
+    // Bob — deliberately NOT alphabetical, so a bug that sorts by the envelope's
+    // embedded timestamp instead of `data` produces a different (wrong) result
+    // than the expected alphabetical order.
+    let names = ["Charlie", "Alice", "Bob"];
+    for (i, name) in names.iter().enumerate() {
+        let item = format!("test://envitem-{i}");
+        let envelope_ts = format!("2024-01-0{}T00:00:00.000Z", i + 1);
+        store
+            .add_link(&make_link(&item, "ns://type", "ns://person2", ts))
+            .unwrap();
+        store
+            .add_link(&make_link(
+                &item,
+                "ns://name2",
+                &signed_envelope_literal_with_ts(name, &envelope_ts),
+                ts,
+            ))
+            .unwrap();
+    }
+
+    let shape_json = r#"{
+        "className": "Person2",
+        "properties": {
+            "type": { "predicate": "ns://type", "required": true, "flag": true, "initial": "ns://person2" },
+            "name": { "predicate": "ns://name2", "required": false, "resolveLanguage": "literal" }
+        },
+        "relations": {}
+    }"#;
+
+    let result = execute_model_query_from_json(
+        &store,
+        "Person2",
+        &ModelQueryInput {
+            limit: Some(2),
+            order: Some(vec![("name".to_string(), OrderDirection::ASC)]),
+            ..Default::default()
+        },
+        shape_json,
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.instances.len(), 2);
+    assert_eq!(result.total_count, 3);
+    assert_eq!(result.instances[0]["name"].as_str().unwrap(), "Alice");
     assert_eq!(result.instances[1]["name"].as_str().unwrap(), "Bob");
 }
 
@@ -4618,6 +4687,100 @@ async fn test_sort_by_relation_property_desc() {
         ids,
         vec!["test://post/z", "test://post/x", "test://post/y"],
         "posts should be ordered by location name DESC: got {ids:?}"
+    );
+}
+
+/// Regression test: real-world literal storage wraps values in a signed
+/// expression envelope (`literal:json:{"author":...,"data":<value>,"proof":...}`),
+/// not a bare `literal:string:<value>`. The pagination subquery's sort-value
+/// extraction must unwrap that envelope via `fn/parse_literal` — a naive
+/// fixed-offset SUBSTR over the raw IRI string previously extracted the whole
+/// envelope blob instead, which happens to sort by the embedded `timestamp`
+/// field (since it precedes `data` in the JSON) rather than the actual value.
+#[tokio::test]
+async fn test_sort_by_relation_property_with_signed_envelope_literal() {
+    let store = SparqlStore::new(None).unwrap();
+    let ts_base = 1700000000000i64;
+
+    // Insertion order deliberately does NOT match either alphabetical or
+    // timestamp order, so a fallback-to-timestamp bug would produce a
+    // different (wrong) result than a fallback-to-insertion-order bug —
+    // either kind of regression is caught.
+    let fixtures = [
+        ("test://post/e1", "test://loc/e1", "Portugal"),
+        ("test://post/e2", "test://loc/e2", "Germany"),
+        ("test://post/e3", "test://loc/e3", "France"),
+    ];
+    for (i, (post_id, loc_id, country)) in fixtures.iter().enumerate() {
+        let ts = format!("{}", ts_base + i as i64);
+        store
+            .add_link(&make_link(post_id, "ns://type", "ns://post3", &ts))
+            .unwrap();
+        store
+            .add_link(&make_link(post_id, "ns://has-location", loc_id, &ts))
+            .unwrap();
+        store
+            .add_link(&make_link(loc_id, "ns://type", "ns://location3", &ts))
+            .unwrap();
+        let envelope_ts = format!("2024-01-0{}T00:00:00.000Z", i + 1);
+        store
+            .add_link(&make_link(
+                loc_id,
+                "ns://loc-country",
+                &signed_envelope_literal_with_ts(country, &envelope_ts),
+                &ts,
+            ))
+            .unwrap();
+    }
+
+    let resolver = StaticShapeResolver::new();
+    let post_shape_json = r#"{
+        "className": "Post3",
+        "properties": {
+            "type": { "predicate": "ns://type", "required": true, "flag": true, "initial": "ns://post3" }
+        },
+        "relations": {
+            "location": { "predicate": "ns://has-location", "targetClassName": "Location3", "kind": "hasOne" }
+        }
+    }"#;
+    let loc_shape_json = r#"{
+        "className": "Location3",
+        "properties": {
+            "type": { "predicate": "ns://type", "required": true, "flag": true, "initial": "ns://location3" },
+            "country": { "predicate": "ns://loc-country", "resolveLanguage": "literal" }
+        },
+        "relations": {}
+    }"#;
+    let post_shape = parse_shape_from_json(post_shape_json, "Post3").unwrap();
+    let loc_shape = parse_shape_from_json(loc_shape_json, "Location3").unwrap();
+    resolver.register("Post3", post_shape.clone());
+    resolver.register("Location3", loc_shape);
+
+    let result = super::query::execute_model_query(
+        &store,
+        &post_shape,
+        &ModelQueryInput {
+            order: Some(vec![("location.country".to_string(), OrderDirection::ASC)]),
+            limit: Some(10),
+            ..Default::default()
+        },
+        &resolver,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.instances.len(), 3);
+    let ids: Vec<&str> = result
+        .instances
+        .iter()
+        .map(|i| i["id"].as_str().unwrap())
+        .collect();
+    // Alphabetical by country ASC: France, Germany, Portugal
+    assert_eq!(
+        ids,
+        vec!["test://post/e3", "test://post/e2", "test://post/e1"],
+        "posts should be ordered by location.country ASC despite signed-envelope \
+         literal storage: got {ids:?}"
     );
 }
 

--- a/rust-executor/src/perspectives/model_query/query.rs
+++ b/rust-executor/src/perspectives/model_query/query.rs
@@ -90,18 +90,64 @@ pub(super) async fn execute_model_query_inner(
         }
     }
 
-    // Full pipeline
+    // Full pipeline.
+    //
+    // A single order key is pushable to SPARQL when it is:
+    //   - a reifier-timestamp synonym (`timestamp`/`createdAt`/`updatedAt`),
+    //   - a scalar property on the entry shape,
+    //   - a `$`-prefixed projection count key whose `from` relation exists, or
+    //   - a dotted relation-property path (`relName.propName`) where the
+    //     relation exists in the shape's include_relations and the named
+    //     property exists as a scalar on the target shape.
+    // Anything else (or more than one key) falls back to the post-hydration
+    // Rust sort.
     let can_push_pagination = all_where_pushable(query_input, shape) && {
         match &query_input.order {
             None => true,
             Some(order) => {
-                order.len() == 1
-                    && (order[0].0 == "timestamp"
-                        || order[0].0 == "createdAt"
-                        || order[0].0 == "updatedAt"
-                        || shape.properties.iter().any(|p| {
-                            p.name == order[0].0 && !p.is_collection && !p.predicate.is_empty()
-                        }))
+                order.len() == 1 && {
+                    let name = &order[0].0;
+                    if name == "timestamp" || name == "createdAt" || name == "updatedAt" {
+                        true
+                    } else if shape
+                        .properties
+                        .iter()
+                        .any(|p| p.name == *name && !p.is_collection && !p.predicate.is_empty())
+                    {
+                        true
+                    } else if name.starts_with('$') {
+                        query_input
+                            .projections
+                            .as_ref()
+                            .and_then(|projs| projs.get(name.as_str()))
+                            .map(|proj| {
+                                proj.count
+                                    && shape
+                                        .properties
+                                        .iter()
+                                        .any(|p| p.name == proj.from && !p.predicate.is_empty())
+                            })
+                            .unwrap_or(false)
+                    } else if let Some(dot_pos) = name.find('.') {
+                        let rel_name = &name[..dot_pos];
+                        let prop_name = &name[dot_pos + 1..];
+                        shape
+                            .include_relations
+                            .iter()
+                            .find(|r| r.name == rel_name && !r.predicate.is_empty())
+                            .and_then(|rel| resolver.get_shape(&rel.target_class_name).ok())
+                            .map(|target_shape| {
+                                target_shape.properties.iter().any(|p| {
+                                    p.name == prop_name
+                                        && !p.is_collection
+                                        && !p.predicate.is_empty()
+                                })
+                            })
+                            .unwrap_or(false)
+                    } else {
+                        false
+                    }
+                }
             }
         }
     };
@@ -126,6 +172,48 @@ pub(super) async fn execute_model_query_inner(
                         .find(|p| p.name == *key && !p.is_collection && !p.predicate.is_empty())
                     {
                         SortKey::Property(prop.predicate.clone())
+                    } else if key.starts_with('$') {
+                        // Projection count sort — find the from-relation's predicate.
+                        query_input
+                            .projections
+                            .as_ref()
+                            .and_then(|projs| projs.get(key.as_str()))
+                            .and_then(|proj| {
+                                shape
+                                    .properties
+                                    .iter()
+                                    .find(|p| p.name == proj.from && !p.predicate.is_empty())
+                                    .map(|p| p.predicate.clone())
+                            })
+                            .map(SortKey::Projection)
+                            .unwrap_or(SortKey::Timestamp)
+                    } else if let Some(dot_pos) = key.find('.') {
+                        // Dotted relation-property path: "relName.propName"
+                        let rel_name = &key[..dot_pos];
+                        let prop_name = &key[dot_pos + 1..];
+                        shape
+                            .include_relations
+                            .iter()
+                            .find(|r| r.name == rel_name && !r.predicate.is_empty())
+                            .and_then(|rel| {
+                                resolver
+                                    .get_shape(&rel.target_class_name)
+                                    .ok()
+                                    .and_then(|ts| {
+                                        ts.properties
+                                            .iter()
+                                            .find(|p| {
+                                                p.name == prop_name
+                                                    && !p.is_collection
+                                                    && !p.predicate.is_empty()
+                                            })
+                                            .map(|p| SortKey::RelationProperty {
+                                                rel_pred: rel.predicate.clone(),
+                                                prop_pred: p.predicate.clone(),
+                                            })
+                                    })
+                            })
+                            .unwrap_or(SortKey::Timestamp)
                     } else {
                         SortKey::Timestamp
                     }
@@ -143,6 +231,10 @@ pub(super) async fn execute_model_query_inner(
 
     let query_plan = build_instance_sparql(shape, query_input, sparql_pagination.as_ref());
 
+    // Captures the source IRI order returned by the phase-1 pagination subquery
+    // so we can restore it after hydration (which uses BTreeMap, alphabetical order).
+    let mut pagination_source_order: Option<Vec<String>> = None;
+
     let raw_results: Vec<Value> = match query_plan {
         InstanceQueryPlan::Single(sparql) => {
             let result_json = store.query_async(&sparql).await?;
@@ -154,6 +246,13 @@ pub(super) async fn execute_model_query_inner(
         } => {
             let page_json = store.query_async(&pagination_subquery).await?;
             let page_results: Vec<Value> = serde_json::from_str(&page_json)?;
+
+            pagination_source_order = Some(
+                page_results
+                    .iter()
+                    .filter_map(|r| r["source"].as_str().map(|s| s.to_string()))
+                    .collect(),
+            );
 
             if page_results.is_empty() {
                 vec![]
@@ -188,6 +287,26 @@ pub(super) async fn execute_model_query_inner(
 
     let grouped = group_results_by_source(&raw_results, shape);
     let mut instances = hydrate_instances(shape, &grouped);
+
+    // group_results_by_source uses BTreeMap (alphabetical by source IRI), so
+    // after hydration the instances are in lexicographic IRI order, not the
+    // sort order produced by the phase-1 pagination subquery.  Restore the
+    // SPARQL-established order here so that subsequent steps (includes,
+    // projections) see instances in the correct sequence.
+    if let Some(ref source_order) = pagination_source_order {
+        let pos: std::collections::HashMap<&str, usize> = source_order
+            .iter()
+            .enumerate()
+            .map(|(i, id)| (id.as_str(), i))
+            .collect();
+        instances.sort_by_key(|inst| {
+            inst["id"]
+                .as_str()
+                .and_then(|id| pos.get(id))
+                .copied()
+                .unwrap_or(usize::MAX)
+        });
+    }
 
     // Apply transform expressions for resolveLanguage properties
     resolve_language_transforms(&shape, &mut instances).await?;
@@ -233,14 +352,12 @@ pub(super) async fn execute_model_query_inner(
 
     // Apply ordering and pagination
     let mut paginated: Vec<Value> = if sparql_pagination.is_some() {
-        if let Some(ref order) = query_input.order {
-            sort_instances(&mut instances, order);
-        } else {
-            sort_instances(
-                &mut instances,
-                &[("timestamp".to_string(), OrderDirection::ASC)],
-            );
-        }
+        // Ordering was pushed into the SPARQL pagination subquery and the
+        // correct sequence has already been restored above — do not re-sort.
+        // (Re-sorting here would also be a no-op-or-worse for Projection /
+        // RelationProperty keys, since their source values — projection
+        // counts, hydrated relations — aren't resolved yet at this point in
+        // the pipeline.)
         instances
     } else {
         if let Some(ref order) = query_input.order {

--- a/rust-executor/src/perspectives/model_query/sparql_builder.rs
+++ b/rust-executor/src/perspectives/model_query/sparql_builder.rs
@@ -164,7 +164,7 @@ pub(super) fn build_instance_sparql(
                     r#"SELECT DISTINCT ?source (SAMPLE(?_nv) AS ?_sort_num) (SAMPLE(?_sv) AS ?_sort_str) WHERE {{
 {conformance}
 {where_extra}
-            OPTIONAL {{ ?source <{predicate}> ?_sort_raw . BIND(SUBSTR(STR(?_sort_raw), 16) AS ?_sv) BIND(<http://www.w3.org/2001/XMLSchema#double>(SUBSTR(STR(?_sort_raw), 16)) AS ?_nv) }}
+            OPTIONAL {{ ?source <{predicate}> ?_sort_raw . BIND(STR(<ad4m://fn/parse_literal>(?_sort_raw)) AS ?_sv) BIND(<http://www.w3.org/2001/XMLSchema#double>(STR(<ad4m://fn/parse_literal>(?_sort_raw))) AS ?_nv) }}
         }} GROUP BY ?source{pagination_suffix}"#
                 )
             }
@@ -185,7 +185,7 @@ pub(super) fn build_instance_sparql(
                     r#"SELECT DISTINCT ?source (SAMPLE(?_rp_num_v) AS ?_rp_num) (SAMPLE(?_rp_str_v) AS ?_rp_str) WHERE {{
 {conformance}
 {where_extra}
-            OPTIONAL {{ ?source <{rel_pred}> ?_rp_rel . OPTIONAL {{ ?_rp_rel <{prop_pred}> ?_rp_raw . BIND(SUBSTR(STR(?_rp_raw), 16) AS ?_rp_str_v) BIND(<http://www.w3.org/2001/XMLSchema#double>(SUBSTR(STR(?_rp_raw), 16)) AS ?_rp_num_v) }} }}
+            OPTIONAL {{ ?source <{rel_pred}> ?_rp_rel . OPTIONAL {{ ?_rp_rel <{prop_pred}> ?_rp_raw . BIND(STR(<ad4m://fn/parse_literal>(?_rp_raw)) AS ?_rp_str_v) BIND(<http://www.w3.org/2001/XMLSchema#double>(STR(<ad4m://fn/parse_literal>(?_rp_raw))) AS ?_rp_num_v) }} }}
         }} GROUP BY ?source{pagination_suffix}"#
                 )
             }

--- a/rust-executor/src/perspectives/model_query/sparql_builder.rs
+++ b/rust-executor/src/perspectives/model_query/sparql_builder.rs
@@ -114,6 +114,25 @@ pub(super) fn build_instance_sparql(
                     "\n    ORDER BY ASC(IF(BOUND(?_sort_str), 0, 1)) {dir}(?_sort_num) {dir}(?_sort_str)"
                 ));
             }
+            SortKey::Projection(_) => {
+                let dir = match pg.direction {
+                    OrderDirection::DESC => "DESC",
+                    OrderDirection::ASC => "ASC",
+                };
+                // COUNT returns 0 for sources with no matches (not unbound),
+                // so no null-guard is needed here.
+                suffix.push_str(&format!("\n    ORDER BY {dir}(?_proj_sort)"));
+            }
+            SortKey::RelationProperty { .. } => {
+                let dir = match pg.direction {
+                    OrderDirection::DESC => "DESC",
+                    OrderDirection::ASC => "ASC",
+                };
+                // Same nulls-to-end + numeric-first logic as Property.
+                suffix.push_str(&format!(
+                    "\n    ORDER BY ASC(IF(BOUND(?_rp_str), 0, 1)) {dir}(?_rp_num) {dir}(?_rp_str)"
+                ));
+            }
         }
         if let Some(offset) = pg.offset {
             if offset > 0 {
@@ -146,6 +165,27 @@ pub(super) fn build_instance_sparql(
 {conformance}
 {where_extra}
             OPTIONAL {{ ?source <{predicate}> ?_sort_raw . BIND(SUBSTR(STR(?_sort_raw), 16) AS ?_sv) BIND(<http://www.w3.org/2001/XMLSchema#double>(SUBSTR(STR(?_sort_raw), 16)) AS ?_nv) }}
+        }} GROUP BY ?source{pagination_suffix}"#
+                )
+            }
+            SortKey::Projection(predicate) => {
+                format!(
+                    r#"SELECT DISTINCT ?source (COUNT(DISTINCT ?_proj_t) AS ?_proj_sort) WHERE {{
+{conformance}
+{where_extra}
+            OPTIONAL {{ ?source <{predicate}> ?_proj_t . }}
+        }} GROUP BY ?source{pagination_suffix}"#
+                )
+            }
+            SortKey::RelationProperty {
+                rel_pred,
+                prop_pred,
+            } => {
+                format!(
+                    r#"SELECT DISTINCT ?source (SAMPLE(?_rp_num_v) AS ?_rp_num) (SAMPLE(?_rp_str_v) AS ?_rp_str) WHERE {{
+{conformance}
+{where_extra}
+            OPTIONAL {{ ?source <{rel_pred}> ?_rp_rel . OPTIONAL {{ ?_rp_rel <{prop_pred}> ?_rp_raw . BIND(SUBSTR(STR(?_rp_raw), 16) AS ?_rp_str_v) BIND(<http://www.w3.org/2001/XMLSchema#double>(SUBSTR(STR(?_rp_raw), 16)) AS ?_rp_num_v) }} }}
         }} GROUP BY ?source{pagination_suffix}"#
                 )
             }
@@ -681,4 +721,137 @@ pub(super) fn build_query_patterns(
     let where_extra = where_patterns.join("\n");
 
     (conformance, where_extra)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::perspectives::model_query::test_helpers::{flag, prop, shape};
+
+    fn make_pg(sort_key: SortKey, direction: OrderDirection) -> SparqlPagination {
+        SparqlPagination {
+            sort_key,
+            direction,
+            offset: None,
+            limit: Some(10),
+        }
+    }
+
+    fn pagination_subquery(shape: &ModelShape, pg: &SparqlPagination) -> String {
+        match build_instance_sparql(shape, &ModelQueryInput::default(), Some(pg)) {
+            InstanceQueryPlan::TwoPhase {
+                pagination_subquery,
+                ..
+            } => pagination_subquery,
+            InstanceQueryPlan::Single(_) => panic!("Expected TwoPhase query plan, got Single"),
+        }
+    }
+
+    #[test]
+    fn test_pagination_subquery_projection_sort_contains_count_distinct() {
+        let s = shape(
+            "Post",
+            vec![
+                flag("type", "test://type", "test://post"),
+                prop("title", "test://title"),
+            ],
+        );
+        let pg = make_pg(
+            SortKey::Projection("test://has-like".to_string()),
+            OrderDirection::DESC,
+        );
+        let sparql = pagination_subquery(&s, &pg);
+
+        assert!(
+            sparql.contains("COUNT(DISTINCT ?_proj_t)"),
+            "should emit COUNT(DISTINCT) for projection sort: {sparql}"
+        );
+        assert!(
+            sparql.contains("?_proj_sort"),
+            "should project ?_proj_sort: {sparql}"
+        );
+        assert!(
+            sparql.contains("OPTIONAL { ?source <test://has-like> ?_proj_t"),
+            "should join via predicate OPTIONAL: {sparql}"
+        );
+        assert!(
+            sparql.contains("GROUP BY ?source"),
+            "should use GROUP BY for count aggregate: {sparql}"
+        );
+        assert!(
+            sparql.contains("DESC(?_proj_sort)"),
+            "ORDER BY should use DESC: {sparql}"
+        );
+    }
+
+    #[test]
+    fn test_pagination_subquery_projection_sort_asc() {
+        let s = shape("Post", vec![flag("type", "test://type", "test://post")]);
+        let pg = make_pg(
+            SortKey::Projection("test://has-comment".to_string()),
+            OrderDirection::ASC,
+        );
+        let sparql = pagination_subquery(&s, &pg);
+        assert!(
+            sparql.contains("ASC(?_proj_sort)"),
+            "ORDER BY should use ASC: {sparql}"
+        );
+    }
+
+    #[test]
+    fn test_pagination_subquery_relation_property_sort_contains_double_optional() {
+        let s = shape(
+            "Post",
+            vec![
+                flag("type", "test://type", "test://post"),
+                prop("title", "test://title"),
+            ],
+        );
+        let pg = make_pg(
+            SortKey::RelationProperty {
+                rel_pred: "test://has-location".to_string(),
+                prop_pred: "test://location-name".to_string(),
+            },
+            OrderDirection::ASC,
+        );
+        let sparql = pagination_subquery(&s, &pg);
+
+        assert!(
+            sparql.contains("?source <test://has-location> ?_rp_rel"),
+            "outer OPTIONAL should join via relation predicate: {sparql}"
+        );
+        assert!(
+            sparql.contains("?_rp_rel <test://location-name> ?_rp_raw"),
+            "inner OPTIONAL should join via property predicate: {sparql}"
+        );
+        assert!(
+            sparql.contains("SAMPLE(?_rp_num_v)") && sparql.contains("SAMPLE(?_rp_str_v)"),
+            "should project SAMPLE of numeric and string sort columns: {sparql}"
+        );
+        assert!(
+            sparql.contains("ASC(IF(BOUND(?_rp_str), 0, 1))"),
+            "ORDER BY should push nulls to end: {sparql}"
+        );
+        assert!(
+            sparql.contains("GROUP BY ?source"),
+            "should use GROUP BY: {sparql}"
+        );
+    }
+
+    #[test]
+    fn test_pagination_subquery_relation_property_sort_desc() {
+        let s = shape("Post", vec![flag("type", "test://type", "test://post")]);
+        let pg = make_pg(
+            SortKey::RelationProperty {
+                rel_pred: "test://has-location".to_string(),
+                prop_pred: "test://location-name".to_string(),
+            },
+            OrderDirection::DESC,
+        );
+        let sparql = pagination_subquery(&s, &pg);
+        assert!(
+            sparql.contains("DESC(?_rp_num)") && sparql.contains("DESC(?_rp_str)"),
+            "ORDER BY should use DESC: {sparql}"
+        );
+    }
 }

--- a/rust-executor/src/perspectives/model_query/types.rs
+++ b/rust-executor/src/perspectives/model_query/types.rs
@@ -270,6 +270,14 @@ pub(super) enum SortKey {
     Timestamp,
     /// Sort by a property value extracted from its literal IRI.
     Property(String), // predicate IRI
+    /// Sort by a projection count — uses `COUNT(DISTINCT ?_proj_t)` in the
+    /// GROUP BY pagination subquery.  The string is the relation predicate IRI
+    /// used to reach the counted items.
+    Projection(String), // relation predicate IRI
+    /// Sort by a scalar property on a directly-related model instance.
+    /// Emits a double-OPTIONAL join in the pagination subquery:
+    /// `?source <rel_pred> ?_rel . ?_rel <prop_pred> ?_sort_val`.
+    RelationProperty { rel_pred: String, prop_pred: String },
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/js/tests/model/model-query.test.ts
+++ b/tests/js/tests/model/model-query.test.ts
@@ -431,6 +431,85 @@ describe("Ad4mModel — Query API", function () {
     expect(aEntries[1].viewCount as any as number).to.equal(2);
   });
 
+  it("order: { $commentCount: 'DESC' } sorts by a projection count (with limit)", async () => {
+    // p1: 0 comments, p2: 2 comments, p3: 1 comment
+    const c1 = await TestComment.create(perspective, { body: "on beta 1" });
+    const c2 = await TestComment.create(perspective, { body: "on beta 2" });
+    const c3 = await TestComment.create(perspective, { body: "on gamma" });
+    await p2.addComments(c1.id);
+    await p2.addComments(c2.id);
+    await p3.addComments(c3.id);
+
+    const results = await TestPost.findAll(perspective, {
+      where: { id: [p1.id, p2.id, p3.id] },
+      include: { $commentCount: { from: "comments", count: true } },
+      order: { $commentCount: "DESC" },
+      limit: 10,
+    });
+    expect(results).to.have.length(3);
+    const ids = results.map((r) => r.id);
+    expect(ids).to.deep.equal([p2.id, p3.id, p1.id]);
+    const counts = results.map((r) => (r as any).$commentCount as number);
+    expect(counts).to.deep.equal([2, 1, 0]);
+  });
+
+  it("order: { $commentCount: 'ASC' } sorts by a projection count ascending (with limit)", async () => {
+    const c1 = await TestComment.create(perspective, { body: "on beta 1" });
+    const c2 = await TestComment.create(perspective, { body: "on beta 2" });
+    const c3 = await TestComment.create(perspective, { body: "on gamma" });
+    await p2.addComments(c1.id);
+    await p2.addComments(c2.id);
+    await p3.addComments(c3.id);
+
+    const results = await TestPost.findAll(perspective, {
+      where: { id: [p1.id, p2.id, p3.id] },
+      include: { $commentCount: { from: "comments", count: true } },
+      order: { $commentCount: "ASC" },
+      limit: 10,
+    });
+    expect(results).to.have.length(3);
+    const ids = results.map((r) => r.id);
+    expect(ids).to.deep.equal([p1.id, p3.id, p2.id]);
+  });
+
+  it("order: { 'pinnedComment.body': 'ASC' } sorts by a relation-property dotted path (with limit)", async () => {
+    // Sorting by a nested relation property isn't yet reflected in TypedOrder,
+    // so this needs an `as any` escape hatch even though the executor supports it.
+    const cZ = await TestComment.create(perspective, { body: "Zebra" });
+    const cA = await TestComment.create(perspective, { body: "Alpha" });
+    const cM = await TestComment.create(perspective, { body: "Middle" });
+    await p1.addPinnedComment(cZ.id);
+    await p2.addPinnedComment(cA.id);
+    await p3.addPinnedComment(cM.id);
+
+    const results = await TestPost.findAll(perspective, {
+      where: { id: [p1.id, p2.id, p3.id] },
+      order: { "pinnedComment.body": "ASC" } as any,
+      limit: 10,
+    });
+    expect(results).to.have.length(3);
+    const ids = results.map((r) => r.id);
+    expect(ids).to.deep.equal([p2.id, p3.id, p1.id]);
+  });
+
+  it("order: { 'pinnedComment.body': 'DESC' } sorts by a relation-property dotted path descending (with limit)", async () => {
+    const cZ = await TestComment.create(perspective, { body: "Zebra" });
+    const cA = await TestComment.create(perspective, { body: "Alpha" });
+    const cM = await TestComment.create(perspective, { body: "Middle" });
+    await p1.addPinnedComment(cZ.id);
+    await p2.addPinnedComment(cA.id);
+    await p3.addPinnedComment(cM.id);
+
+    const results = await TestPost.findAll(perspective, {
+      where: { id: [p1.id, p2.id, p3.id] },
+      order: { "pinnedComment.body": "DESC" } as any,
+      limit: 10,
+    });
+    expect(results).to.have.length(3);
+    const ids = results.map((r) => r.id);
+    expect(ids).to.deep.equal([p1.id, p3.id, p2.id]);
+  });
+
   // ── 6. limit / offset ──────────────────────────────────────────────────────
 
   it("findAll() with limit returns at most that many results", async () => {


### PR DESCRIPTION
# Model query sorting by projection counts and related model properties

Branch: `feat/model-query-sort-extensions-v2`, based on `dev` (`a32f18b6`). Replaces #858 — same feature, rebuilt directly on `dev` instead of on the (now-dropped) #842 → #846 → #853 chain.

## Summary

Extends the ad4m model query pipeline to support two new sort key types in `order`:

- **Projection count sort** — sort by the number of related items, e.g. sort posts by total likes:
  ```ts
  order: { $likeCount: 'DESC' }
  projections: { $likeCount: { from: 'likes', count: true } }
  ```

- **Relation-property sort** — sort by a scalar property on a directly-related model, using dotted-path syntax:
  ```ts
  order: { 'location.name': 'ASC' }
  include: { location: true }
  ```

Both require `limit` or `offset` to be set (which triggers the TwoPhase SPARQL plan). This is the expected usage — sorting an unbounded result set by a derived aggregate without pagination would require a full-table GROUP BY and is better handled as a separate concern.

## How it works

The existing query pipeline already uses a **TwoPhase execution plan** when pagination is pushed to SPARQL:
1. Phase 1 — a lightweight pagination subquery returns source IRIs in sorted order with LIMIT/OFFSET applied
2. Phase 2 — a `VALUES ?source { ... }` property fetch retrieves the full data for that page

Both new sort types are pushed into the phase-1 subquery as SPARQL aggregates, following the same pattern already used for the existing `Property` sort key:

**Projection count** uses `COUNT(DISTINCT)` with an `OPTIONAL` join:
```sparql
OPTIONAL { ?source <ns://has-like> ?_proj_t . }
(COUNT(DISTINCT ?_proj_t) AS ?_proj_sort)
...
ORDER BY DESC(?_proj_sort)
```
COUNT returns 0 for sources with no matches, so no null-guard is needed.

**Relation-property** uses a double-`OPTIONAL` join with `SAMPLE` aggregation and nulls-to-end ordering:
```sparql
OPTIONAL {
  ?source <ns://has-location> ?_rp_rel .
  OPTIONAL {
    ?_rp_rel <ns://loc-name> ?_rp_raw .
    BIND(STR(<ad4m://fn/parse_literal>(?_rp_raw)) AS ?_rp_str_v)
    BIND(xsd:double(STR(<ad4m://fn/parse_literal>(?_rp_raw))) AS ?_rp_num_v)
  }
}
(SAMPLE(?_rp_num_v) AS ?_rp_num) (SAMPLE(?_rp_str_v) AS ?_rp_str)
...
ORDER BY ASC(IF(BOUND(?_rp_str), 0, 1)) ASC(?_rp_num) ASC(?_rp_str)
```
Numeric-first ordering mirrors the existing `Property` sort pattern. Sources with no linked relation sort to the end.

`parse_literal` is the same custom SPARQL function already used everywhere else in this file for extracting literal values in `WHERE` clauses (see the literal-extraction bug fix below) — the initial version of this PR used a naive `SUBSTR(STR(...), 16)` here instead, which was wrong.

### Single sort key only (scope note)

`dev`'s pagination pushdown supports exactly one sort key at a time (`SparqlPagination.sort_key: SortKey`). This PR adds two more variants to that same single-key model — it does **not** introduce multi-key/combined sorting (e.g. sort by projection count *and* timestamp together). That capability existed in the original #858 only because it was built on top of a separate multi-key `Vec<SortKey>` refactor from a different, unrelated PR in the old chain. Keeping this PR single-key keeps the diff scoped purely to the two features described above; multi-key sorting can be proposed as its own follow-up if needed.

### TwoPhase ordering fix

A pre-existing issue was discovered and fixed as part of this work: `group_results_by_source` uses a `BTreeMap` (alphabetical by source IRI), which discards the pagination subquery's sort order after hydration. This meant even the existing `Timestamp`/`Property` sorts could be silently overridden in edge cases where IRI-alphabetical order disagreed with the intended sort order.

The fix captures the phase-1 source order before hydration and restores it afterwards. The `sort_instances` call is then skipped for the pushed-pagination path since the SPARQL-established order is already correct.

### Literal extraction bug (found during WE testing, fixed)

Discovered while manually testing relation-property sort in WE (sorting spaces by `location.country`): direction toggling reordered the list, but the order never correlated with the actual country name.

Root cause: both `Property` and `RelationProperty` sort keys extracted their comparison value with a fixed-offset `SUBSTR(STR(?raw), 16)`, assuming string literals are stored as bare `literal:string:<value>` IRIs. Real string literals are signed expression envelopes — `literal:json:{"author":...,"timestamp":...,"data":<value>,"proof":...}` — so `SUBSTR` extracted the *entire envelope blob* instead of the value. Since `"timestamp"` appears before `"data"` in the envelope JSON, sorting on that blob effectively sorted by write time rather than the requested property. This is not new to this PR — the pre-existing `Property` sort key (used for plain scalar sorts, e.g. `order: { name: 'ASC' }`) had the identical bug; this PR's new `RelationProperty` sort key just copied the existing (broken) pattern. It went unnoticed because nearly all prior sort usage was on `createdAt`/`timestamp`, a separate code path (`SortKey::Timestamp`) that reads the reifier's own timestamp directly and never touches literal extraction — and the existing test fixtures for both `Property` and `RelationProperty` sort used simplified `literal:string:<value>` literals rather than the real signed-envelope format, so neither caught it.

Fixed by swapping `SUBSTR(STR(...), 16)` for `<ad4m://fn/parse_literal>(...)`, the custom SPARQL function already used everywhere else in `sparql_builder.rs` for extracting literal values in `WHERE` clauses — it correctly unwraps both plain and signed-envelope literals. Two regression tests were added (`test_full_model_query_order_by_property_string_signed_envelope`, `test_sort_by_relation_property_with_signed_envelope_literal`), each with a per-fixture *distinct* embedded envelope timestamp — the existing `signed_envelope_literal` test helper hardcodes one shared timestamp across all callers, so fixtures built from it never diverge on that field and would pass even under the buggy extraction. Both new tests were verified to fail against the pre-fix code and pass against the fix.

## Files changed

| File | Change |
|------|--------|
| `rust-executor/src/perspectives/model_query/types.rs` | Two new `SortKey` variants: `Projection(String)` and `RelationProperty { rel_pred, prop_pred }` |
| `rust-executor/src/perspectives/model_query/sparql_builder.rs` | `build_instance_sparql`'s existing sort match arms extended to emit SPARQL for both new key types; 4 unit tests. Follow-up fix: `Property`/`RelationProperty` value extraction switched from `SUBSTR(STR(...), 16)` to `<ad4m://fn/parse_literal>(...)` — see literal extraction bug fix above |
| `rust-executor/src/perspectives/model_query/query.rs` | Pushability check extended for `$`-prefixed and dotted-path keys; sort key resolution extended; TwoPhase ordering fix |
| `rust-executor/src/perspectives/model_query/filtering.rs` | `sort_instances` uses new `extract_sort_value` for dotted-path traversal; 8 unit tests |
| `core/src/model/types.ts` | `StrictTypedOrder` extended to accept `$`-prefixed projection keys |
| `rust-executor/src/perspectives/model_query/integration_tests.rs` | 8 new integration tests (see below) |

## Tests

**Unit tests** (`sparql_builder.rs`):
- Projection sort ASC, DESC (+ `COUNT(DISTINCT)` present in generated SPARQL)
- Relation-property sort — double-`OPTIONAL` present in generated SPARQL
- Relation-property sort DESC

**Unit tests** (`filtering.rs`):
- `extract_sort_value` plain key
- `extract_sort_value` dotted path through object
- `extract_sort_value` dotted path through array (uses first element)
- `extract_sort_value` dotted path through empty array
- `extract_sort_value` dotted path with scalar intermediate (returns null)
- `sort_instances` dotted path ASC, DESC, nulls-to-end, plain key unchanged

**Integration tests** (`integration_tests.rs`):
- `test_sort_by_projection_count_desc` — 3 posts with 5/2/0 likes, DESC order
- `test_sort_by_projection_count_asc` — 3 posts with 3/0/7 likes, ASC order
- `test_sort_by_projection_count_with_pagination` — 5 posts, page 1 of 2 DESC, total_count verified
- `test_sort_by_relation_property_asc` — 3 posts linked to locations, ASC by name
- `test_sort_by_relation_property_desc` — same data, DESC
- `test_sort_by_relation_property_with_missing_relation` — post with no location sorts to end
- `test_full_model_query_order_by_property_string_signed_envelope` — regression: `Property` sort by a signed-envelope literal, per-fixture distinct embedded timestamps; fails pre-fix, passes post-fix
- `test_sort_by_relation_property_with_signed_envelope_literal` — regression: `RelationProperty` sort by a signed-envelope literal (`location.country`), per-fixture distinct embedded timestamps; fails pre-fix, passes post-fix

All 165 tests in `perspectives::model_query` pass. `cargo check --lib` / `--tests` clean. `tsc --noEmit` on `core/` clean.

**Manual end-to-end**: both sort types verified against a locally built executor from within WE — projection-count sort (posts by like count, `CardsRoute/PostsList.ts`) and relation-property sort (spaces by `location.country`, `CardsRoute/SpacesList.ts`), including the ASC/DESC direction toggle. This is how the literal extraction bug above was found — it wasn't visible from the Rust test suite alone since the existing fixtures didn't use real signed-envelope literals.

## Known limitation

Projection and relation-property sorts are only applied when `limit` or `offset` is also set. Without pagination, the Rust-side fallback sort fires but the values it needs (`$likeCount`, hydrated relations) aren't resolved yet at that point in the pipeline — the sort silently becomes a no-op. This is acceptable for the intended use case. A follow-up can extend the TwoPhase trigger to fire on advanced sort keys even without pagination if needed.

## Not included (by design)

- Multi-key sort combination — see scope note above.
- Anything from #842 (typed RDF literal storage / `resolveLiteral`), #846 (broader orchestrator perf overhaul), or #853 (CONSTRUCT-based subgraph hydration). Verified no references to any of that work in this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sorting support for nested related fields (dotted paths like `location.name`) and computed projection counts (keys like `$commentCount`).
  * Improved pagination so results remain in the correct sorted order across pages, including for projection-based and relation-property ordering.
* **Bug Fixes**
  * Missing or invalid nested paths now consistently sort last (including empty arrays and scalar intermediates).
  * Fixed sorting for values stored in wrapped signed envelopes so the displayed data value is used rather than the envelope timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->