### PR TITLE
Adopt #842 follow-up fixes (security, reifier stability, Ops/encoding alignment)

### DIFF
--- a/core/src/model/Ad4mModel.test.ts
+++ b/core/src/model/Ad4mModel.test.ts
@@ -2432,3 +2432,62 @@ describe("IncludeProjection type guard and key splitting", () => {
     expect((results[0] as any).$signalCount).toBe(5);
   });
 });
+
+describe("Ad4mModel instance identity (uniqueness without envelopes)", () => {
+  // Without a signed envelope, the only thing that keeps two instances from
+  // collapsing onto the same node is their auto-generated base expression.
+  // These tests pin that guarantee down: identity must come from the
+  // instance's own IRI, never from (possibly duplicate) property content.
+  const mockPerspective = {} as any;
+
+  it("auto-generates a distinct id for every instance, even with identical property values", () => {
+    @Model({ name: "IdentityTestMessage" })
+    class IdentityTestMessage extends Ad4mModel {
+      @Property({ through: "identity://body", resolveLanguage: "literal" })
+      body: string = "";
+    }
+
+    const message1 = new IdentityTestMessage(mockPerspective);
+    const message2 = new IdentityTestMessage(mockPerspective);
+
+    message1.body = "hello";
+    message2.body = "hello";
+
+    expect(message1.body).toBe(message2.body);
+    expect(message1.id).not.toBe(message2.id);
+  });
+
+  it("uses the ad4m://obj/<random> scheme, not content-derived addressing", () => {
+    @Model({ name: "IdentityTestSchemeCheck" })
+    class IdentityTestSchemeCheck extends Ad4mModel {}
+
+    const instance = new IdentityTestSchemeCheck(mockPerspective);
+
+    // 24 lowercase a-z chars after the prefix (see makeRandomId in ./util.ts).
+    // Locks in the scheme so a regression toward hashing property content
+    // for the base expression — which would reintroduce the exact collision
+    // this scheme exists to prevent — fails this test.
+    expect(instance.id).toMatch(/^ad4m:\/\/obj\/[a-z]{24}$/);
+  });
+
+  it("never reuses an id across many instances", () => {
+    @Model({ name: "IdentityTestManyInstances" })
+    class IdentityTestManyInstances extends Ad4mModel {}
+
+    const ids = Array.from(
+      { length: 200 },
+      () => new IdentityTestManyInstances(mockPerspective).id
+    );
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("respects an explicitly-provided base expression instead of generating one", () => {
+    @Model({ name: "IdentityTestExplicitId" })
+    class IdentityTestExplicitId extends Ad4mModel {}
+
+    const instance = new IdentityTestExplicitId(mockPerspective, "flux://existing-instance");
+
+    expect(instance.id).toBe("flux://existing-instance");
+  });
+});

--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -441,16 +441,18 @@ export class Ad4mModel {
    * 
    * @param perspective - The perspective where this model will be stored
    * @param baseExpression - Optional expression URI for this instance.
-   *             If omitted, a random Literal URL is generated.
+   *             If omitted, a random `ad4m://obj/<id>` IRI is generated,
+   *             independent of any property content — this is what keeps
+   *             two instances with identical property values distinct.
    * @param source - Optional source expression this instance is linked to
-   * 
+   *
    * @example
    * ```typescript
    * // Create a new recipe with auto-generated base expression
    * const recipe = new Recipe(perspective);
-   * 
+   *
    * // Create with specific base expression
-   * const recipe = new Recipe(perspective, "literal:...");
+   * const recipe = new Recipe(perspective, "ad4m://obj/existing-id");
    * ```
    */
   constructor(perspective: PerspectiveProxy, baseExpression?: string) {

--- a/plugins/ad4m/skills/ad4m/SKILL.md
+++ b/plugins/ad4m/skills/ad4m/SKILL.md
@@ -76,6 +76,8 @@ Almost always, work on the level of **CLASSES**. AD4M provides a type-system on 
 
 **For you, that means: to CREATE and MODIFY INSTANCES OF MESSAGES, TASKS, CHANNELS — ALWAYS USE DYNAMIC MCP TOOLS like `ad4m_message_create` or `ad4m_channel_set_name`.** Unless you have good reason to write links directly. But if you do, don't expect other UI apps and thus your human(s) to get that data.
 
+**Why this matters beyond compatibility: raw links don't give you uniqueness.** `addLink`/`ad4m_add_link` writes exactly the triple you give it — it has no concept of "this one particular message" versus "this text." Link directly against content (e.g. using a message's text as the link's source/target) instead of going through a subject class, and two entities with identical content become indistinguishable — there's no separate node to tell them apart. Reifier-based signing doesn't fix this either: it authenticates *who claimed this link and when*, not *which entity this is*. Subject classes fix it because every instance gets its own randomly-generated, content-independent ID (`ad4m://obj/<id>`) the moment it's created — that ID, not the property values, is what makes the instance unique. Full explanation in `references/architecture.md`.
+
 ### 6. expression_address is now optional
 
 When creating any subject instance (`message_create`, etc.), you can now **omit** the `expression_address` — a random address is automatically generated for you. Only provide it if you need a specific ID.
@@ -210,7 +212,7 @@ Use `ad4m_list_waker_subscriptions()` to see active subscriptions, and `ad4m_uns
 
 ## Model base expressions / IDs
 
-Model instances are constructed around a base node (called base expression, also ID). Usually those are random literal strings (`literal://string:xyz`). Their properties hang off of that base node with predicates as defined by the class.
+Model instances are constructed around a base node (called base expression, also ID) — a freshly generated, random `ad4m://obj/<id>` IRI, independent of any property content. Their properties hang off of that base node with predicates as defined by the class. This is also what keeps two instances with identical property values (e.g. two messages with the same text) distinct and independently addressable — see rule 5 and `references/architecture.md`.
 
 ## Tree structure
 

--- a/plugins/ad4m/skills/ad4m/references/architecture.md
+++ b/plugins/ad4m/skills/ad4m/references/architecture.md
@@ -60,6 +60,14 @@ interface LinkExpression {
 - `did:key:z6Mk...` — agent identity
 - `Qm...` — content-addressed expression (language-specific)
 
+### Links Alone Don't Give You Uniqueness
+
+`addLink` is a raw graph-edge primitive — `ad4m_add_link(perspective_id, source, predicate, target)` writes exactly the triple you give it and has no opinion about whether `source` or `target` uniquely identifies anything in your domain. Link directly against content (e.g. using a message's text itself as the source or target of a link, instead of a dedicated instance IRI) and two logically distinct entities with identical content collapse onto the same graph node — there's nothing left to tell them apart.
+
+**Reifiers provide provenance, not identity.** Every link is stored with an RDF 1.2 reifier — `<link:HASH> rdf:reifies <<( source predicate target )>>` — carrying author, timestamp, and signature metadata for that specific triple-assertion (`rust-executor/src/perspectives/sparql_store.rs`). This answers "who claimed this link, when, and is it validly signed" for any individual write. It does **not** give the entity the triple describes a stable, addressable identity. Two different messages, each independently reified with their own author and timestamp, are still indistinguishable as entities if both use the same literal as their source/target — the reifier authenticates the assertion, not the thing being asserted about.
+
+**Subject classes are the canonical fix.** Instantiating a subject class always mints a fresh, random, content-independent base expression (`ad4m://obj/<24 random chars>` — see `core/src/model/Ad4mModel.ts`) *before* any property is written, and every property write for that instance uses this IRI as the link's `source` — never the property's own value. Two instances with byte-identical properties therefore stay distinct: identity lives in the instance's IRI, not in whatever its properties happen to hold. Work at the class/model level (`ad4m_add_model`, `{class}_create`, `@Property`) rather than writing raw links directly, unless you're deliberately reconstructing this uniqueness guarantee yourself.
+
 ## Languages
 
 Protocol abstractions that handle expression storage and retrieval. A language defines:
@@ -102,6 +110,8 @@ Subject classes impose structure on the link graph using SHACL (Shapes Constrain
 ### How It Works
 
 Classes are registered via the `ad4m_add_model` MCP tool (or `add_sdna()` in Rust) using a JSON representation of a SHACL shape. The JSON is parsed by `SHACLShape` / `PropertyShape` structs and converted to RDF links in the perspective.
+
+Each instance's identity is its base expression — a freshly generated, content-independent `ad4m://obj/<id>` IRI (see [Links Alone Don't Give You Uniqueness](#links-alone-dont-give-you-uniqueness) above). This is what makes subject classes the canonical way to model anything where two instances might end up with identical property values.
 
 ### SHACL JSON Format
 

--- a/rust-executor/src/mcp/tools/subscriptions.rs
+++ b/rust-executor/src/mcp/tools/subscriptions.rs
@@ -46,6 +46,23 @@ pub struct MentionWakerConfigParams {
 }
 
 // ============================================================================
+// Helpers
+// ============================================================================
+
+/// Escape a string for safe interpolation inside a double-quoted SPARQL
+/// string literal. Mention terms come from profile names / `name_override`
+/// — untrusted input, potentially attacker-controlled in a shared
+/// neighbourhood — so without this, a `"` or `\` breaks out of the literal
+/// and can inject arbitrary SPARQL into the mention-matching FILTER.
+fn escape_sparql_literal(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
+}
+
+// ============================================================================
 // Tool Implementations
 // ============================================================================
 
@@ -223,7 +240,7 @@ impl Ad4mMcpHandler {
             .map(|t| {
                 format!(
                     "CONTAINS(LCASE(STR(<ad4m://fn/parse_literal>(?target))), \"{}\")",
-                    t
+                    escape_sparql_literal(t)
                 )
             })
             .collect();
@@ -286,5 +303,41 @@ impl Ad4mMcpHandler {
             ),
         })
         .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_escape_sparql_literal_neutralizes_quote_breakout() {
+        // A profile name / name_override containing a `"` must not be able
+        // to close the SPARQL string literal early and inject a second
+        // CONTAINS(...) clause (or worse) into the mention FILTER.
+        let malicious = r#"x") || CONTAINS(STR(?target), "leaked"#;
+        let escaped = escape_sparql_literal(malicious);
+
+        let condition = format!("CONTAINS(LCASE(STR(?target)), \"{}\")", escaped);
+
+        // The whole payload must resolve to a single string literal — i.e.
+        // exactly two unescaped double quotes (the ones we added), none
+        // contributed by the input.
+        let unescaped_quote_count = condition
+            .char_indices()
+            .filter(|&(i, c)| c == '"' && (i == 0 || condition.as_bytes()[i - 1] != b'\\'))
+            .count();
+        assert_eq!(
+            unescaped_quote_count, 2,
+            "escaped payload must not introduce unescaped quotes: {condition}"
+        );
+    }
+
+    #[test]
+    fn test_escape_sparql_literal_handles_backslash_and_control_chars() {
+        assert_eq!(escape_sparql_literal(r"a\b"), r"a\\b");
+        assert_eq!(escape_sparql_literal("a\"b"), "a\\\"b");
+        assert_eq!(escape_sparql_literal("a\nb"), "a\\nb");
+        assert_eq!(escape_sparql_literal("plain"), "plain");
     }
 }

--- a/rust-executor/src/perspectives/migration.rs
+++ b/rust-executor/src/perspectives/migration.rs
@@ -591,9 +591,7 @@ mod tests {
             .iter()
             .find(|l| l.data.source == "ad4m://self")
             .expect("Should find link with canonical source URI");
-        // After typed-literal round-trip the underscore is percent-encoded
-        // canonically (NON_ALPHANUMERIC), matching `literal_encode`'s output.
-        assert_eq!(canonical.data.target, "literal:string:already%5Fgood");
+        assert_eq!(canonical.data.target, "literal:string:already_good");
 
         // Rusqlite should be empty
         let remaining = Ad4mDb::with_global_instance(|db| db.get_all_links(&handle.uuid).unwrap());

--- a/rust-executor/src/perspectives/mod.rs
+++ b/rust-executor/src/perspectives/mod.rs
@@ -743,8 +743,9 @@ mod tests {
     use chrono::Utc;
 
     fn setup() {
-        //setup_wallet();
+        crate::test_utils::setup_wallet();
         Ad4mDb::init_global_instance(":memory:").unwrap();
+        crate::agent::AgentService::init_global_test_instance();
     }
 
     async fn find_perspective_by_uuid(

--- a/rust-executor/src/perspectives/model_query/integration_tests.rs
+++ b/rust-executor/src/perspectives/model_query/integration_tests.rs
@@ -10,7 +10,7 @@ use super::sparql_builder::build_instance_sparql;
 use super::test_helpers::{
     evaluate_getters_batch_from_json, execute_model_query_from_json, StaticShapeResolver,
 };
-use super::types::{ModelShape, ShapeProperty};
+use super::types::{ModelQueryInput, ModelShape, ShapeProperty};
 use super::utils::literal_percent_encode;
 use super::*;
 use crate::perspectives::sparql_store::SparqlStore;
@@ -5099,5 +5099,366 @@ async fn test_sort_by_relation_property_with_missing_relation() {
         ids,
         vec!["test://post3/b", "test://post3/a", "test://post3/c"],
         "post without location should sort to end: got {ids:?}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Indexed-WHERE benchmark
+// -----------------------------------------------------------------------------
+//
+// `cargo test --release --lib perspectives::model_query::integration_tests::bench`
+//
+// Compares two equivalent SPARQL queries against the same `literal:string:`
+// data: an indexed direct-IRI probe vs. a `fn/parse_literal`-wrapped FILTER.
+// The former is what the WHERE builders now emit; the latter is the shape
+// they emitted before. Both queries find the same rows; the difference is
+// whether Oxigraph's planner can use the POS index.
+
+#[test]
+fn bench_indexed_iri_vs_fn_parse_literal_filter() {
+    use std::time::Instant;
+
+    // Skip in debug builds — comparing per-row function call to an index probe
+    // is meaningless without optimisations.
+    if cfg!(debug_assertions) {
+        eprintln!("(bench skipped — run with --release)");
+        return;
+    }
+
+    // Toggle scale with WT_BENCH_LINKS; 10k by default.
+    let n_links: usize = std::env::var("WT_BENCH_LINKS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10_000);
+
+    let store = SparqlStore::new(None).unwrap();
+    let pred = "ns://body";
+    let target_value = "needle";
+    let stored_target = format!("literal:string:{}", literal_percent_encode(target_value));
+
+    // Seed N rows; only the last carries the matching target.
+    let needle_idx = n_links - 1;
+    for i in 0..n_links {
+        let source = format!("test://row/{i}");
+        store
+            .add_link(&make_link(
+                &source,
+                "ns://type",
+                "ns://row",
+                &format!("{}", 1_700_000_000_000_i64 + i as i64),
+            ))
+            .unwrap();
+        let target = if i == needle_idx {
+            stored_target.clone()
+        } else {
+            format!(
+                "literal:string:{}",
+                literal_percent_encode(&format!("row-{i}"))
+            )
+        };
+        store
+            .add_link(&make_link(
+                &source,
+                pred,
+                &target,
+                &format!("{}", 1_700_000_000_000_i64 + i as i64),
+            ))
+            .unwrap();
+    }
+
+    let indexed = format!("SELECT ?source WHERE {{ ?source <{pred}> \"{target_value}\" . }}");
+    let filtered = format!(
+        "SELECT ?source WHERE {{ \
+            ?source <{pred}> ?t . \
+            FILTER(STR(?t) = \"{target_value}\") \
+        }}"
+    );
+
+    // Warm-up — touch every triple under both query plans before timing.
+    let _ = store.query(&indexed).unwrap();
+    let _ = store.query(&filtered).unwrap();
+
+    let runs = 5;
+    let mut indexed_total = std::time::Duration::ZERO;
+    let mut filtered_total = std::time::Duration::ZERO;
+    let expected = format!("test://row/{needle_idx}");
+
+    for _ in 0..runs {
+        let start = Instant::now();
+        let r = store.query(&indexed).unwrap();
+        indexed_total += start.elapsed();
+        let rows: Vec<Value> = serde_json::from_str(&r).unwrap();
+        assert_eq!(rows.len(), 1, "indexed query must return exactly 1 row");
+        assert_eq!(
+            rows[0]["source"].as_str(),
+            Some(expected.as_str()),
+            "indexed query must return only the needle source",
+        );
+
+        let start = Instant::now();
+        let r = store.query(&filtered).unwrap();
+        filtered_total += start.elapsed();
+        let rows: Vec<Value> = serde_json::from_str(&r).unwrap();
+        assert_eq!(rows.len(), 1, "filtered query must return exactly 1 row");
+        assert_eq!(
+            rows[0]["source"].as_str(),
+            Some(expected.as_str()),
+            "filtered query must return only the needle source",
+        );
+    }
+
+    let indexed_us = (indexed_total.as_secs_f64() * 1_000_000.0) / runs as f64;
+    let filtered_us = (filtered_total.as_secs_f64() * 1_000_000.0) / runs as f64;
+    let speedup = filtered_us / indexed_us;
+    eprintln!(
+        "[bench] n={n_links}  indexed={indexed_us:.1}µs  fn_parse_literal_filter={filtered_us:.1}µs  speedup={speedup:.1}x"
+    );
+}
+
+#[tokio::test]
+async fn test_persistent_store_typed_literal_comparison() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = SparqlStore::new(Some(dir.path().to_str().unwrap())).unwrap();
+    let ts = "1700000000000";
+
+    let items: Vec<String> = (0..5).map(|i| format!("test://item-{i}")).collect();
+    let scores = [10.0, 30.0, 50.0, 70.0, 90.0];
+    let names = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"];
+
+    for (i, item) in items.iter().enumerate() {
+        store
+            .add_link(&make_link(item, "ns://type", "ns://scored", ts))
+            .unwrap();
+        store
+            .add_link(&make_link(
+                item,
+                "ns://score",
+                &signed_literal_number(scores[i]),
+                ts,
+            ))
+            .unwrap();
+        store
+            .add_link(&make_link(item, "ns://name", &signed_literal(names[i]), ts))
+            .unwrap();
+    }
+
+    let shape_json = r#"{
+        "className": "Scored",
+        "properties": {
+            "type": { "predicate": "ns://type", "required": true, "flag": true, "initial": "ns://scored" },
+            "score": { "predicate": "ns://score", "required": false, "resolveLanguage": "literal" },
+            "name": { "predicate": "ns://name", "required": false, "resolveLanguage": "literal" }
+        },
+        "relations": {}
+    }"#;
+
+    // Test 1: gt numeric
+    let mut wc = BTreeMap::new();
+    wc.insert(
+        "score".to_string(),
+        WhereCondition::Ops(WhereOps {
+            gt: Some(50.0),
+            ..Default::default()
+        }),
+    );
+    let result = execute_model_query_from_json(
+        &store,
+        "Scored",
+        &ModelQueryInput {
+            where_clause: Some(wc),
+            ..Default::default()
+        },
+        shape_json,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        result.instances.len(),
+        2,
+        "persistent: gt:50 should match 70 and 90, got {:?}",
+        result.instances
+    );
+
+    // Test 2: not string
+    let mut wc = BTreeMap::new();
+    wc.insert(
+        "name".to_string(),
+        WhereCondition::Ops(WhereOps {
+            not: Some(Value::String("Alpha".to_string())),
+            ..Default::default()
+        }),
+    );
+    let result = execute_model_query_from_json(
+        &store,
+        "Scored",
+        &ModelQueryInput {
+            where_clause: Some(wc),
+            ..Default::default()
+        },
+        shape_json,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        result.instances.len(),
+        4,
+        "persistent: not:Alpha should match 4 items, got {:?}",
+        result.instances
+    );
+
+    // Test 3: not string array
+    let mut wc = BTreeMap::new();
+    wc.insert(
+        "name".to_string(),
+        WhereCondition::Ops(WhereOps {
+            not: Some(Value::Array(vec![
+                Value::String("Alpha".to_string()),
+                Value::String("Beta".to_string()),
+            ])),
+            ..Default::default()
+        }),
+    );
+    let result = execute_model_query_from_json(
+        &store,
+        "Scored",
+        &ModelQueryInput {
+            where_clause: Some(wc),
+            ..Default::default()
+        },
+        shape_json,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        result.instances.len(),
+        3,
+        "persistent: not:[Alpha,Beta] should match 3 items, got {:?}",
+        result.instances
+    );
+
+    // Diagnostic: raw SPARQL to verify typed literal comparison
+    let raw_gt = store
+        .query(
+            r#"SELECT ?s WHERE {
+                ?s <ns://score> ?v .
+                FILTER(?v > "50"^^<http://www.w3.org/2001/XMLSchema#integer>)
+            }"#,
+        )
+        .unwrap();
+    let raw_gt_rows: Vec<Value> = serde_json::from_str(&raw_gt).unwrap();
+    eprintln!(
+        "[diag] raw gt:50 query returned {} rows: {:?}",
+        raw_gt_rows.len(),
+        raw_gt_rows
+    );
+    assert_eq!(raw_gt_rows.len(), 2, "raw SPARQL gt:50 must return 2 rows");
+
+    let raw_neq = store
+        .query(
+            r#"SELECT ?s WHERE {
+                ?s <ns://name> ?v .
+                FILTER(?v != "Alpha"^^<http://www.w3.org/2001/XMLSchema#string>)
+            }"#,
+        )
+        .unwrap();
+    let raw_neq_rows: Vec<Value> = serde_json::from_str(&raw_neq).unwrap();
+    eprintln!(
+        "[diag] raw neq:Alpha query returned {} rows: {:?}",
+        raw_neq_rows.len(),
+        raw_neq_rows
+    );
+    assert_eq!(
+        raw_neq_rows.len(),
+        4,
+        "raw SPARQL neq:Alpha must return 4 rows"
+    );
+}
+
+#[tokio::test]
+async fn test_model_query_from_js_wire_format() {
+    use super::query::execute_model_query;
+
+    let store = SparqlStore::new(None).unwrap();
+    let ts = "1700000000000";
+
+    let items: Vec<String> = (0..5).map(|i| format!("test://item-{i}")).collect();
+    let titles = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"];
+    let counts = [10i64, 20, 30, 40, 50];
+
+    for (i, item) in items.iter().enumerate() {
+        store
+            .add_link(&make_link(item, "test://post_type", "test://post", ts))
+            .unwrap();
+        store
+            .add_link(&make_link(
+                item,
+                "test://title",
+                &signed_literal(titles[i]),
+                ts,
+            ))
+            .unwrap();
+        store
+            .add_link(&make_link(
+                item,
+                "test://view_count",
+                &format!("literal:number:{}", counts[i]),
+                ts,
+            ))
+            .unwrap();
+    }
+
+    let shape_json = r#"{
+        "className": "TestPost",
+        "properties": {
+            "type": { "predicate": "test://post_type", "required": true, "flag": true, "initial": "test://post" },
+            "title": { "predicate": "test://title", "required": true, "resolveLanguage": "literal" },
+            "viewCount": { "predicate": "test://view_count", "required": false, "resolveLanguage": "literal" }
+        },
+        "relations": {}
+    }"#;
+
+    // Simulate exact JSON wire format from JS client:
+    // { "where": { "viewCount": { "gt": 30 } }, "deepQuery": true }
+    let wire_json = r#"{"where": {"viewCount": {"gt": 30}}, "deepQuery": true}"#;
+    let query_input: ModelQueryInput = serde_json::from_str(wire_json).unwrap();
+    eprintln!("[wire] parsed query: {:?}", query_input);
+
+    let (resolver, shape) = StaticShapeResolver::from_json("TestPost", shape_json).unwrap();
+    let result = execute_model_query(&store, shape.as_ref(), &query_input, &resolver)
+        .await
+        .unwrap();
+    assert_eq!(
+        result.instances.len(),
+        2,
+        "wire gt:30 should match 40 and 50, got {:?}",
+        result.instances
+    );
+
+    // not:Alpha from JS wire format
+    let wire_json = r#"{"where": {"title": {"not": "Alpha"}}, "deepQuery": true}"#;
+    let query_input: ModelQueryInput = serde_json::from_str(wire_json).unwrap();
+    eprintln!("[wire] parsed not query: {:?}", query_input);
+
+    let result = execute_model_query(&store, shape.as_ref(), &query_input, &resolver)
+        .await
+        .unwrap();
+    assert_eq!(
+        result.instances.len(),
+        4,
+        "wire not:Alpha should match 4, got {:?}",
+        result.instances
+    );
+
+    // between from JS wire format
+    let wire_json = r#"{"where": {"viewCount": {"between": [20, 40]}}, "deepQuery": true}"#;
+    let query_input: ModelQueryInput = serde_json::from_str(wire_json).unwrap();
+    let result = execute_model_query(&store, shape.as_ref(), &query_input, &resolver)
+        .await
+        .unwrap();
+    assert_eq!(
+        result.instances.len(),
+        3,
+        "wire between:[20,40] should match 3, got {:?}",
+        result.instances
     );
 }

--- a/rust-executor/src/perspectives/model_query/integration_tests.rs
+++ b/rust-executor/src/perspectives/model_query/integration_tests.rs
@@ -5462,3 +5462,148 @@ async fn test_model_query_from_js_wire_format() {
         result.instances
     );
 }
+
+#[tokio::test]
+async fn test_duplicate_literal_property_values_keep_instances_distinct() {
+    // Two Message-like instances with IDENTICAL body text must remain two
+    // distinct, independently addressable/queryable entities. Uniqueness
+    // comes from each instance's own subject-class base IRI (the source of
+    // the property triple), never from the shared literal object — see PR
+    // #842 discussion on why bare literals cannot provide entity identity.
+    let store = SparqlStore::new(None).unwrap();
+
+    let base1 = "ad4m://obj/aaaaaaaaaaaaaaaaaaaaaaaa";
+    let base2 = "ad4m://obj/bbbbbbbbbbbbbbbbbbbbbbbb";
+    let hello_target = format!("literal:string:{}", literal_percent_encode("hello"));
+
+    for base in [base1, base2] {
+        store
+            .add_link(&make_link(
+                base,
+                "ad4m://type",
+                "message://Message",
+                "1700000000000",
+            ))
+            .unwrap();
+        store
+            .add_link(&make_link(
+                base,
+                "message://body",
+                &hello_target,
+                "1700000000001",
+            ))
+            .unwrap();
+    }
+
+    let shape_json = r#"{
+        "className": "Message",
+        "properties": {
+            "type": {
+                "predicate": "ad4m://type",
+                "required": true,
+                "flag": true,
+                "initial": "message://Message"
+            },
+            "body": {
+                "predicate": "message://body",
+                "required": false,
+                "resolveLanguage": "literal"
+            }
+        },
+        "relations": {}
+    }"#;
+
+    // Identical body text must NOT collapse the two instances into one.
+    let result =
+        execute_model_query_from_json(&store, "Message", &ModelQueryInput::default(), shape_json)
+            .await
+            .unwrap();
+    assert_eq!(
+        result.instances.len(),
+        2,
+        "two instances with identical body text must both be returned, not deduplicated: {:?}",
+        result.instances
+    );
+
+    let mut ids: Vec<String> = result
+        .instances
+        .iter()
+        .map(|i| i["id"].as_str().unwrap().to_string())
+        .collect();
+    ids.sort();
+    let mut expected_ids = vec![base1.to_string(), base2.to_string()];
+    expected_ids.sort();
+    assert_eq!(
+        ids, expected_ids,
+        "each instance must keep its own distinct base IRI"
+    );
+    for instance in &result.instances {
+        assert_eq!(instance["body"], json!("hello"));
+    }
+
+    // A WHERE clause on the shared value must match both — the store
+    // indexes triples by (subject, predicate, object), not by object value
+    // alone, so a shared literal never merges two subjects into one.
+    let mut where_clause = BTreeMap::new();
+    where_clause.insert(
+        "body".to_string(),
+        WhereCondition::String("hello".to_string()),
+    );
+    let query_where = ModelQueryInput {
+        where_clause: Some(where_clause),
+        ..Default::default()
+    };
+    let result2 = execute_model_query_from_json(&store, "Message", &query_where, shape_json)
+        .await
+        .unwrap();
+    assert_eq!(
+        result2.instances.len(),
+        2,
+        "WHERE body='hello' must match both instances sharing that literal value"
+    );
+
+    // Mutating one instance's property must never leak onto the other —
+    // this is what `setSingleTarget` relies on in production: remove+add
+    // scoped by (source, predicate), where `source` is the instance's own
+    // base IRI, not the literal value being replaced.
+    store
+        .remove_link(&make_link(
+            base1,
+            "message://body",
+            &hello_target,
+            "1700000000001",
+        ))
+        .unwrap();
+    let goodbye_target = format!("literal:string:{}", literal_percent_encode("goodbye"));
+    store
+        .add_link(&make_link(
+            base1,
+            "message://body",
+            &goodbye_target,
+            "1700000000002",
+        ))
+        .unwrap();
+
+    let result3 =
+        execute_model_query_from_json(&store, "Message", &ModelQueryInput::default(), shape_json)
+            .await
+            .unwrap();
+    let body_by_id: HashMap<String, String> = result3
+        .instances
+        .iter()
+        .map(|i| {
+            (
+                i["id"].as_str().unwrap().to_string(),
+                i["body"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        body_by_id[base1], "goodbye",
+        "base1's body should reflect its own update"
+    );
+    assert_eq!(
+        body_by_id[base2], "hello",
+        "base2's body must be unaffected by base1's independent update"
+    );
+}

--- a/rust-executor/src/perspectives/model_query/integration_tests.rs
+++ b/rust-executor/src/perspectives/model_query/integration_tests.rs
@@ -5106,16 +5106,16 @@ async fn test_sort_by_relation_property_with_missing_relation() {
 // Indexed-WHERE benchmark
 // -----------------------------------------------------------------------------
 //
-// `cargo test --release --lib perspectives::model_query::integration_tests::bench`
+// `cargo test --release --lib perspectives::model_query::integration_tests::bench_indexed_literal_vs_str_filter`
 //
 // Compares two equivalent SPARQL queries against the same `literal:string:`
-// data: an indexed direct-IRI probe vs. a `fn/parse_literal`-wrapped FILTER.
-// The former is what the WHERE builders now emit; the latter is the shape
-// they emitted before. Both queries find the same rows; the difference is
-// whether Oxigraph's planner can use the POS index.
+// data: an indexed direct-typed-literal probe vs. a `FILTER(STR(?t) = ...)`
+// comparison. The former is what the WHERE builders now emit; the latter is
+// the shape they emitted before. Both queries find the same rows; the
+// difference is whether Oxigraph's planner can use the POS index.
 
 #[test]
-fn bench_indexed_iri_vs_fn_parse_literal_filter() {
+fn bench_indexed_literal_vs_str_filter() {
     use std::time::Instant;
 
     // Skip in debug builds — comparing per-row function call to an index probe

--- a/rust-executor/src/perspectives/model_query/round_trip_tests.rs
+++ b/rust-executor/src/perspectives/model_query/round_trip_tests.rs
@@ -567,3 +567,179 @@ fn round_trip_no_resolve_options_is_deterministic() {
         "no resolve options → deterministic literal storage (perf default)",
     );
 }
+
+/// End-to-end test mimicking the JS integration test pipeline:
+/// SHACL shape → store → load shape → add data → model query with operators.
+#[tokio::test]
+async fn e2e_shacl_shape_with_where_ops() {
+    use super::query::execute_model_query;
+    use super::test_helpers::StaticShapeResolver;
+    use super::types::{ModelQueryInput, WhereCondition, WhereOps};
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    let store = SparqlStore::new(None).unwrap();
+
+    let shacl_json = r#"{
+        "target_class": "ns://TestPost",
+        "properties": [
+            {
+                "path": "test://post_type",
+                "name": "type",
+                "min_count": 1,
+                "max_count": 1,
+                "has_value": "test://post",
+                "resolve_language": null
+            },
+            {
+                "path": "test://title",
+                "name": "title",
+                "datatype": "xsd://string",
+                "resolve_language": "literal"
+            },
+            {
+                "path": "test://view_count",
+                "name": "viewCount",
+                "datatype": "xsd://integer",
+                "resolve_language": "literal"
+            }
+        ]
+    }"#;
+
+    let class_name = "TestPost";
+    let target_class_uri = "ns://TestPost";
+    let shape_uri = "ns://TestPostShape";
+
+    let shacl_links = parse_shacl_to_links(shacl_json, class_name).expect("parse SHACL");
+    let mut all_links = vec![
+        Link {
+            source: target_class_uri.to_string(),
+            predicate: Some("rdf://type".to_string()),
+            target: "ad4m://SubjectClass".to_string(),
+        },
+        Link {
+            source: target_class_uri.to_string(),
+            predicate: Some("ad4m://shape".to_string()),
+            target: shape_uri.to_string(),
+        },
+    ];
+    all_links.extend(shacl_links);
+    for link in all_links {
+        store.add_link(&make_link_for_round_trip(link)).unwrap();
+    }
+
+    let shape = load_shape(&store, class_name).expect("load shape");
+    eprintln!("[e2e] Loaded shape properties:");
+    for p in &shape.properties {
+        eprintln!(
+            "  {} predicate={} resolve_language={:?} is_flag={} is_required={} initial={:?}",
+            p.name, p.predicate, p.resolve_language, p.is_flag, p.is_required, p.initial_value
+        );
+    }
+
+    let ts = "1700000000000";
+    let items = [
+        "test://post-1",
+        "test://post-2",
+        "test://post-3",
+        "test://post-4",
+        "test://post-5",
+    ];
+    let titles = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"];
+    let counts: [f64; 5] = [10.0, 20.0, 30.0, 40.0, 50.0];
+
+    for (i, item) in items.iter().enumerate() {
+        store
+            .add_link(&make_link_for_round_trip(Link {
+                source: item.to_string(),
+                predicate: Some("test://post_type".to_string()),
+                target: "test://post".to_string(),
+            }))
+            .unwrap();
+        store
+            .add_link(&make_link_for_round_trip(Link {
+                source: item.to_string(),
+                predicate: Some("test://title".to_string()),
+                target: format!(
+                    "literal:string:{}",
+                    percent_encoding::utf8_percent_encode(
+                        titles[i],
+                        percent_encoding::NON_ALPHANUMERIC
+                    )
+                ),
+            }))
+            .unwrap();
+        let count_target = if counts[i].fract() == 0.0 {
+            format!("literal:number:{}", counts[i] as i64)
+        } else {
+            format!("literal:number:{}", counts[i])
+        };
+        store
+            .add_link(&make_link_for_round_trip(Link {
+                source: item.to_string(),
+                predicate: Some("test://view_count".to_string()),
+                target: count_target,
+            }))
+            .unwrap();
+    }
+
+    let shape_arc = Arc::new(shape);
+    let resolver = StaticShapeResolver::new();
+    resolver.register_arc(class_name, shape_arc.clone());
+
+    // Test: gt numeric
+    let mut wc = BTreeMap::new();
+    wc.insert(
+        "viewCount".to_string(),
+        WhereCondition::Ops(WhereOps {
+            gt: Some(30.0),
+            ..Default::default()
+        }),
+    );
+    let result = execute_model_query(
+        &store,
+        shape_arc.as_ref(),
+        &ModelQueryInput {
+            where_clause: Some(wc),
+            ..Default::default()
+        },
+        &resolver,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        result.instances.len(),
+        2,
+        "e2e: gt:30 should match 40 and 50, got {} instances: {:?}",
+        result.instances.len(),
+        result.instances
+    );
+
+    // Test: not string
+    let mut wc = BTreeMap::new();
+    wc.insert(
+        "title".to_string(),
+        WhereCondition::Ops(WhereOps {
+            not: Some(serde_json::Value::String("Alpha".to_string())),
+            ..Default::default()
+        }),
+    );
+    let result = execute_model_query(
+        &store,
+        shape_arc.as_ref(),
+        &ModelQueryInput {
+            where_clause: Some(wc),
+            ..Default::default()
+        },
+        &resolver,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        result.instances.len(),
+        4,
+        "e2e: not:Alpha should match 4, got {} instances: {:?}",
+        result.instances.len(),
+        result.instances
+    );
+}

--- a/rust-executor/src/perspectives/model_query/sparql_builder.rs
+++ b/rust-executor/src/perspectives/model_query/sparql_builder.rs
@@ -717,176 +717,111 @@ pub(super) fn build_query_patterns(
                     }
                     WhereCondition::Ops(ops) => {
                         let var = format!("?_pw_{safe_name}");
+                        let val_var = format!("?_pw_{safe_name}_v");
                         where_patterns.push(format!("    ?source <{}> {var} .", prop.predicate));
+                        // Compare on the lexical string rather than on a typed
+                        // literal term: Oxigraph treats a simple literal and an
+                        // `xsd:string` literal as distinct terms, so `?v != "x"^^xsd:string`
+                        // silently fails to match values stored either way.
+                        //
+                        // Deterministic literals expose their value via `STR()`
+                        // directly; envelope / custom-language values need
+                        // `parse_literal` first to reach the inner `data`.
+                        let val_src = if is_literal_prop {
+                            var.clone()
+                        } else {
+                            format!("<ad4m://fn/parse_literal>({var})")
+                        };
+                        where_patterns.push(format!("    BIND(STR({val_src}) AS {val_var})"));
 
                         let mut filters = Vec::new();
 
-                        if is_literal_prop {
-                            // Deterministic typed-literal storage: compare directly
-                            // against `?val` using SPARQL's native xsd datatype
-                            // semantics so Oxigraph's index serves the comparison.
-                            if let Some(ref not_val) = ops.not {
-                                match not_val {
-                                    Value::String(s) => {
-                                        let escaped = escape_sparql_string(s);
+                        if let Some(ref not_val) = ops.not {
+                            match not_val {
+                                Value::String(s) => {
+                                    filters.push(format!(
+                                        "{val_var} != \"{}\"",
+                                        escape_sparql_string(s)
+                                    ));
+                                }
+                                Value::Number(n) => {
+                                    let n_f64 = n.as_f64().unwrap_or(0.0);
+                                    let n_str = if n_f64.fract() == 0.0 {
+                                        format!("{}", n_f64 as i64)
+                                    } else {
+                                        format!("{n_f64}")
+                                    };
+                                    filters.push(format!("{val_var} != \"{n_str}\""));
+                                }
+                                Value::Bool(b) => {
+                                    filters.push(format!("{val_var} != \"{b}\""));
+                                }
+                                Value::Array(arr) => {
+                                    let items: Vec<String> = arr
+                                        .iter()
+                                        .filter_map(|item| match item {
+                                            Value::String(s) => {
+                                                Some(format!("\"{}\"", escape_sparql_string(s)))
+                                            }
+                                            Value::Number(n) => {
+                                                let f = n.as_f64().unwrap_or(0.0);
+                                                let s = if f.fract() == 0.0 {
+                                                    format!("{}", f as i64)
+                                                } else {
+                                                    format!("{f}")
+                                                };
+                                                Some(format!("\"{s}\""))
+                                            }
+                                            _ => None,
+                                        })
+                                        .collect();
+                                    if !items.is_empty() {
                                         filters.push(format!(
-                                            "{var} != \"{escaped}\"^^<{XSD_STRING}>"
+                                            "{val_var} NOT IN ({})",
+                                            items.join(", ")
                                         ));
                                     }
-                                    Value::Number(n) => {
-                                        let n_f64 = n.as_f64().unwrap_or(0.0);
-                                        if let Some(typed) = typed_number_literal(n_f64) {
-                                            filters.push(format!("{var} != {typed}"));
-                                        }
-                                    }
-                                    Value::Bool(b) => {
-                                        filters.push(format!("{var} != \"{b}\"^^<{XSD_BOOLEAN}>"));
-                                    }
-                                    Value::Array(arr) => {
-                                        let items: Vec<String> = arr
-                                            .iter()
-                                            .filter_map(|item| match item {
-                                                Value::String(s) => Some(format!(
-                                                    "\"{}\"^^<{XSD_STRING}>",
-                                                    escape_sparql_string(s)
-                                                )),
-                                                Value::Number(n) => {
-                                                    let f = n.as_f64().unwrap_or(0.0);
-                                                    typed_number_literal(f)
-                                                }
-                                                Value::Bool(b) => {
-                                                    Some(format!("\"{b}\"^^<{XSD_BOOLEAN}>"))
-                                                }
-                                                _ => None,
-                                            })
-                                            .collect();
-                                        if !items.is_empty() {
-                                            filters.push(format!(
-                                                "{var} NOT IN ({})",
-                                                items.join(", ")
-                                            ));
-                                        }
-                                    }
-                                    _ => {}
                                 }
+                                _ => {}
                             }
+                        }
+
+                        let has_numeric = ops.gt.is_some()
+                            || ops.gte.is_some()
+                            || ops.lt.is_some()
+                            || ops.lte.is_some()
+                            || ops.between.is_some();
+
+                        if has_numeric {
+                            let num_var = format!("?_pw_{safe_name}_num");
+                            where_patterns
+                                .push(format!("    BIND(<{XSD_DOUBLE}>({val_var}) AS {num_var})"));
                             if let Some(gt) = ops.gt {
-                                match typed_number_literal(gt) {
-                                    Some(typed) => filters.push(format!("{var} > {typed}")),
-                                    None => filters.push("false".to_string()),
-                                }
+                                filters.push(format!("{num_var} > {gt}"));
                             }
                             if let Some(gte) = ops.gte {
-                                match typed_number_literal(gte) {
-                                    Some(typed) => filters.push(format!("{var} >= {typed}")),
-                                    None => filters.push("false".to_string()),
-                                }
+                                filters.push(format!("{num_var} >= {gte}"));
                             }
                             if let Some(lt) = ops.lt {
-                                match typed_number_literal(lt) {
-                                    Some(typed) => filters.push(format!("{var} < {typed}")),
-                                    None => filters.push("false".to_string()),
-                                }
+                                filters.push(format!("{num_var} < {lt}"));
                             }
                             if let Some(lte) = ops.lte {
-                                match typed_number_literal(lte) {
-                                    Some(typed) => filters.push(format!("{var} <= {typed}")),
-                                    None => filters.push("false".to_string()),
-                                }
+                                filters.push(format!("{num_var} <= {lte}"));
                             }
                             if let Some((lo, hi)) = ops.between {
-                                match (typed_number_literal(lo), typed_number_literal(hi)) {
-                                    (Some(lo_t), Some(hi_t)) => {
-                                        filters.push(format!("{var} >= {lo_t} && {var} <= {hi_t}"))
-                                    }
-                                    _ => filters.push("false".to_string()),
-                                }
+                                filters.push(format!("{num_var} >= {lo} && {num_var} <= {hi}"));
                             }
-                            if let Some(ref contains_val) = ops.contains {
-                                let needle = match contains_val {
-                                    Value::String(s) => s.clone(),
-                                    other => other.to_string(),
-                                };
-                                filters.push(format!(
-                                    "CONTAINS(LCASE(STR({var})), LCASE(\"{}\"))",
-                                    escape_sparql_string(&needle)
-                                ));
-                            }
-                        } else {
-                            // Expression-resolved storage (signed literal envelope
-                            // or a custom resolveLanguage). The stored term is the
-                            // envelope, so unwrap the inner value with
-                            // `fn/parse_literal` and compare on the decoded text /
-                            // numeric cast. Not index-served, but correct.
-                            let pv = format!("<ad4m://fn/parse_literal>({var})");
-                            let num = format!("<{XSD_DOUBLE}>({pv})");
-                            if let Some(ref not_val) = ops.not {
-                                match not_val {
-                                    Value::String(s) => {
-                                        filters.push(format!(
-                                            "{pv} != \"{}\"",
-                                            escape_sparql_string(s)
-                                        ));
-                                    }
-                                    Value::Number(n) => {
-                                        filters.push(format!(
-                                            "{num} != {}",
-                                            n.as_f64().unwrap_or(0.0)
-                                        ));
-                                    }
-                                    Value::Bool(b) => {
-                                        filters.push(format!("{pv} != \"{b}\""));
-                                    }
-                                    Value::Array(arr) => {
-                                        let items: Vec<String> = arr
-                                            .iter()
-                                            .filter_map(|item| match item {
-                                                Value::String(s) => {
-                                                    Some(format!("\"{}\"", escape_sparql_string(s)))
-                                                }
-                                                Value::Number(n) => Some(format!(
-                                                    "\"{}\"",
-                                                    n.as_f64().unwrap_or(0.0)
-                                                )),
-                                                Value::Bool(b) => Some(format!("\"{b}\"")),
-                                                _ => None,
-                                            })
-                                            .collect();
-                                        if !items.is_empty() {
-                                            filters.push(format!(
-                                                "{pv} NOT IN ({})",
-                                                items.join(", ")
-                                            ));
-                                        }
-                                    }
-                                    _ => {}
-                                }
-                            }
-                            if let Some(gt) = ops.gt {
-                                filters.push(format!("{num} > {gt}"));
-                            }
-                            if let Some(gte) = ops.gte {
-                                filters.push(format!("{num} >= {gte}"));
-                            }
-                            if let Some(lt) = ops.lt {
-                                filters.push(format!("{num} < {lt}"));
-                            }
-                            if let Some(lte) = ops.lte {
-                                filters.push(format!("{num} <= {lte}"));
-                            }
-                            if let Some((lo, hi)) = ops.between {
-                                filters.push(format!("{num} >= {lo} && {num} <= {hi}"));
-                            }
-                            if let Some(ref contains_val) = ops.contains {
-                                let needle = match contains_val {
-                                    Value::String(s) => s.clone(),
-                                    other => other.to_string(),
-                                };
-                                filters.push(format!(
-                                    "CONTAINS(LCASE({pv}), LCASE(\"{}\"))",
-                                    escape_sparql_string(&needle)
-                                ));
-                            }
+                        }
+
+                        if let Some(ref contains_val) = ops.contains {
+                            let needle = match contains_val {
+                                Value::String(s) => s.clone(),
+                                other => other.to_string(),
+                            };
+                            filters.push(format!(
+                                "CONTAINS(LCASE({val_var}), LCASE(\"{}\"))",
+                                escape_sparql_string(&needle)
+                            ));
                         }
 
                         if !filters.is_empty() {

--- a/rust-executor/src/perspectives/model_query/utils.rs
+++ b/rust-executor/src/perspectives/model_query/utils.rs
@@ -7,22 +7,30 @@
 
 use deno_core::anyhow::{anyhow, Error};
 #[cfg(test)]
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use percent_encoding::utf8_percent_encode;
 use serde_json::Value;
 
 // ---------------------------------------------------------------------------
 // SPARQL injection prevention helpers
 // ---------------------------------------------------------------------------
 
-/// Encode a string for use in a `literal:string:…` IRI, using
-/// `NON_ALPHANUMERIC` percent-encoding to match `literal_encode` in
-/// `languages/literal.rs`. (`urlencoding::encode` keeps RFC 3986's
-/// `.-_~`, which diverges from the storage encoding.) Test-only —
+/// Percent-encoding set matching JS `encodeRFC3986URIComponent`.
+/// Leaves `A-Z a-z 0-9 - _ . ~` un-encoded — same characters the SDK
+/// preserves, so `literal:*:` URLs round-trip without re-encoding drift.
+#[cfg(test)]
+const RFC3986_COMPONENT_ENCODE: percent_encoding::AsciiSet = percent_encoding::NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
+
+/// Encode a string for use in a `literal:string:…` IRI, matching
+/// the JS SDK's `encodeRFC3986URIComponent` encoding. Test-only —
 /// production paths construct typed RDF literals instead of synthesising
 /// the URI form by hand.
 #[cfg(test)]
 pub(super) fn literal_percent_encode(s: &str) -> String {
-    utf8_percent_encode(s, NON_ALPHANUMERIC).to_string()
+    utf8_percent_encode(s, &RFC3986_COMPONENT_ENCODE).to_string()
 }
 
 /// Format a finite f64 for the `literal:number:` IRI tail, mirroring

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -2930,9 +2930,13 @@ impl PerspectiveInstance {
         .await
     }
 
-    /// Execute a SPARQL query against this perspective's Oxigraph store
+    /// Execute a SPARQL query against this perspective's Oxigraph store.
+    /// This is the generic `perspective.querySparql` entrypoint — the query
+    /// text is caller-supplied, so it uses `query_arbitrary` rather than
+    /// `query` (no wire-format re-encoding of coincidentally-named
+    /// `?target`/`?t` bindings; see `SparqlStore::query_arbitrary`).
     pub fn sparql_query(&self, query: String) -> Result<String, deno_core::anyhow::Error> {
-        self.sparql_store.query(&query)
+        self.sparql_store.query_arbitrary(&query)
     }
 
     /// Execute a model query — the executor-side replacement for

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -6317,16 +6317,13 @@ mod tests {
             .await
             .expect("add_sdna");
 
-        // `literal:string:` URIs are wire-format encodings of typed string
-        // values; round-tripping them through typed-literal storage
-        // re-encodes `_` as `%5F` per `literal_encode`'s canonical output.
-        let post_root = "literal:string:test%5Fpost%5Froot";
-        let parent_root = "literal:string:test%5Fparent%5Froot";
+        let post_root = "literal:string:test_post_root";
+        let parent_root = "literal:string:test_parent_root";
 
         // Title link makes the post a BlogPost instance (structural conformance)
         for (src, pred, tgt) in &[
-            (post_root, "blog://title", "literal:string:my%5Fpost"),
-            (parent_root, "blog://title", "literal:string:my%5Fparent"),
+            (post_root, "blog://title", "literal:string:my_post"),
+            (parent_root, "blog://title", "literal:string:my_parent"),
             (post_root, "blog://reply_to", parent_root),
         ] {
             let link = DecoratedLinkExpression {

--- a/rust-executor/src/perspectives/sparql_store.rs
+++ b/rust-executor/src/perspectives/sparql_store.rs
@@ -273,11 +273,27 @@ pub fn validate_readonly_query(query: &str) -> Result<(), Error> {
 
 /// Generate a deterministic reifier IRI from link data + timestamp.
 fn make_reifier_iri(link: &DecoratedLinkExpression) -> NamedNode {
+    // Hash the *normalized* storage-term form of the target, not the raw
+    // wire string. `literal:json:` targets are canonicalized before storage
+    // (see `target_to_storage_term`), so two callers describing the same
+    // JSON value with different key order/whitespace would otherwise hash
+    // to different reifier IRIs for what ends up being the identical stored
+    // triple. `remove_link` recomputes this same hash from whatever
+    // wire-format string the caller passes in (e.g. the hydrated form read
+    // back from a query), so a mismatch here orphans the reifier metadata
+    // and leaves the direct triple un-removable. Normalizing first makes
+    // the hash a pure function of the stored term, independent of how the
+    // caller happened to format an equivalent value. This is a no-op for
+    // every other target shape (NamedNode / number / boolean round-trip
+    // through `target_to_storage_term` unchanged).
+    let normalized_target =
+        storage_term_to_target_string(&target_to_storage_term(&link.data.target));
+
     let mut hasher = Sha256::new();
     hasher.update(link.author.as_bytes());
     hasher.update(link.data.source.as_bytes());
     hasher.update(link.data.predicate.as_deref().unwrap_or("").as_bytes());
-    hasher.update(link.data.target.as_bytes());
+    hasher.update(normalized_target.as_bytes());
     hasher.update(link.timestamp.as_bytes());
     let hash = hex::encode(hasher.finalize());
     NamedNode::new_unchecked(format!("link:{}", &hash[..32]))
@@ -968,9 +984,31 @@ impl SparqlStore {
         })
     }
 
-    /// Execute an arbitrary read-only SPARQL SELECT query, returning a JSON string.
+    /// Execute a read-only SPARQL SELECT query, returning a JSON string.
     /// All data lives in the default graph — no union graph needed.
+    ///
+    /// Applies wire-format hydration to `?target`/`?t` bindings — this is
+    /// the internal convention AD4M's own hydration/relation/projection
+    /// query builders rely on. For query text supplied by an external or
+    /// untrusted caller (who has no reason to expect — or want — a
+    /// same-named variable of their own silently reformatted), use
+    /// [`Self::query_arbitrary`] instead.
     pub fn query(&self, query_string: &str) -> Result<String, Error> {
+        self.query_internal(query_string, true)
+    }
+
+    /// Execute a caller-supplied read-only SPARQL SELECT query (e.g. the
+    /// `perspective.querySparql` RPC). Unlike [`Self::query`], this never
+    /// re-encodes `?target`/`?t` bindings as wire-format `literal:*:`
+    /// strings — those names are purely an internal convention, and an
+    /// external caller choosing the same name for something unrelated
+    /// (say, `SELECT ?target WHERE { ?r <ad4m://ontology/author> ?target }`)
+    /// should get its plain lexical value back, not a silently mangled one.
+    pub fn query_arbitrary(&self, query_string: &str) -> Result<String, Error> {
+        self.query_internal(query_string, false)
+    }
+
+    fn query_internal(&self, query_string: &str, hydrate_target_vars: bool) -> Result<String, Error> {
         validate_readonly_query(query_string)?;
 
         let results = self
@@ -1007,8 +1045,11 @@ impl SparqlStore {
                             // hydrates to a JSON `5`, not the string `"5"`).
                             // All other variables emit the lexical form so
                             // SPARQL `FILTER(STR(?x) = ...)` and `COUNT`
-                            // consumers continue to see the raw value.
-                            let is_target_var = var == "target" || var == "t";
+                            // consumers continue to see the raw value. Only
+                            // applied for internal callers — see
+                            // `query_arbitrary` for external/untrusted queries.
+                            let is_target_var =
+                                hydrate_target_vars && (var == "target" || var == "t");
                             let val = match term {
                                 Term::NamedNode(n) => Value::String(n.as_str().to_string()),
                                 Term::Literal(l) => {
@@ -4206,6 +4247,104 @@ mod tests {
             !last_ts.is_empty(),
             "MAX timestamp should be present. Raw: {}",
             result
+        );
+    }
+
+    // ── Reifier IRI stability for literal:json: targets ──
+
+    #[test]
+    fn test_remove_link_with_hydrated_json_target_round_trip() {
+        // The realistic failure mode: a caller inserts with a hand-written
+        // (whitespace-containing) JSON target, later reads it back via a
+        // query — receiving the re-serialized, whitespace-compacted wire
+        // string `storage_term_to_target_string` produces — and then
+        // removes the link using that hydrated string. Before normalizing
+        // the reifier-IRI hash input, insert and remove hashed two
+        // differently-formatted (but semantically identical) strings to
+        // two different reifier IRIs, so removal silently no-opped: the
+        // recomputed reifier IRI never matched the one stored at insert
+        // time. Note: canonicalization here normalizes whitespace, not
+        // object key order (this crate builds serde_json with the
+        // `preserve_order` feature via a transitive dependency).
+        let svc = new_service();
+        let insert_target = "literal:json:{\"a\": 1, \"b\": 2}".to_string();
+
+        let link = make_link("ad4m://json_source", "ad4m://json_pred", &insert_target);
+        svc.add_link(&link).unwrap();
+
+        let before = svc.get_all_links().unwrap();
+        assert_eq!(
+            before.iter().filter(|l| l.data.source == "ad4m://json_source").count(),
+            1,
+            "link should be present after insert"
+        );
+
+        // Simulate "query, then remove what you read back".
+        let hydrated_target =
+            storage_term_to_target_string(&target_to_storage_term(&insert_target));
+        assert_ne!(
+            hydrated_target, insert_target,
+            "test setup: hydration must actually reformat the target (whitespace-compacted), \
+             otherwise this test isn't exercising the mismatch at all"
+        );
+
+        let remove_link = make_link("ad4m://json_source", "ad4m://json_pred", &hydrated_target);
+        svc.remove_link(&remove_link).unwrap();
+
+        let after = svc.get_all_links().unwrap();
+        assert_eq!(
+            after.iter().filter(|l| l.data.source == "ad4m://json_source").count(),
+            0,
+            "link should be gone after removing with the hydrated (re-serialized) JSON target"
+        );
+    }
+
+    // ── query() vs query_arbitrary() target-hydration scoping ──
+
+    #[test]
+    fn test_query_arbitrary_does_not_hydrate_coincidentally_named_variables() {
+        // A caller-supplied query has no reason to expect a variable it
+        // happens to name `?target` or `?t` to be silently re-encoded into
+        // AD4M's internal literal:*: wire format.
+        let svc = new_service();
+        svc.add_link(&make_link(
+            "ad4m://msg1",
+            "ad4m://ontology/author",
+            "did:key:zAlice",
+        ))
+        .unwrap();
+        svc.add_link(&make_link(
+            "ad4m://msg1",
+            "flux://priority",
+            "literal:number:5",
+        ))
+        .unwrap();
+
+        // query_arbitrary(): ?t bound to a typed-integer literal must come
+        // back as its plain lexical value, not `literal:number:5`.
+        let arbitrary_result = svc
+            .query_arbitrary("SELECT ?t WHERE { <ad4m://msg1> <flux://priority> ?t . }")
+            .unwrap();
+        let arbitrary_rows: Vec<serde_json::Value> =
+            serde_json::from_str(&arbitrary_result).unwrap();
+        assert_eq!(
+            arbitrary_rows[0]["t"].as_str(),
+            Some("5"),
+            "query_arbitrary must not wire-encode a coincidentally-named ?t: {}",
+            arbitrary_result
+        );
+
+        // query(): same shape, but through the internal-hydration path —
+        // still wire-encodes ?t, unchanged from before this fix.
+        let internal_result = svc
+            .query("SELECT ?t WHERE { <ad4m://msg1> <flux://priority> ?t . }")
+            .unwrap();
+        let internal_rows: Vec<serde_json::Value> = serde_json::from_str(&internal_result).unwrap();
+        assert_eq!(
+            internal_rows[0]["t"].as_str(),
+            Some("literal:number:5"),
+            "query() must keep wire-encoding ?t for internal callers: {}",
+            internal_result
         );
     }
 }

--- a/rust-executor/src/perspectives/sparql_store.rs
+++ b/rust-executor/src/perspectives/sparql_store.rs
@@ -26,6 +26,15 @@ const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
 const XSD_DECIMAL: &str = "http://www.w3.org/2001/XMLSchema#decimal";
 const XSD_BOOLEAN: &str = "http://www.w3.org/2001/XMLSchema#boolean";
 
+/// Percent-encoding set matching JS `encodeRFC3986URIComponent`.
+/// Leaves `A-Z a-z 0-9 - _ . ~` un-encoded — same characters the SDK
+/// preserves, so `literal:*:` URLs round-trip without re-encoding drift.
+const RFC3986_COMPONENT_ENCODE: percent_encoding::AsciiSet = percent_encoding::NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
+
 /// Convert a wire-format link target string to the oxigraph [`Term`] that
 /// represents it in storage.
 ///
@@ -95,7 +104,7 @@ fn target_to_storage_term(target: &str) -> Term {
 /// consumers (TypeScript SDK, `parse_literal_value`) see the same shape they
 /// did before the typed-literal migration.
 fn storage_term_to_target_string(term: &Term) -> String {
-    use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+    use percent_encoding::utf8_percent_encode;
 
     match term {
         Term::NamedNode(n) => n.as_str().to_string(),
@@ -106,13 +115,11 @@ fn storage_term_to_target_string(term: &Term) -> String {
                 XSD_INTEGER | XSD_DECIMAL => format!("literal:number:{val}"),
                 XSD_BOOLEAN => format!("literal:boolean:{val}"),
                 ONT_JSON => {
-                    let encoded = utf8_percent_encode(val, NON_ALPHANUMERIC).to_string();
+                    let encoded = utf8_percent_encode(val, &RFC3986_COMPONENT_ENCODE).to_string();
                     format!("literal:json:{encoded}")
                 }
-                // `xsd:string` (or the legacy simple literal, which oxigraph
-                // also reports as xsd:string) — encode as `literal:string:`.
                 _ => {
-                    let encoded = utf8_percent_encode(val, NON_ALPHANUMERIC).to_string();
+                    let encoded = utf8_percent_encode(val, &RFC3986_COMPONENT_ENCODE).to_string();
                     format!("literal:string:{encoded}")
                 }
             }
@@ -1008,7 +1015,11 @@ impl SparqlStore {
         self.query_internal(query_string, false)
     }
 
-    fn query_internal(&self, query_string: &str, hydrate_target_vars: bool) -> Result<String, Error> {
+    fn query_internal(
+        &self,
+        query_string: &str,
+        hydrate_target_vars: bool,
+    ) -> Result<String, Error> {
         validate_readonly_query(query_string)?;
 
         let results = self
@@ -4274,7 +4285,10 @@ mod tests {
 
         let before = svc.get_all_links().unwrap();
         assert_eq!(
-            before.iter().filter(|l| l.data.source == "ad4m://json_source").count(),
+            before
+                .iter()
+                .filter(|l| l.data.source == "ad4m://json_source")
+                .count(),
             1,
             "link should be present after insert"
         );
@@ -4293,7 +4307,10 @@ mod tests {
 
         let after = svc.get_all_links().unwrap();
         assert_eq!(
-            after.iter().filter(|l| l.data.source == "ad4m://json_source").count(),
+            after
+                .iter()
+                .filter(|l| l.data.source == "ad4m://json_source")
+                .count(),
             0,
             "link should be gone after removing with the hydrated (re-serialized) JSON target"
         );

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -2275,7 +2275,7 @@ describe("Prolog + Literals", () => {
 
                         // Poll until callback called. 60s upper bound matches
                         // the surrounding waitForCondition timeouts in this
-                        // suite. Even with the previous 30s ceiling the test
+                        // suite. Even with the previous 5s ceiling the test
                         // still flaked on integration-tests-js #17171 after
                         // the dev merge pulled in the lazy-load resolveLanguage
                         // change (#848), which adds first-fetch latency on a


### PR DESCRIPTION
Stacked on #874.

#842 gained a set of follow-up fixes after the force-push that are **orthogonal to the
`resolveLanguage` / `resolveLiteral` storage-mode disagreement** — they're correctness and
security work that should land whichever API shape wins. This branch cherry-picks them onto
#874 so that debate isn't blocking them, and so #874 is judged on the storage-mode question
alone.

All commits keep @HexaField as author and carry `cherry picked from commit …` trailers.

## What's picked

| Commit | Why it matters |
|---|---|
| `fix(security): escape SPARQL string interpolation in mention matching` | Mention terms (profile names / `name_override`) reach `get_mention_waker_config` from untrusted callers and were interpolated into a SPARQL string literal unescaped. A `"` in a name breaks out of the literal and injects arbitrary SPARQL into the mention FILTER. |
| `fix: reifier IRI hash stability + stop wire-encoding arbitrary queries` | (1) `make_reifier_iri()` hashed the raw wire target, but `literal:json:` targets are canonicalized before storage — so removing a link using a value read back via `query()` computed a *different* reifier IRI, orphaning the metadata and leaving the triple un-removable. (2) `query()`'s `?target`/`?t` hydration heuristic is an internal convention but was also applied to caller-supplied SPARQL via `perspective.querySparql`, silently re-encoding unrelated queries. Split into `query()` / `query_arbitrary()`. |
| `fix: align SPARQL ops handler and percent encoding with JS SDK` | (1) The Ops handler (`not`/`gt`/`gte`/`lt`/`lte`/`between`) compared against typed RDF literals; Oxigraph treats a simple literal and an `xsd:string` literal as distinct terms, so those comparisons silently failed to match. Now binds the lexical form via `STR()` and compares plain strings, with an `xsd:double` cast for numeric ops. (2) `storage_term_to_target_string` used `NON_ALPHANUMERIC` percent-encoding, which encodes `-_.~` that the JS SDK's `encodeRFC3986URIComponent` leaves alone — round-trip encoding drift between Rust and the SDK. |
| `fix: update migration test assertion for RFC3986 encoding + init AgentService in mod tests` | Follows from the encoding change above. |
| `docs: fix stale comment references flagged by review` | Bench name/comment claimed `fn/parse_literal` where the query is a plain `FILTER(STR(?t) = …)`; flaky-test comment cited the wrong previous timeout. |
| `test: regression coverage for duplicate subject-class instance uniqueness` | Two instances with identical property values must stay distinct. |
| `docs(ad4m skill): clarify addLink/reifier uniqueness vs subject classes` | |

## Conflict resolutions

Only one commit conflicted substantively — the Ops handler, because #874 had split that arm into
a deterministic-literal path (typed-literal comparison) and an envelope path (`parse_literal`).
#842's fix says the typed-literal comparison is the broken one, which is right.

Resolved by **unifying both paths onto #842's lexical-string comparison**, keeping only the
difference that actually matters — how `?val` is derived:

```rust
let val_src = if is_literal_prop {
    var.clone()                                    // typed literal: STR() is the value
} else {
    format!("<ad4m://fn/parse_literal>({var})")    // envelope: unwrap to inner `data` first
};
where_patterns.push(format!("    BIND(STR({val_src}) AS {val_var})"));
```

Everything downstream is #842's code verbatim. Net result: the Ops arm shrank from 269 lines to
100, the Oxigraph term-semantics bug is fixed for *both* storage modes, and envelope properties
gain Ops support they didn't have on #842 (where they can't exist).

Two smaller ones, in the `origin/dev` merge on #874 rather than here:

- `SortKey::Property` sort: kept dev's `STR(fn/parse_literal(?raw))` over #842's bare
  `STR(?raw)`. `parse_literal` is a superset — lexical form for a typed literal, inner `data`
  for an envelope — so it's correct for both modes, whereas `STR` would sort envelope
  properties by their author/timestamp prefix. dev's `SortKey::RelationProperty` already
  depends on this and pins it with
  `test_sort_by_relation_property_with_signed_envelope_literal`. No index is lost: the ORDER BY
  is inside a GROUP BY subquery over an already-filtered set.
- Test helper naming: #874 had renamed the envelope helper to `legacy_envelope_literal`; dev
  meanwhile split it into `signed_envelope_literal` + `signed_envelope_literal_with_ts`. Kept
  dev's names.

## Not picked

Deliberately excluded, because these *are* the storage-mode disagreement rather than
independent fixes:

- `refactor: restore resolveLanguage string API, remove resolveLiteral boolean` (`94e11e84f`)
- `fix: use deterministic literal IRIs for resolve_language=literal properties` (`91420362d`)

Together these make `resolveLanguage: "literal"` mean "deterministic literal" — a silent
behaviour change for a declaration that means "signed expression on the literal language" on
`dev` today. That's the open question on #874.

Also skipped: `0453d07fb` (transform-on-deterministic-literal), which #874 already carries as
`4ca730fe7` — it was cherry-picked *from* this work in the first place.

## Verification

- `cargo test -p ad4m-executor -- --test-threads=1` → **698 passed / 0 failed**, 7 ignored.
  (The suite needs `--test-threads=1`; several agent/keystore tests share global state and
  fail spuriously under the default parallel runner, on `dev` as well.)
- core TS → **473 passed / 0 failed**, 16 suites.
- `tsc --noEmit` clean, `cargo fmt --all --check` clean.
