### PR TITLE
fix(executor): propagate real event-loop errors instead of TLA mask

### DIFF
--- a/rust-executor/src/js_core/futures.rs
+++ b/rust-executor/src/js_core/futures.rs
@@ -84,13 +84,18 @@ where
             };
         }
 
-        if let Poll::Ready(event_loop_result) = &mut worker
+        let event_loop_poll = worker
             .js_runtime
-            .poll_event_loop(cx, deno_core::PollEventLoopOptions::default())
-        {
+            .poll_event_loop(cx, deno_core::PollEventLoopOptions::default());
+        if let Poll::Ready(event_loop_result) = event_loop_poll {
             if let Err(err) = event_loop_result {
+                // Propagate the actual event-loop error. This previously returned a
+                // hardcoded CoreError::TLA, which relabelled EVERY event-loop failure
+                // (permission denials, uncaught rejections, module-eval errors) as
+                // "Top-level await is not allowed in synchronous evaluation" — a red
+                // herring that hid the real cause of language-bundle load failures.
                 log::error!("Error in event loop: {:?}", err);
-                return Poll::Ready(Err(CoreError::TLA));
+                return Poll::Ready(Err(err));
             }
 
             if let Poll::Ready(result) = value_pin.poll(cx) {


### PR DESCRIPTION
## Summary

`SmartGlobalVariableFuture::poll` returned a hardcoded `CoreError::TLA` for **every** event-loop failure during synchronous language evaluation — permission denials, uncaught rejections, and module-eval errors all surfaced as *"Top-level await is not allowed in synchronous evaluation."* That red herring hid the real cause of language-bundle load failures.

Concretely: a bundled dependency reading `process.env` under `allow_env:none` throws `NotCapable`, but the executor reported it as a phantom TLA error — with no top-level await anywhere in the bundle. The real error was already being logged one line above; this just returns it instead of discarding it.

Surfaced while bringing [git-link-language](https://github.com/coasys/git-link-language) up on a live executor (AD4M wind-tunnel C1 convergence run), where a sandbox `NotCapable` denial masqueraded as a TLA error across multiple sessions.

## Change

Single commit, +9/−4 in `rust-executor/src/js_core/futures.rs`: return the actual event-loop error rather than `CoreError::TLA`.

## Test plan

- [x] `cargo fmt --check` clean (rust-executor)
- [ ] `cargo build` + executor suite green on CI
- [ ] A language bundle that trips a sandbox permission denial now reports the real cause (`NotCapable` / env access) instead of a phantom top-level-await error

## Notes

- Branch is currently behind `dev` (cut from an earlier point) — happy to Update branch / rebase before merge.

cc @lucksus @data-bot-coasys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during asynchronous processing.
  * When the event loop fails, the actual error details are now surfaced instead of a generic fallback, making issues easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->