### PR TITLE
fix: don't resubmit entire shared link set on a transient sync failure

### DIFF
--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -851,16 +851,42 @@ impl PerspectiveInstance {
 
             local_links.retain(|(_, status)| status == &LinkStatus::Shared);
 
+            // Only a genuine `Ok(None)` from `current_revision()` means "nothing has been
+            // committed to this neighbourhood yet" — safe to treat as an empty remote set.
+            // Any other non-success outcome (a transport/timeout error from either call, or
+            // an unexpected `Ok(None)` from `render()` despite a revision existing) means we
+            // don't actually know the remote state. Treating that the same as "remote is
+            // empty" — which the previous `.unwrap_or(None).unwrap_or_default()` did — makes
+            // every local shared link look "missing" below, so a single transient timeout
+            // resubmits the perspective's *entire* shared link set (SDNA included) as a fresh
+            // batch of creates. Bail out and let the caller's backoff loop retry once the
+            // link language is actually reachable again.
             let remote_links = match link_language.current_revision().await {
-                Ok(Some(_)) => {
-                    link_language
-                        .render()
-                        .await
-                        .unwrap_or(None)
-                        .unwrap_or_default()
-                        .links
+                Ok(None) => vec![],
+                Ok(Some(_)) => match link_language.render().await {
+                    Ok(Some(rendered)) => rendered.links,
+                    Ok(None) => {
+                        log::warn!(
+                            "ensure_public_links_are_shared: render() returned no perspective for {} despite an existing revision — skipping this sync attempt rather than risk resubmitting the whole shared link set",
+                            uuid
+                        );
+                        return false;
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "ensure_public_links_are_shared: render() failed for perspective {}: {:?} — skipping this sync attempt",
+                            uuid, e
+                        );
+                        return false;
+                    }
+                },
+                Err(e) => {
+                    log::warn!(
+                        "ensure_public_links_are_shared: current_revision() failed for perspective {}: {:?} — skipping this sync attempt",
+                        uuid, e
+                    );
+                    return false;
                 }
-                _ => vec![],
             };
 
             let mut links_to_commit = Vec::new();
@@ -878,6 +904,20 @@ impl PerspectiveInstance {
 
             if !links_to_commit.is_empty() {
                 let links_count = links_to_commit.len();
+
+                // Defensive check: a fallback sync should normally only ever need to commit
+                // a handful of links that failed to make it into a prior commit. If it's
+                // about to resubmit most or all of the perspective's shared links, that's a
+                // signal something upstream (e.g. a misread of the remote state) is wrong —
+                // log it loudly so a future regression like this one is caught immediately
+                // rather than only discoverable by manually auditing link counts later.
+                if links_count > 20 && links_count as f64 > local_links.len() as f64 * 0.5 {
+                    log::warn!(
+                        "ensure_public_links_are_shared: about to commit {} of {} local shared links for perspective {} — this looks like a full resync rather than a small catch-up, which usually indicates the remote state couldn't be read correctly",
+                        links_count, local_links.len(), uuid
+                    );
+                }
+
                 let result = link_language
                     .commit(PerspectiveDiff {
                         additions: links_to_commit,

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -851,23 +851,52 @@ impl PerspectiveInstance {
 
             local_links.retain(|(_, status)| status == &LinkStatus::Shared);
 
-            // Only a genuine `Ok(None)` from `current_revision()` means "nothing has been
-            // committed to this neighbourhood yet" — safe to treat as an empty remote set.
-            // Any other non-success outcome (a transport/timeout error from either call, or
-            // an unexpected `Ok(None)` from `render()` despite a revision existing) means we
-            // don't actually know the remote state. Treating that the same as "remote is
-            // empty" — which the previous `.unwrap_or(None).unwrap_or_default()` did — makes
-            // every local shared link look "missing" below, so a single transient timeout
-            // resubmits the perspective's *entire* shared link set (SDNA included) as a fresh
-            // batch of creates. Bail out and let the caller's backoff loop retry once the
-            // link language is actually reachable again.
-            let remote_links = match link_language.current_revision().await {
-                Ok(None) => vec![],
-                Ok(Some(_)) => match link_language.render().await {
+            // `current_revision()` returns `Ok(None)` both when the link language
+            // genuinely has no committed revision yet AND when it lacks the
+            // `PerspectiveCurrentRevision` capability at all (see
+            // `Language::current_revision`) — the two cases are indistinguishable from
+            // the return value alone. Only trust `Ok(None)` as "nothing committed yet"
+            // when the capability is actually present; otherwise go straight to
+            // `render()`, which has its own capability check and safely reports
+            // "unavailable" as `Ok(None)` too.
+            //
+            // Any other non-success outcome (a transport/timeout error from either call,
+            // or an unexpected `Ok(None)` from `render()` despite a revision existing)
+            // means we don't actually know the remote state. Treating that the same as
+            // "remote is empty" — which the previous `.unwrap_or(None).unwrap_or_default()`
+            // did — makes every local shared link look "missing" below, so a single
+            // transient timeout resubmits the perspective's *entire* shared link set
+            // (SDNA included) as a fresh batch of creates. Bail out and let the caller's
+            // backoff loop retry once the link language is actually reachable again.
+            let has_revision_capability = link_language
+                .has(crate::languages::capability::Capability::PerspectiveCurrentRevision);
+
+            // `Ok(Some(_))` here just means "we're clear to call render()" — it's reached
+            // both when a revision genuinely exists and when we skip the check entirely
+            // because the capability isn't supported.
+            let known_revision = if has_revision_capability {
+                match link_language.current_revision().await {
+                    Ok(None) => None,
+                    Ok(Some(_)) => Some(()),
+                    Err(e) => {
+                        log::warn!(
+                            "ensure_public_links_are_shared: current_revision() failed for perspective {}: {:?} — skipping this sync attempt",
+                            uuid, e
+                        );
+                        return false;
+                    }
+                }
+            } else {
+                Some(())
+            };
+
+            let remote_links = match known_revision {
+                None => vec![],
+                Some(()) => match link_language.render().await {
                     Ok(Some(rendered)) => rendered.links,
                     Ok(None) => {
                         log::warn!(
-                            "ensure_public_links_are_shared: render() returned no perspective for {} despite an existing revision — skipping this sync attempt rather than risk resubmitting the whole shared link set",
+                            "ensure_public_links_are_shared: render() returned no perspective for {} — skipping this sync attempt rather than risk resubmitting the whole shared link set",
                             uuid
                         );
                         return false;
@@ -880,13 +909,6 @@ impl PerspectiveInstance {
                         return false;
                     }
                 },
-                Err(e) => {
-                    log::warn!(
-                        "ensure_public_links_are_shared: current_revision() failed for perspective {}: {:?} — skipping this sync attempt",
-                        uuid, e
-                    );
-                    return false;
-                }
             };
 
             let mut links_to_commit = Vec::new();


### PR DESCRIPTION
# fix: don't resubmit entire shared link set on a transient sync failure

Branch: `fix/fallback-sync-render-failure`, based on `dev`.

## Summary

`ensure_public_links_are_shared` treats a failed/timed-out call to the neighbourhood's link
language the same as "nothing has been committed remotely yet," causing it to resubmit a
perspective's **entire shared link set** — including its whole SDNA graph — as a fresh batch
of creates. This runs on a continuous background loop for the lifetime of the node process,
independent of any client app, so it can (and did) silently duplicate thousands of links
with zero user interaction.

## Problem

Discovered while chasing a separate bug: SDNA links (has_shacl, shacl_shape_uri, sh://property,
per-property triples) accumulating as duplicates on shared perspectives, badly enough to make
schema reads (`getAllShacl`/`getShacl`) take 15+ seconds and occasionally hang the app. App-level
fixes landed in WE and Flux for their own non-idempotent SDNA registration calls, but large
duplicate bursts (9,779 links, then 771, then 206) kept appearing on a shared "global discovery"
perspective even with those fixes in place and with **no app open at all** — the node process
was simply left running, idle.

That ruled out application code and pointed at `rust-executor`'s own background sync. Live logs
during an idle session showed the exact signature: repeated `render`/`commit`/`sendBroadcast`
timeouts against the neighbourhood's link language, immediately followed by
`"Fallback sync failed for perspective <uuid>, backing off to 60s"`, and a burst of
`"Error trying to commit diff: Other pending diffs already in queue"` messages consistent with
a large batch commit.

Root cause, in `ensure_public_links_are_shared` (`rust-executor/src/perspectives/perspective_instance.rs`):

```rust
// before
let remote_links = match link_language.current_revision().await {
    Ok(Some(_)) => {
        link_language
            .render()
            .await
            .unwrap_or(None)
            .unwrap_or_default()
            .links
    }
    _ => vec![],
};
```

- `current_revision()` returning `Ok(None)` genuinely means "nothing committed yet" — fine to
  treat as an empty remote set.
- But `current_revision()` returning `Err(_)` (a transport/timeout failure) falls into the same
  `_ => vec![]` catch-all as the legitimate case above, even though it means "unknown," not
  "empty."
- Separately, once inside the `Ok(Some(_))` branch (a revision is known to exist),
  `render().await.unwrap_or(None).unwrap_or_default()` silently collapses **both** an `Err`
  from `render()` **and** an unexpected `Ok(None)` into an empty `Perspective` — again treating
  "the call failed" as "the remote is empty."

Every local shared link then looks "missing" against that (wrongly) empty remote set, with no
size cap or sanity check on how many links that produces, and all of them get bundled into one
`commit()` call. It's plausibly self-reinforcing too: `render()` has to reconstruct state from
the neighbourhood's diff history, which is now bloated by this function's own past misfires —
making the next `render()` call slower and more likely to time out again.

## Solution

Only a genuine `Ok(None)` produces an empty remote set. Every other non-success outcome bails
out of the sync attempt entirely and lets the existing exponential-backoff loop
(`fallback_sync_loop`) retry later, instead of guessing "empty" and risking a full resubmission:

```rust
// after
let remote_links = match link_language.current_revision().await {
    Ok(None) => vec![],
    Ok(Some(_)) => match link_language.render().await {
        Ok(Some(rendered)) => rendered.links,
        Ok(None) => {
            log::warn!(
                "ensure_public_links_are_shared: render() returned no perspective for {} \
                 despite an existing revision — skipping this sync attempt rather than \
                 risk resubmitting the whole shared link set",
                uuid
            );
            return false;
        }
        Err(e) => {
            log::warn!(
                "ensure_public_links_are_shared: render() failed for perspective {}: {:?} \
                 — skipping this sync attempt",
                uuid, e
            );
            return false;
        }
    },
    Err(e) => {
        log::warn!(
            "ensure_public_links_are_shared: current_revision() failed for perspective {}: \
             {:?} — skipping this sync attempt",
            uuid, e
        );
        return false;
    }
};
```

Also added a defensive log: if a fallback sync is about to commit an unusually large
fraction of the perspective's local shared links (>20 links and >50% of the total), it now
logs a warning before doing so — a normal fallback sync should only ever be catching a
handful of links that failed to make it into a prior commit, so a large batch is itself a
signal something upstream misread the remote state, and this makes a future regression of
this kind loud in the logs immediately rather than only discoverable by manually auditing
link counts days later.

## Notes

- Single function, error-handling branches only — the success path (genuine first sync,
  genuine incremental catch-up) is unchanged.
- No protocol or storage format change, no migration needed.
- Doesn't fix the separate, likely secondary issue of SDNA registration's own existence
  check not being fully gossip-safe (`ensureSDNASubjectClass`/`add_sdna_inner`) — tracked
  separately; app-level diff-checks in WE and Flux remain worth keeping regardless.
- `cargo check --lib` clean, no new warnings.
- No automated test added yet — would need mocking the link language's `render()` /
  `current_revision()` to force the failure branches (the `retriever/mock.rs` pattern used
  in the perspective-diff-sync zome tests looks like the right starting point).

## Test plan

- [x] `cargo check --lib` — clean, no new warnings.
- [x] Manual test: rebuild `ad4m-launcher` (`ui/src-tauri`, which depends on `rust-executor`
      via a workspace path dependency) and re-run the exact idle-node repro that originally
      surfaced the bug (leave the node running with no app open, check the global space's
      duplicate link count before/after) — in progress.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link-sharing sync handling so unexpected remote-state issues no longer look like an empty remote set.
  * Sync attempts now stop and log a warning when remote revision data can’t be read reliably.
  * Added a warning when a large number of links would be committed, helping catch accidental full resyncs before they happen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->