### PR TITLE
fix(interpretation): decode literal-encoded overlay `kind` on read

### DIFF
--- a/rust-executor/src/perspectives/interpretation/overlay/accept.rs
+++ b/rust-executor/src/perspectives/interpretation/overlay/accept.rs
@@ -47,7 +47,7 @@ pub(crate) async fn overlay_of(
     base: &str,
 ) -> anyhow::Result<Option<OverlayView>> {
     let all = links_from(perspective, base).await?;
-    let kind = match first_target(&all, OVERLAY_KIND_PRED) {
+    let kind = match overlay_kind(&all) {
         Some(k) => k,
         None => return Ok(None),
     };
@@ -139,7 +139,7 @@ pub(crate) async fn reject_interpretation(
 ) -> anyhow::Result<()> {
     let _ = context;
     let all = links_from(perspective, base).await?;
-    let kind = match first_target(&all, OVERLAY_KIND_PRED) {
+    let kind = match overlay_kind(&all) {
         Some(k) => k,
         None => anyhow::bail!("reject_interpretation: no overlay on `{base}`"),
     };
@@ -184,6 +184,24 @@ fn first_target(links: &[DecoratedLinkExpression], predicate: &str) -> Option<St
         .iter()
         .find(|l| l.data.predicate.as_deref() == Some(predicate))
         .map(|l| l.data.target.clone())
+}
+
+/// The overlay's `kind` value (`create` | `update`), decoded from its link
+/// target.
+///
+/// `write_overlay` mints the overlay through `create_subject`, whose `kind`
+/// SHACL setter (`setSingleTarget`, no `resolveLanguage`) stores the value
+/// literal-encoded (`literal:string:create`). Every consumer — the §8 accept /
+/// reject branches below, the `interpretationOverlays` query surface, and the
+/// module's own tests (`decoded_targets`) — treats `kind` as the bare
+/// discriminator string, so decode it on read exactly as `inferred/<p>` targets
+/// are decoded. `parse_literal_value` passes an already-plain target through
+/// unchanged, so this stays correct regardless of how the link was written.
+fn overlay_kind(links: &[DecoratedLinkExpression]) -> Option<String> {
+    first_target(links, OVERLAY_KIND_PRED).map(|k| match parse_literal_value(&k) {
+        serde_json::Value::String(s) => s,
+        other => other.to_string(),
+    })
 }
 
 /// The `inferred/<p>` links on the base, optionally narrowed to one real
@@ -383,6 +401,64 @@ mod tests {
         assert!(
             overlay_of(&p, base).await.unwrap().is_none(),
             "overlay gone"
+        );
+    }
+
+    /// The production write path (`write_overlay` → `create_subject`) stores
+    /// `kind` through its SHACL `setSingleTarget` setter, which — because the
+    /// property carries no `resolveLanguage` — literal-encodes the value as
+    /// `literal:string:create`. Every reader treats `kind` as the bare
+    /// discriminator, so `overlay_of` must decode it and the §8 create/update
+    /// branches must fire on the decoded value.
+    ///
+    /// Regression for the wind-tunnel I3 failure: a literal-encoded `kind` read
+    /// back as `"literal:string:create"`, so `== "create"` never matched and
+    /// `reject`(create) wrongly took the update branch. The pre-existing tests
+    /// missed it only because their `add(..., "create")` seed wrote `kind`
+    /// *plain*, unlike the real setter.
+    #[tokio::test]
+    async fn overlay_kind_decodes_literal_encoded_target() {
+        let (mut p, _s, ctx) = setup_perspective_no_llm(&[]).await;
+        let base = "soa://ext/Task/kind-enc";
+        // Mint the overlay exactly as create_subject's `kind` setter does: a
+        // literal-encoded target, not the bare discriminator string.
+        add(
+            &mut p,
+            base,
+            OVERLAY_KIND_PRED,
+            "literal:string:create",
+            &ctx,
+        )
+        .await;
+        add(&mut p, base, OVERLAY_RUN_PRED, "ad4m://interp/run/r1", &ctx).await;
+        add(&mut p, base, "soa://title", "literal:string:Fix", &ctx).await;
+        add(
+            &mut p,
+            base,
+            &format!("{INFERRED_PREFIX}soa://title"),
+            "literal:string:Fix",
+            &ctx,
+        )
+        .await;
+
+        let view = overlay_of(&p, base)
+            .await
+            .unwrap()
+            .expect("overlay present");
+        assert_eq!(
+            view.kind, "create",
+            "kind must decode to the bare discriminator, not stay literal-encoded"
+        );
+
+        // The create branch must fire on the decoded kind: rejecting a create
+        // wipes the whole instance. If `kind` stayed `literal:string:create` this
+        // would wrongly hit the update branch and leave `soa://title` behind.
+        reject_interpretation(&mut p, base, None, &ctx)
+            .await
+            .unwrap();
+        assert!(
+            preds_on(&p, base).await.is_empty(),
+            "reject(create) removed the whole instance"
         );
     }
 }


### PR DESCRIPTION
## What

Fixes a read/write encoding mismatch on the `InterpretationOverlay` `kind` discriminator (`create` | `update`).

`write_overlay` mints the overlay through `create_subject`, whose `kind` SHACL setter (`setSingleTarget`) has no `resolveLanguage`, so `create_subject` stores the value **literal-encoded** — `literal:string:create`. But the readers treated `kind` as the bare discriminator string:

- `overlay_of` returned it raw, so `perspective.interpretationOverlays` surfaced `"literal:string:create"` to clients instead of `"create"`.
- `reject_interpretation` compared `kind == "create"` to choose its branch. On a real overlay that comparison never matched, so rejecting a *create* overlay wrongly took the *update* branch — it dropped only the overlay shell and left the LLM-authored instance behind, instead of deleting it wholesale.

The module's own tests missed this because their seed helper wrote `kind` **plain** (`add(..., "create")`), unlike the production `create_subject` setter.

## Fix

`overlay/accept.rs`: add an `overlay_kind()` helper that decodes the `kind` target with `parse_literal_value` — exactly how `inferred/<p>` targets are already decoded in `overlay_of` — and use it at both read sites (`overlay_of`, `reject_interpretation`). `parse_literal_value` passes an already-plain target through unchanged, so the read stays correct regardless of how the link was written.

Adds a regression test (`overlay_kind_decodes_literal_encoded_target`) that seeds a literal-encoded `kind` link (the production write-path shape) and asserts both that `overlay_of` decodes it to `"create"` and that `reject_interpretation` then deletes the whole instance. It fails without the fix.

## Verification

- `cargo fmt --check` clean.
- `cargo test perspectives::interpretation::overlay::accept` — 4/4 green (the new regression test plus the three pre-existing accept/reject tests, no regression).
- End to end against a containerised executor built from this stack: the interpretation wind-tunnel scenarios I3 (provenance gate) and I4 (accept/reject) both pass — I4's "reject an untouched create overlay deletes the whole instance" corner is the exact branch this fix repairs.

## Scope

Stacked on top of the generic-LLM-interpretation series; base branch `feature/generic-extraction-ws-ts`. One file changed (`rust-executor/src/perspectives/interpretation/overlay/accept.rs`), +78/−2.
