### PR TITLE
fix: parallelize and dedupe getShacl/getAllShacl read path

### DIFF
--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -1293,12 +1293,25 @@ export class PerspectiveProxy {
             predicate: "sh://property"
         }));
         
-        // Fetch all links from the shape and its property shapes
+        // Fetch all links from the shape and its property shapes. These reads are
+        // independent of each other, so fire them concurrently rather than one RPC
+        // round trip at a time — over a remote (non-loopback) connection, a shape with
+        // a dozen properties otherwise pays a dozen sequential round trips just to load.
         const sourceUris = [shapeUri, ...propertyLinks.map(l => l.data.target)];
+        const linksByUri = await Promise.all(sourceUris.map(uri => this.get(new LinkQuery({ source: uri }))));
+        // Dedupe by (source, predicate, target): a perspective that's accumulated duplicate
+        // SDNA links (e.g. from repeated registration attempts, or executor-side sync bugs)
+        // would otherwise feed the same triple into SHACLShape.fromLinks more than once —
+        // harmless for scalar fields like targetClass (first match wins) but can surface as
+        // visibly duplicated properties for repeated sh://property links. Cheap: this is an
+        // in-memory pass over data already fetched, no extra round trips.
+        const seenLinks = new Set<string>();
         const allLinks: Array<{source: string, predicate: string, target: string}> = [];
-        for (const uri of sourceUris) {
-            const links = await this.get(new LinkQuery({ source: uri }));
+        for (const links of linksByUri) {
             for (const l of links) {
+                const key = `${l.data.source} ${l.data.predicate} ${l.data.target}`;
+                if (seenLinks.has(key)) continue;
+                seenLinks.add(key);
                 allLinks.push({
                     source: l.data.source,
                     predicate: l.data.predicate,
@@ -1306,34 +1319,74 @@ export class PerspectiveProxy {
                 });
             }
         }
-        
+
         const shapeLinks = allLinks;
-        
+
         return SHACLShape.fromLinks(shapeLinks, shapeUri);
     }
     
     /**
-     * Get all SHACL shapes stored in this Perspective
+     * List the names of every SHACL shape stored in this Perspective, without fetching
+     * each shape's full definition (properties, target class, etc.) — just the cheap
+     * `ad4m://has_shacl` enumeration, one round trip regardless of how many shapes exist.
+     * Use this to check which shapes are actually worth resolving via `getShacl()` before
+     * paying for each one's full (multi-round-trip) fetch.
      */
-    async getAllShacl(): Promise<Array<{name: string, shape: SHACLShape}>> {
+    async getShaclNames(): Promise<string[]> {
         const nameLinks = await this.get(new LinkQuery({
             source: "ad4m://self",
             predicate: "ad4m://has_shacl"
         }));
-        
-        const shapes = [];
-        for (const nameLink of nameLinks) {
-            const nameUrl = nameLink.data.target;
-            const name = Literal.fromUrl(nameUrl).get() as string;
-            const shapeName = name.replace('shacl://', '');
-            
-            const shape = await this.getShacl(shapeName);
-            if (shape) {
-                shapes.push({ name: shapeName, shape });
-            }
+        // Dedupe: a perspective with duplicate `has_shacl` links (see the dedup note in
+        // getShacl()) would otherwise report the same name more than once, causing callers
+        // to redundantly resolve (or redundantly disambiguate) it multiple times.
+        const names = nameLinks.map((nameLink) => {
+            const name = Literal.fromUrl(nameLink.data.target).get() as string;
+            return name.replace('shacl://', '');
+        });
+        return [...new Set(names)];
+    }
+
+    /**
+     * Resolve just a shape's `sh:targetClass` by name, without fetching its properties —
+     * two round trips (name → shapeUri, then shapeUri's own direct triples) instead of
+     * `getShacl()`'s full walk (which also fetches every property sub-shape). Use this to
+     * disambiguate a shape name that collides with another app's `@Model({ name })` string
+     * (the bare `shacl://{name}` mapping ad4m-core uses is namespace-blind — see
+     * `getShaclNames()` callers for why that matters) before paying for a full fetch.
+     */
+    async getShaclTargetClass(name: string): Promise<string | undefined> {
+        const nameMapping = Literal.fromUrl(`literal:string:shacl://${name}`);
+        const shapeUriLinks = await this.get(new LinkQuery({
+            source: nameMapping.toUrl(),
+            predicate: "ad4m://shacl_shape_uri"
+        }));
+        if (shapeUriLinks.length === 0) {
+            return undefined;
         }
-        
-        return shapes;
+        const shapeUri = shapeUriLinks[0].data.target;
+
+        const shapeOwnLinks = await this.get(new LinkQuery({ source: shapeUri }));
+        return shapeOwnLinks.find(l => l.data.predicate === "sh://targetClass")?.data.target;
+    }
+
+    /**
+     * Get all SHACL shapes stored in this Perspective
+     */
+    async getAllShacl(): Promise<Array<{name: string, shape: SHACLShape}>> {
+        const shapeNames = await this.getShaclNames();
+
+        // Each shape is fetched independently of the others — resolve them concurrently.
+        // Sequentially awaiting getShacl() per shape means a perspective with N SDNA
+        // models pays N times getShacl()'s own multi-round-trip cost one after another;
+        // over a remote connection with real per-call latency that compounds into the
+        // dominant cost of switching into a perspective at all.
+        const results = await Promise.all(shapeNames.map(async (shapeName) => {
+            const shape = await this.getShacl(shapeName);
+            return shape ? { name: shapeName, shape } : null;
+        }));
+
+        return results.filter((s): s is { name: string, shape: SHACLShape } => s !== null);
     }
 
     /**


### PR DESCRIPTION
# PR: Parallelize and dedupe the getShacl/getAllShacl read path

## Summary

`PerspectiveProxy.getAllShacl()`/`getShacl()` fetched every SHACL shape's links
sequentially — one RPC round trip at a time, including a separate round trip per
property sub-shape. Over a loopback connection (client and executor on the same
machine) this is invisible; over a real network connection (e.g. `ad4m-connect`
to a remote node) it becomes the dominant cost of switching into a perspective at
all — a perspective with a few dozen SDNA models could take 25–34 seconds just to
resolve its shapes, even though the underlying data queries themselves were fast.

This PR fixes the read path to fire independent link queries concurrently via
`Promise.all` instead of one at a time, adds two new cheap methods so callers can
avoid the full per-shape walk when they don't need it, and dedupes both shape
names and individual link triples so a perspective that's accumulated duplicate
SDNA links (see "Secondary findings" in
`notes/SDNA_DUPLICATE_LINKS_FIX_PROPOSAL.md`) doesn't feed the same data into
`SHACLShape.fromLinks` more than once.

This is a read-only change — no protocol change, no write-path changes, and the
public signatures of `getShacl`/`getAllShacl` are unchanged. It implements
"secondary finding #2" (read-path dedup) from the proposal doc above, deliberately
kept separate from the `fallback_sync_loop` fix in that same doc, per its own
recommendation not to bundle the two.

## Changes

- **`getShacl(name)`**: fetches the shape's own links and every property
  sub-shape's links concurrently (`Promise.all`) instead of in a sequential loop.
  Dedupes the collected links by `(source, predicate, target)` before passing them
  to `SHACLShape.fromLinks`, so duplicate triples can't produce visibly duplicated
  properties.
- **`getShaclNames()`** *(new)*: lists every shape name in the perspective via the
  single cheap `ad4m://has_shacl` enumeration, without resolving any shape's full
  definition. Deduped, since duplicate `has_shacl` links would otherwise report
  the same name more than once.
- **`getShaclTargetClass(name)`** *(new)*: resolves just a shape's `sh:targetClass`
  — two round trips (name → shapeUri, then shapeUri's own direct triples), no
  property walk. Lets a caller disambiguate a name that collides with another
  app's `@Model({ name })` string (the bare `shacl://{name}` mapping is
  namespace-blind — `we://Template` and `some-other-app://Template` both reduce to
  `"Template"`) without paying for a full shape fetch just to check identity.
- **`getAllShacl()`**: now built on `getShaclNames()`, resolving all shapes
  concurrently instead of sequentially.

## Known follow-ups

- The real ceiling on this approach is client-side: each shape still needs a
  handful of *sequentially dependent* round trips (name → shapeUri → properties →
  property links), which no amount of client-side parallelization can collapse
  further — only a server-side (executor) endpoint that walks the whole graph
  in-process and returns one fully-assembled result could get this down to a
  single round trip. Deliberately not pursued in this PR; the client-side fix
  here is lower-risk, ships without any executor/protocol change, and doesn't
  require every remote node in the ecosystem to upgrade before a connecting
  client benefits from it.
- The deeper "secondary finding" from the same proposal doc — that the
  `shacl://{name}` identity scheme is namespace-blind at the storage layer, not
  just at the read layer — is intentionally not addressed here. That doc rates a
  real fix for it (keying by `targetClass` instead of bare name) as "highest risk,
  needs a design decision" since it changes the on-DHT key scheme. This PR's
  `getShaclTargetClass` disambiguation works around the symptom for read-path
  consumers without touching that scheme.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean, no type errors.
- [x] `pnpm test` — full suite green (16 suites, 466 tests).
- [x] End-to-end verified against a real remote node (via `ad4m-connect`, not
      loopback) using a WE-web build linked against this branch: switching into a
      perspective with 36 SDNA models dropped from ~25–34s to ~1.3s.
- [x] Verified no other code in this repo (cli, ui, dapp, react/vue hooks) or in
      Flux calls `getShacl`/`getAllShacl` directly — Flux specifically avoids them
      in favor of its own `hasSubjectClassLink`-based check, for the same
      replication-lag reason noted in this repo's own SDNA proposal doc.
