### PR TITLE
test+fix(agent-harness): CLI watch, waker, and plugin — coverage audit fixes

### DIFF
--- a/cli/src/perspectives.rs
+++ b/cli/src/perspectives.rs
@@ -119,6 +119,67 @@ pub enum PerspectiveFunctions {
     },
 }
 
+/// The kind of link change carried by a perspective watch event.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum LinkChangeKind {
+    Added,
+    Removed,
+    Updated,
+}
+
+impl LinkChangeKind {
+    /// ANSI-coloured label for terminal output.
+    pub fn label(self) -> &'static str {
+        match self {
+            LinkChangeKind::Added => "\x1b[32m+ ADDED",
+            LinkChangeKind::Removed => "\x1b[31m- REMOVED",
+            LinkChangeKind::Updated => "\x1b[33m~ UPDATED",
+        }
+    }
+}
+
+/// A classified perspective link-watch event, ready to render.
+#[derive(Debug, PartialEq)]
+pub struct LinkWatchEvent {
+    pub kind: LinkChangeKind,
+    pub link: serde_json::Value,
+}
+
+/// Classify a raw event from the executor's events websocket for `watch <id>`.
+///
+/// Returns `Some` only for a link change on the watched perspective. The executor
+/// serialises the perspective id as `perspectiveUuid` and an updated link as
+/// `newLink`/`oldLink` (camelCase — see `PerspectiveLinkWithOwner` and
+/// `PerspectiveLinkUpdatedWithOwner`), so this reads those keys. Reading `uuid`
+/// or `link` for updates silently matches nothing. A matched event always yields
+/// a payload (falling back to the whole event) so a change is never dropped.
+///
+/// Pure over the event JSON, so it unit-tests without a live executor.
+pub fn classify_link_watch_event(
+    event: &serde_json::Value,
+    watched_id: &str,
+) -> Option<LinkWatchEvent> {
+    let event_uuid = event
+        .get("perspectiveUuid")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if event_uuid != watched_id {
+        return None;
+    }
+    let (kind, key) = match event.get("type").and_then(|v| v.as_str()).unwrap_or("") {
+        "link-added" => (LinkChangeKind::Added, "link"),
+        "link-removed" => (LinkChangeKind::Removed, "link"),
+        "link-updated" => (LinkChangeKind::Updated, "newLink"),
+        _ => return None,
+    };
+    let link = event
+        .get(key)
+        .or_else(|| event.get("data"))
+        .cloned()
+        .unwrap_or_else(|| event.clone());
+    Some(LinkWatchEvent { kind, link })
+}
+
 pub async fn run(ad4m_client: Ad4mClient, command: Option<PerspectiveFunctions>) -> Result<()> {
     if command.is_none() {
         // Use interactive perspective selector instead of just printing
@@ -182,37 +243,17 @@ pub async fn run(ad4m_client: Ad4mClient, command: Option<PerspectiveFunctions>)
             loop {
                 match rx.recv().await {
                     Ok(event) => {
-                        let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("");
-                        let event_uuid = event.get("uuid").and_then(|v| v.as_str()).unwrap_or("");
-                        if event_uuid != id {
-                            continue;
-                        }
-                        match event_type {
-                            "link-added" | "link-removed" | "link-updated" => {
-                                let label = match event_type {
-                                    "link-added" => "\x1b[32m+ ADDED",
-                                    "link-removed" => "\x1b[31m- REMOVED",
-                                    "link-updated" => "\x1b[33m~ UPDATED",
-                                    _ => unreachable!(),
-                                };
-                                if let Some(link_val) =
-                                    event.get("link").or_else(|| event.get("data"))
-                                {
-                                    if let Ok(link) = serde_json::from_value::<
-                                        ad4m_client::types::LinkExpression,
-                                    >(
-                                        link_val.clone()
-                                    ) {
-                                        print!("{}\x1b[0m ", label);
-                                        print_link(link.into());
-                                    } else {
-                                        println!("{}\x1b[0m {}", label, link_val);
-                                    }
-                                } else {
-                                    println!("{}\x1b[0m {}", label, event);
-                                }
+                        if let Some(change) = classify_link_watch_event(&event, &id) {
+                            let label = change.kind.label();
+                            if let Ok(link) = serde_json::from_value::<
+                                ad4m_client::types::LinkExpression,
+                            >(change.link.clone())
+                            {
+                                print!("{}\x1b[0m ", label);
+                                print_link(link.into());
+                            } else {
+                                println!("{}\x1b[0m {}", label, change.link);
                             }
-                            _ => {}
                         }
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
@@ -509,5 +550,90 @@ async fn interactive_perspective_selector(ad4m_client: Ad4mClient) -> Result<()>
                 _ => {}
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // Wire shapes match the executor's `PerspectiveLinkWithOwner` (added/removed)
+    // and `PerspectiveLinkUpdatedWithOwner` (updated), both `rename_all=camelCase`.
+    fn added_event(uuid: &str) -> serde_json::Value {
+        json!({
+            "type": "link-added",
+            "perspectiveUuid": uuid,
+            "link": { "author": "did:key:z6Mkxyz", "timestamp": "t", "data": { "source": "s", "predicate": "p", "target": "tgt" } },
+            "owner": "did:key:z6Mkxyz"
+        })
+    }
+
+    #[test]
+    fn classifies_link_added_on_the_watched_perspective() {
+        let ev = added_event("uuid-1");
+        let got = classify_link_watch_event(&ev, "uuid-1").expect("should classify");
+        assert_eq!(got.kind, LinkChangeKind::Added);
+        assert_eq!(
+            got.link.get("author").and_then(|v| v.as_str()),
+            Some("did:key:z6Mkxyz")
+        );
+    }
+
+    #[test]
+    fn ignores_events_for_a_different_perspective() {
+        let ev = added_event("uuid-OTHER");
+        // Regression guard: the id lives under `perspectiveUuid`, not `uuid`.
+        assert_eq!(classify_link_watch_event(&ev, "uuid-1"), None);
+    }
+
+    #[test]
+    fn reads_the_perspective_id_from_perspectiveuuid_not_uuid() {
+        // The old code read `uuid`, which the executor never emits — so every
+        // event mismatched and `watch` displayed nothing. Pin the correct key.
+        let ev = json!({ "type": "link-added", "uuid": "uuid-1", "perspectiveUuid": "uuid-1", "link": {} });
+        assert!(classify_link_watch_event(&ev, "uuid-1").is_some());
+        let wrong = json!({ "type": "link-added", "uuid": "uuid-1", "link": {} }); // no perspectiveUuid
+        assert_eq!(classify_link_watch_event(&wrong, "uuid-1"), None);
+    }
+
+    #[test]
+    fn link_updated_reads_newlink_not_link() {
+        // Updated events carry `newLink`/`oldLink`, never a bare `link`.
+        let ev = json!({
+            "type": "link-updated",
+            "perspectiveUuid": "uuid-1",
+            "newLink": { "marker": "NEW" },
+            "oldLink": { "marker": "OLD" }
+        });
+        let got = classify_link_watch_event(&ev, "uuid-1").expect("should classify update");
+        assert_eq!(got.kind, LinkChangeKind::Updated);
+        assert_eq!(got.link.get("marker").and_then(|v| v.as_str()), Some("NEW"));
+    }
+
+    #[test]
+    fn classifies_removed() {
+        let ev = json!({ "type": "link-removed", "perspectiveUuid": "uuid-1", "link": { "marker": "R" } });
+        assert_eq!(
+            classify_link_watch_event(&ev, "uuid-1").unwrap().kind,
+            LinkChangeKind::Removed
+        );
+    }
+
+    #[test]
+    fn ignores_non_link_event_types() {
+        let ev = json!({ "type": "agent-updated", "perspectiveUuid": "uuid-1", "agent": {} });
+        assert_eq!(classify_link_watch_event(&ev, "uuid-1"), None);
+    }
+
+    #[test]
+    fn matched_event_missing_payload_falls_back_to_whole_event() {
+        // Never silently drop a matched change: with no `link` key, surface the event.
+        let ev = json!({ "type": "link-added", "perspectiveUuid": "uuid-1" });
+        let got = classify_link_watch_event(&ev, "uuid-1").expect("should still classify");
+        assert_eq!(
+            got.link.get("type").and_then(|v| v.as_str()),
+            Some("link-added")
+        );
     }
 }

--- a/plugins/ad4m/index.test.ts
+++ b/plugins/ad4m/index.test.ts
@@ -711,6 +711,57 @@ describe("ensureExecutorRunning", () => {
     const msgs = logger.info.mock.calls.map((c: any[]) => c[0]);
     expect(msgs.some((m: string) => m.includes("ad4m.log"))).toBe(true);
   }, 10000);
+
+  it("includes --run-holochain false in spawn args when runHolochain=false", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const fakeProc = createFakeChildProcess();
+    mockSpawn.mockClear();
+    mockSpawn.mockReturnValue(fakeProc as any);
+
+    const logger = makeMockLogger();
+    const resultPromise = ensureExecutorRunning(
+      "cred",
+      logger,
+      "http://localhost:3001/mcp",
+      "http://localhost:12000",
+      undefined,
+      undefined,
+      "file",
+      false,
+    );
+
+    setTimeout(() => {
+      fakeProc.emit("error", new Error("spawn ENOENT"));
+    }, 100);
+
+    await resultPromise;
+
+    const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+    const flagIndex = spawnArgs.indexOf("--run-holochain");
+    expect(flagIndex).toBeGreaterThan(-1);
+    expect(spawnArgs[flagIndex + 1]).toBe("false");
+  }, 10000);
+
+  it("omits --run-holochain from spawn args when runHolochain is true (default)", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const fakeProc = createFakeChildProcess();
+    mockSpawn.mockClear();
+    mockSpawn.mockReturnValue(fakeProc as any);
+
+    const logger = makeMockLogger();
+    const resultPromise = ensureExecutorRunning("cred", logger);
+
+    setTimeout(() => {
+      fakeProc.emit("error", new Error("spawn ENOENT"));
+    }, 100);
+
+    await resultPromise;
+
+    const spawnArgs = mockSpawn.mock.calls[0][1] as string[];
+    expect(spawnArgs).not.toContain("--run-holochain");
+  }, 10000);
 });
 
 // ---------------------------------------------------------------------------
@@ -1168,6 +1219,26 @@ describe("mcpNotify", () => {
     expect(body.jsonrpc).toBe("2.0");
     expect(body.method).toBe("notifications/initialized");
     expect(body.id).toBeUndefined();
+  });
+
+  it("cancels the response body even on an OK status (releases the connection)", async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers(),
+      body: { cancel },
+    } as any);
+
+    await mcpNotify(
+      "http://localhost:3001/mcp",
+      "notifications/initialized",
+      {},
+      "session-123",
+    );
+
+    expect(cancel).toHaveBeenCalled();
   });
 });
 
@@ -1695,6 +1766,109 @@ describe("ad4mPlugin", () => {
     expect(result.content[0].text).toContain("No new tools found");
   });
 
+  it("ad4m_subscribe_to_mentions reports 'Waker service not connected' when the waker isn't running", async () => {
+    const registeredTools: Array<{ name: string; execute: Function }> = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, opts) => {
+      const body = JSON.parse((opts as any).body as string);
+      if (body.method === "initialize") {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: { serverInfo: { name: "ad4m" } },
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+              "Mcp-Session-Id": "sess-1",
+            },
+          },
+        );
+      }
+      if (body.method === "notifications/initialized") {
+        return new Response(null, { status: 200 });
+      }
+      if (
+        body.method === "tools/call" &&
+        body.params?.name === "get_mention_waker_config"
+      ) {
+        return fakeJsonResponse({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  query: "SELECT * FROM link WHERE ...",
+                  names: ["TestAgent"],
+                  did: "did:key:zTest",
+                }),
+              },
+            ],
+          },
+        });
+      }
+      return fakeJsonResponse({ jsonrpc: "2.0", id: body.id, result: {} });
+    });
+
+    const mockApi = {
+      pluginConfig: {
+        mode: "external",
+        mcpEndpoint: "http://localhost:3001/mcp",
+        token: "test-cred",
+      },
+      logger: makeMockLogger(),
+      registerTool: vi.fn((tool: any) => registeredTools.push(tool)),
+      registerService: vi.fn(),
+      registerCli: vi.fn(),
+    };
+
+    await ad4mPlugin(mockApi);
+
+    const subscribeTool = registeredTools.find(
+      (t) => t.name === "ad4m_subscribe_to_mentions",
+    );
+    expect(subscribeTool).toBeDefined();
+
+    const result = await subscribeTool!.execute("call-1", {
+      perspective_id: "persp-uuid-1",
+    });
+
+    expect(result.content[0].text).toBe(
+      "Error: Waker service not connected. Ensure ad4m-executor is running and wakerEnabled is true.",
+    );
+  });
+
+  it("ad4m_unsubscribe_from_mentions reports 'No mention subscription found' when nothing matches", async () => {
+    const registeredTools: Array<{ name: string; execute: Function }> = [];
+
+    const mockApi = {
+      pluginConfig: {},
+      logger: makeMockLogger(),
+      registerTool: vi.fn((tool: any) => registeredTools.push(tool)),
+      registerService: vi.fn(),
+      registerCli: vi.fn(),
+    };
+
+    ad4mPlugin(mockApi);
+
+    const unsubscribeTool = registeredTools.find(
+      (t) => t.name === "ad4m_unsubscribe_from_mentions",
+    );
+    expect(unsubscribeTool).toBeDefined();
+
+    const result = await unsubscribeTool!.execute("call-1", {
+      perspective_id: "persp-1",
+    });
+
+    expect(result.content[0].text).toBe(
+      "No mention subscription found for perspective persp-1.",
+    );
+  });
+
   it("mcp-service start connects and registers MCP tools", async () => {
     const registeredTools: Array<{ name: string; execute: Function }> = [];
     const registeredServices: Array<{
@@ -2160,6 +2334,104 @@ describe("ad4mPlugin", () => {
     expect(warningFound).toBe(true);
   });
 
+  it("obtains a JWT via request_capability/generate_jwt when external mode has no token", async () => {
+    const registeredServices: Array<{
+      id: string;
+      start: Function;
+      stop: Function;
+    }> = [];
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, opts) => {
+      const body = JSON.parse((opts as any).body as string);
+      if (body.method === "initialize") {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: { serverInfo: { name: "ad4m" } },
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+              "Mcp-Session-Id": "sess-1",
+            },
+          },
+        );
+      }
+      if (body.method === "notifications/initialized") {
+        return new Response(null, { status: 200 });
+      }
+      if (
+        body.method === "tools/call" &&
+        body.params?.name === "request_capability"
+      ) {
+        return fakeJsonResponse({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({ request_id: "req-1", code: "123456" }),
+              },
+            ],
+          },
+        });
+      }
+      if (
+        body.method === "tools/call" &&
+        body.params?.name === "generate_jwt"
+      ) {
+        return fakeJsonResponse({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: {
+            content: [
+              { type: "text", text: JSON.stringify({ token: "jwt-abc" }) },
+            ],
+          },
+        });
+      }
+      if (body.method === "tools/list") {
+        return fakeJsonResponse({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { tools: [] },
+        });
+      }
+      return fakeJsonResponse({ jsonrpc: "2.0", id: body.id, result: {} });
+    });
+
+    const mockApi = {
+      pluginConfig: {
+        mode: "external",
+        mcpEndpoint: "http://localhost:3001/mcp",
+        // no token — forces JWT auto-auth via obtainJwtFromExecutor
+      },
+      logger: makeMockLogger(),
+      registerTool: vi.fn(),
+      registerService: vi.fn((svc: any) => registeredServices.push(svc)),
+      registerCli: vi.fn(),
+    };
+
+    await ad4mPlugin(mockApi);
+
+    const mcpService = registeredServices.find((s) => s.id === "ad4m-mcp");
+    expect(mcpService).toBeDefined();
+    await mcpService!.start(makeServiceCtx());
+
+    const infoMsgs = mockApi.logger.info.mock.calls.map((c: any[]) => c[0]);
+    expect(infoMsgs.some((m: string) => m.includes("JWT obtained"))).toBe(
+      true,
+    );
+    expect(
+      infoMsgs.some((m: string) => m.includes("Auth token ready")),
+    ).toBe(true);
+
+    mcpService!.stop();
+  });
+
   it("logs setup hint when mode is not configured", async () => {
     const mockApi: any = {
       id: "ad4m",
@@ -2183,6 +2455,63 @@ describe("ad4mPlugin", () => {
     expect(
       infoMessages.some((m: string) => m.includes("openclaw ad4m-setup")),
     ).toBe(true);
+  });
+
+  it("captures stateDir via ctx.stateDir so the waker can see it (regression: guard used to check ctx._stateDir, which is never set)", async () => {
+    const registeredServices: Array<{
+      id: string;
+      start: Function;
+      stop: Function;
+    }> = [];
+
+    // Neither service should reach the network in this scenario — mode is
+    // unset (ad4m-mcp returns right after capturing stateDir) and wakeToken
+    // is unset (ad4m-waker returns right after logging the stateDir line).
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new Error("fetch should not be called in this test"),
+    );
+
+    const mockApi: any = {
+      id: "ad4m",
+      pluginConfig: {},
+      logger: makeMockLogger(),
+      registerTool: vi.fn(),
+      registerService: vi.fn((svc: any) => registeredServices.push(svc)),
+      registerCli: vi.fn(),
+      config: {},
+    };
+
+    ad4mPlugin(mockApi);
+
+    const tmpDir = makeTempDir();
+    try {
+      const mcpService = registeredServices.find((s) => s.id === "ad4m-mcp");
+      const wakerService = registeredServices.find(
+        (s) => s.id === "ad4m-waker",
+      );
+      expect(mcpService).toBeDefined();
+      expect(wakerService).toBeDefined();
+
+      // ad4m-mcp starts first and captures ctx.stateDir into module state.
+      await mcpService!.start(makeServiceCtx(tmpDir));
+
+      // ad4m-waker starts with NO stateDir of its own — if ad4m-mcp had
+      // failed to capture ctx.stateDir (e.g. reverted to the ctx._stateDir
+      // bug), the waker would see "existing stateDir: N/A" below.
+      await wakerService!.start({});
+
+      const infoMsgs = mockApi.logger.info.mock.calls.map(
+        (c: any[]) => c[0],
+      );
+      const stateDirLog = infoMsgs.find((m: string) =>
+        m.includes("stateDir from ctx:"),
+      );
+      expect(stateDirLog).toBeDefined();
+      expect(stateDirLog).toContain(`existing stateDir: ${tmpDir}`);
+      expect(stateDirLog).not.toContain("existing stateDir: N/A");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("registers ad4m-setup CLI command", () => {

--- a/plugins/ad4m/index.ts
+++ b/plugins/ad4m/index.ts
@@ -850,8 +850,10 @@ Notes:
   api.registerService({
     id: "ad4m-mcp",
     async start(ctx: any) {
-      // Capture _stateDir from service context
-      if (ctx?._stateDir) {
+      // Capture the state dir from the service context. The field is `stateDir`
+      // (the guard used to check `_stateDir`, which the context never sets, so
+      // the dir was never captured and waker state never persisted).
+      if (ctx?.stateDir) {
         _stateDir = ctx.stateDir;
       }
 
@@ -1021,8 +1023,9 @@ Notes:
       logger.info("[ad4m-waker] ── Waker service start() ──");
       logger.info(`[ad4m-waker] stateDir from ctx: ${ctx?.stateDir ?? "N/A"}, existing stateDir: ${_stateDir || "N/A"}`);
 
-      // Capture _stateDir from service context (in case mcp service didn't set it)
-      if (ctx?._stateDir && !_stateDir) {
+      // Capture the state dir from the service context (in case the mcp service
+      // didn't set it). The field is `stateDir`, not `_stateDir`.
+      if (ctx?.stateDir && !_stateDir) {
         _stateDir = ctx.stateDir;
       }
 

--- a/plugins/ad4m/index.ts
+++ b/plugins/ad4m/index.ts
@@ -498,8 +498,9 @@ Notes:
   async function subscribeToMentionsForPerspective(
     perspectiveId: string,
   ): Promise<string> {
-    // Skip if already subscribed
-    const existingId = `mention-${perspectiveId.substring(0, 8)}`;
+    // Skip if already subscribed. Must match the executor's build_mention_sub_id
+    // (`mention-${perspective_id}`) so the dedup guard is effective.
+    const existingId = `mention-${perspectiveId}`;
     if (_subscriptionManager?.has(existingId)) {
       return `Already subscribed to mentions in perspective ${perspectiveId}.`;
     }

--- a/rust-executor/src/mcp/tools/subscriptions.rs
+++ b/rust-executor/src/mcp/tools/subscriptions.rs
@@ -265,6 +265,10 @@ impl Ad4mMcpHandler {
 /// authored (its own author-DID proof metadata), so the agent would wake on its
 /// own writes rather than on real mentions.
 ///
+/// Search terms (profile names, DID) are interpolated into the query, so each is
+/// escaped as a SPARQL string literal — a name containing `"` or `\` would
+/// otherwise break out of the CONTAINS literal and could inject query syntax.
+///
 /// Pure over its inputs, so it unit-tests without an agent or perspective.
 pub fn build_mention_query(names: &[String], did: &str, body_predicate: Option<&str>) -> String {
     let all_terms: Vec<String> = names
@@ -277,7 +281,7 @@ pub fn build_mention_query(names: &[String], did: &str, body_predicate: Option<&
         .map(|t| {
             format!(
                 "CONTAINS(LCASE(STR(<ad4m://fn/parse_literal>(?target))), \"{}\")",
-                t
+                escape_sparql_literal(t)
             )
         })
         .collect();
@@ -296,18 +300,23 @@ pub fn build_mention_query(names: &[String], did: &str, body_predicate: Option<&
     }
 }
 
+/// Escape a string for embedding inside a SPARQL double-quoted literal:
+/// backslash first, then double-quote.
+fn escape_sparql_literal(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 /// Build a mention-subscription id keyed on the perspective.
 ///
 /// Deriving the id from the agent DID alone made it identical across every
 /// neighbourhood the agent joined; the waker's dispose-by-id then evicted a
 /// prior perspective's subscription when the agent subscribed in a second one,
 /// so an agent in N neighbourhoods only woke in the most-recent. Keying on the
-/// perspective gives distinct ids for distinct perspectives, and matches the
-/// plugin's `mention-${perspectiveId.slice(0,8)}` dedup guard so a repeat
-/// subscribe on the same perspective is correctly skipped.
+/// full perspective id gives distinct ids for distinct perspectives with no
+/// truncation collision, and matches the plugin's `mention-${perspectiveId}`
+/// dedup guard so a repeat subscribe on the same perspective is skipped.
 pub fn build_mention_sub_id(perspective_id: &str) -> String {
-    let head: String = perspective_id.chars().take(8).collect();
-    format!("mention-{}", head)
+    format!("mention-{}", perspective_id)
 }
 
 #[cfg(test)]
@@ -317,7 +326,7 @@ mod tests {
     #[test]
     fn scoped_query_excludes_ontology_proof_metadata() {
         let q = build_mention_query(
-            &["hex".to_string()],
+            &["alice".to_string()],
             "did:key:zAgent",
             Some("ad4m://message_body"),
         );
@@ -335,7 +344,7 @@ mod tests {
     fn unscoped_fallback_still_excludes_ontology_proof_metadata() {
         // Regression: the fallback (no body predicate) used to be fully unscoped,
         // so the DID term matched the agent's own ad4m://ontology/author links.
-        let q = build_mention_query(&["hex".to_string()], "did:key:zAgent", None);
+        let q = build_mention_query(&["alice".to_string()], "did:key:zAgent", None);
         assert!(
             q.contains("FILTER(!STRSTARTS(STR(?predicate), \"ad4m://ontology/\"))"),
             "fallback must still exclude proof metadata"
@@ -345,24 +354,37 @@ mod tests {
     #[test]
     fn query_matches_names_and_did_case_insensitively() {
         let q = build_mention_query(
-            &["Hex".to_string(), "Josh".to_string()],
+            &["Alice".to_string(), "Bob".to_string()],
             "did:key:zABC",
             None,
         );
-        assert!(q.contains("\"hex\""), "name lowercased");
-        assert!(q.contains("\"josh\""), "second name lowercased");
+        assert!(q.contains("\"alice\""), "name lowercased");
+        assert!(q.contains("\"bob\""), "second name lowercased");
         assert!(q.contains("\"did:key:zabc\""), "DID lowercased + included");
         assert!(q.contains("parse_literal"), "decodes literal targets");
     }
 
     #[test]
+    fn query_escapes_quotes_and_backslashes_in_terms() {
+        // A term containing a double-quote or backslash must not break out of the
+        // CONTAINS string literal (SPARQL injection guard).
+        let q = build_mention_query(&["a\"b\\c".to_string()], "did:key:zX", None);
+        assert!(q.contains("a\\\"b\\\\c"), "quote + backslash escaped: {q}");
+        assert!(
+            !q.contains("\"a\"b"),
+            "raw unescaped quote must not appear: {q}"
+        );
+    }
+
+    #[test]
     fn sub_id_is_perspective_scoped_not_did_scoped() {
         // Two perspectives, same agent → distinct ids (no cross-neighbourhood
-        // eviction). Matches the plugin's mention-${perspectiveId.slice(0,8)} guard.
+        // eviction). Uses the full perspective id (no truncation collision) and
+        // matches the plugin's mention-${perspectiveId} dedup guard.
         let a = build_mention_sub_id("c41dfd35-769e-474f-a2e6-4e5d580615c8");
         let b = build_mention_sub_id("8432bdcb-410e-48e2-b1e1-2bb3f831d067");
         assert_ne!(a, b, "distinct perspectives must yield distinct sub ids");
-        assert_eq!(a, "mention-c41dfd35");
+        assert_eq!(a, "mention-c41dfd35-769e-474f-a2e6-4e5d580615c8");
         // Repeat subscribe on the same perspective → same id (dedup fires).
         assert_eq!(
             a,

--- a/rust-executor/src/mcp/tools/subscriptions.rs
+++ b/rust-executor/src/mcp/tools/subscriptions.rs
@@ -201,35 +201,6 @@ impl Ad4mMcpHandler {
 
         let perspective_id = &params.0.perspective_id;
 
-        // Build the SPARQL query using CONTAINS for mention matching.
-        //
-        // The SPARQL CONTAINS function performs substring matching on the target IRI/literal.
-        // Case-insensitive matching via LCASE().
-        // Search terms are lowercased in Rust before embedding in the query.
-        let all_terms: Vec<String> = names
-            .iter()
-            .map(|n| n.to_lowercase())
-            .chain(std::iter::once(did.to_lowercase()))
-            .collect();
-
-        // Build CONTAINS conditions for mention matching.
-        // Use fn::parse_literal to decode literal:// targets:
-        // - literal:string: targets are URL-decoded to plain text
-        // - literal:json: signed expressions are decoded and only the "data"
-        //   field is returned, so author/timestamp metadata doesn't match
-        // This ensures we match against the actual message content, not metadata.
-        let mention_conditions: Vec<String> = all_terms
-            .iter()
-            .map(|t| {
-                format!(
-                    "CONTAINS(LCASE(STR(<ad4m://fn/parse_literal>(?target))), \"{}\")",
-                    t
-                )
-            })
-            .collect();
-
-        let mention_predicate = format!("({})", mention_conditions.join(" || "));
-
         // Discover the body property predicate from SHACL to scope the query.
         // Without this, the query scans ALL links which is very slow on large perspectives.
         let perspective = self
@@ -246,20 +217,12 @@ impl Ad4mMcpHandler {
             None
         };
 
-        let query = if let Some(ref pred) = body_predicate {
-            format!(
-                "SELECT ?source ?predicate ?target WHERE {{ ?source ?predicate ?target . FILTER(isIRI(?source) && isIRI(?predicate)) FILTER(STR(?predicate) = \"{}\") FILTER({}) }}",
-                pred, mention_predicate
-            )
-        } else {
-            log::warn!("get_mention_waker_config: no body predicate found in SHACL for Message class, falling back to unscoped query");
-            format!(
-                "SELECT ?source ?predicate ?target WHERE {{ ?source ?predicate ?target . FILTER(isIRI(?source) && isIRI(?predicate)) FILTER({}) }}",
-                mention_predicate
-            )
-        };
+        if body_predicate.is_none() {
+            log::warn!("get_mention_waker_config: no body predicate found in SHACL for Message class, falling back to unscoped (but ontology-excluded) query");
+        }
+        let query = build_mention_query(&names, &did, body_predicate.as_deref());
 
-        let sub_id = format!("mention-{}", &did[did.len().saturating_sub(12)..]);
+        let sub_id = build_mention_sub_id(perspective_id);
 
         let subscription = json!({
             "id": sub_id,
@@ -286,5 +249,124 @@ impl Ad4mMcpHandler {
             ),
         })
         .to_string()
+    }
+}
+
+/// Build the SPARQL mention-detection query for the waker.
+///
+/// CONTAINS does case-insensitive substring matching on the parsed literal
+/// target, so a message body containing any profile name or the agent DID
+/// matches. `body_predicate` scopes the scan to the message-body predicate when
+/// SHACL resolves it (much faster on large perspectives).
+///
+/// Both the scoped and the unscoped-fallback query exclude `ad4m://ontology/*`
+/// predicates (author DID, timestamp, proofKey — see `sparql_store`). Without
+/// that exclusion the DID search term matches every link the agent itself
+/// authored (its own author-DID proof metadata), so the agent would wake on its
+/// own writes rather than on real mentions.
+///
+/// Pure over its inputs, so it unit-tests without an agent or perspective.
+pub fn build_mention_query(names: &[String], did: &str, body_predicate: Option<&str>) -> String {
+    let all_terms: Vec<String> = names
+        .iter()
+        .map(|n| n.to_lowercase())
+        .chain(std::iter::once(did.to_lowercase()))
+        .collect();
+    let mention_conditions: Vec<String> = all_terms
+        .iter()
+        .map(|t| {
+            format!(
+                "CONTAINS(LCASE(STR(<ad4m://fn/parse_literal>(?target))), \"{}\")",
+                t
+            )
+        })
+        .collect();
+    let mention_predicate = format!("({})", mention_conditions.join(" || "));
+    // Never match proof metadata, else the DID term self-matches authored links.
+    let ontology_guard = "FILTER(!STRSTARTS(STR(?predicate), \"ad4m://ontology/\"))";
+    match body_predicate {
+        Some(pred) => format!(
+            "SELECT ?source ?predicate ?target WHERE {{ ?source ?predicate ?target . FILTER(isIRI(?source) && isIRI(?predicate)) FILTER(STR(?predicate) = \"{}\") {} FILTER({}) }}",
+            pred, ontology_guard, mention_predicate
+        ),
+        None => format!(
+            "SELECT ?source ?predicate ?target WHERE {{ ?source ?predicate ?target . FILTER(isIRI(?source) && isIRI(?predicate)) {} FILTER({}) }}",
+            ontology_guard, mention_predicate
+        ),
+    }
+}
+
+/// Build a mention-subscription id keyed on the perspective.
+///
+/// Deriving the id from the agent DID alone made it identical across every
+/// neighbourhood the agent joined; the waker's dispose-by-id then evicted a
+/// prior perspective's subscription when the agent subscribed in a second one,
+/// so an agent in N neighbourhoods only woke in the most-recent. Keying on the
+/// perspective gives distinct ids for distinct perspectives, and matches the
+/// plugin's `mention-${perspectiveId.slice(0,8)}` dedup guard so a repeat
+/// subscribe on the same perspective is correctly skipped.
+pub fn build_mention_sub_id(perspective_id: &str) -> String {
+    let head: String = perspective_id.chars().take(8).collect();
+    format!("mention-{}", head)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_mention_query, build_mention_sub_id};
+
+    #[test]
+    fn scoped_query_excludes_ontology_proof_metadata() {
+        let q = build_mention_query(
+            &["hex".to_string()],
+            "did:key:zAgent",
+            Some("ad4m://message_body"),
+        );
+        assert!(
+            q.contains("ad4m://message_body"),
+            "scoped to the body predicate"
+        );
+        assert!(
+            q.contains("FILTER(!STRSTARTS(STR(?predicate), \"ad4m://ontology/\"))"),
+            "excludes ontology proof metadata"
+        );
+    }
+
+    #[test]
+    fn unscoped_fallback_still_excludes_ontology_proof_metadata() {
+        // Regression: the fallback (no body predicate) used to be fully unscoped,
+        // so the DID term matched the agent's own ad4m://ontology/author links.
+        let q = build_mention_query(&["hex".to_string()], "did:key:zAgent", None);
+        assert!(
+            q.contains("FILTER(!STRSTARTS(STR(?predicate), \"ad4m://ontology/\"))"),
+            "fallback must still exclude proof metadata"
+        );
+    }
+
+    #[test]
+    fn query_matches_names_and_did_case_insensitively() {
+        let q = build_mention_query(
+            &["Hex".to_string(), "Josh".to_string()],
+            "did:key:zABC",
+            None,
+        );
+        assert!(q.contains("\"hex\""), "name lowercased");
+        assert!(q.contains("\"josh\""), "second name lowercased");
+        assert!(q.contains("\"did:key:zabc\""), "DID lowercased + included");
+        assert!(q.contains("parse_literal"), "decodes literal targets");
+    }
+
+    #[test]
+    fn sub_id_is_perspective_scoped_not_did_scoped() {
+        // Two perspectives, same agent → distinct ids (no cross-neighbourhood
+        // eviction). Matches the plugin's mention-${perspectiveId.slice(0,8)} guard.
+        let a = build_mention_sub_id("c41dfd35-769e-474f-a2e6-4e5d580615c8");
+        let b = build_mention_sub_id("8432bdcb-410e-48e2-b1e1-2bb3f831d067");
+        assert_ne!(a, b, "distinct perspectives must yield distinct sub ids");
+        assert_eq!(a, "mention-c41dfd35");
+        // Repeat subscribe on the same perspective → same id (dedup fires).
+        assert_eq!(
+            a,
+            build_mention_sub_id("c41dfd35-769e-474f-a2e6-4e5d580615c8")
+        );
     }
 }


### PR DESCRIPTION
Stacked on #880 (base `fix/agent-harness-findings`). A test-coverage audit of three areas — the `ad4m` CLI `watch` command, the OpenClaw plugin, and the waker — turned up four correctness bugs alongside the coverage gaps. This PR fixes each bug and lands the regression test that would have caught it, plus a coverage uplift on the newly/at-risk surfaces.

## Bugs fixed (each with the test that guards it)

**1. `ad4m perspectives watch <id>` displayed nothing, for any perspective.** `cli/src/perspectives.rs` read the perspective id from `uuid`, but the executor emits `perspectiveUuid` (camelCase) — so the id filter mismatched every event and the loop body was unreachable. Secondary: an updated link arrives as `newLink`/`oldLink`, not `link`, so updates would have rendered as a raw JSON dump. Fixed by classifying events through a pure `classify_link_watch_event()` reading the correct keys. Adds the cli crate's first tests (7).

**2. The waker mention query woke the agent on its own writes.** `get_mention_waker_config` ORs the agent DID as a search term; proof metadata stores `<link:HASH> ad4m://ontology/author "<agent DID>"`, so the DID term matched every link the agent authored. The scoped path avoided this only as a side effect of the body-predicate FILTER; the unscoped fallback had no exclusion at all. Both paths now exclude `ad4m://ontology/*` predicates.

**3. The waker mention subscription id collided across neighbourhoods.** The id derived from the agent DID alone, so it was identical for every neighbourhood the agent joined; the waker's dispose-by-id then evicted a prior perspective's subscription when the agent subscribed in a second one — an agent in N neighbourhoods only woke in the most recent. The id is now keyed on the perspective, which also makes the plugin's `mention-${perspectiveId.slice(0,8)}` dedup guard effective. (Fixes 2 + 3 extract `build_mention_query()` + `build_mention_sub_id()` as pure functions with the mcp module's first unit tests.)

**4. Waker state never persisted across a restart.** The `ad4m-mcp` / `ad4m-waker` services captured the state dir only when `ctx?._stateDir` was truthy, but the context sets `stateDir` (no underscore). The guard never fired, so subscriptions + mention-dedup state were lost on every restart. Fixed to read `ctx.stateDir`.

## Coverage uplift
- **cli**: first-ever tests (7) — event classification + arg-shape regression guards.
- **rust-executor mcp**: first unit tests on the mention-query builder + sub-id (4).
- **plugin**: +7 — the stateDir regression guard, `ensureExecutorRunning` `--run-holochain false` (recently added, was 0% covered), `mcpNotify` body-cancel, subscribe/unsubscribe tool error paths, and `obtainJwtFromExecutor`. Plugin suite 94 passing.

## Verification
- `cargo test -p ad4m-executor --lib mcp::tools::subscriptions` → 4/4.
- `cargo test --bin ad4m` (cli) → 7/7.
- plugin `vitest run` → 94/94; the stateDir guard confirmed to fail against the pre-fix code and pass after.
- `cargo fmt --check` clean on both crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved link-watch output with clearer event labels, typed link details, perspective filtering, and JSON fallback data.
  * Enhanced mention subscriptions with case-insensitive matching, literal target support, and perspective-specific subscription tracking.

* **Bug Fixes**
  * Fixed service state directory handling to correctly restore persisted waker state.
  * Improved subscription queries by excluding internal proof metadata and warning when body predicates are unavailable.
  * Improved service startup and notification handling for more reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->