### PR TITLE
fix(interpretation): read a transcript body out of an expression envelope

### DIFF
--- a/rust-executor/src/perspectives/interpretation/graph/read.rs
+++ b/rust-executor/src/perspectives/interpretation/graph/read.rs
@@ -31,7 +31,7 @@ pub async fn gather_transcript(
         .map_err(|e| anyhow::anyhow!("gather_transcript: get_links failed: {e:#}"))?;
     let mut out = Vec::with_capacity(links.len());
     for l in links {
-        if let Some(body) = decode_literal_string(&l.data.target) {
+        if let Some(body) = decode_transcript_body(&l.data.target) {
             out.push(TranscriptTurn {
                 speaker: l.author,
                 text: body,
@@ -50,6 +50,42 @@ pub(crate) fn decode_literal_string(uri: &str) -> Option<String> {
     use ad4m_client::literal::{Literal, LiteralValue};
     match Literal::from_url(uri.to_string()).ok()?.get().ok()? {
         LiteralValue::String(s) => Some(s),
+        _ => None,
+    }
+}
+
+/// Decode a transcript body from a `literal:` URI, resolving an **expression
+/// envelope** as well as a bare string.
+///
+/// A property declared with `resolveLanguage` — which `@Property` sets by
+/// default, so *every* ORM-declared body has it — is not stored as
+/// `literal:string:…`. Setting it creates an expression in the Literal
+/// language, so the stored target is a signed envelope:
+///
+/// ```json
+/// literal:json:{"author":"did:key:…","timestamp":"…","data":"the words","proof":{…}}
+/// ```
+///
+/// [`decode_literal_string`] answers `None` for that (it is `LiteralValue::Json`,
+/// not `String`), which made both gathers silently skip every row and report an
+/// empty transcript — indistinguishable from a conversation with nothing in it.
+/// The fixtures write `ns://body` as a bare literal, so the path had only ever
+/// been exercised against text no ORM model produces.
+///
+/// So: a string literal is the body; a JSON envelope carrying a string `data` is
+/// the body inside it; anything else is still not a message body.
+pub(crate) fn decode_transcript_body(uri: &str) -> Option<String> {
+    use ad4m_client::literal::{Literal, LiteralValue};
+    match Literal::from_url(uri.to_string()).ok()?.get().ok()? {
+        LiteralValue::String(s) => Some(s),
+        // An expression envelope. `data` is the payload the author signed; the
+        // envelope's own `author`/`timestamp` are richer than the link
+        // reifier's and a caller could prefer them, but reading the body is
+        // what unblocks the gather.
+        LiteralValue::Json(v) => v
+            .get("data")
+            .and_then(|d| d.as_str())
+            .map(|s| s.to_string()),
         _ => None,
     }
 }
@@ -121,7 +157,7 @@ pub async fn gather_transcript_sparql(
             );
         };
         let text = if raw_text.starts_with("literal:") {
-            match decode_literal_string(raw_text) {
+            match decode_transcript_body(raw_text) {
                 Some(s) => s,
                 None => continue, // non-string literal — not a message body
             }
@@ -334,6 +370,41 @@ mod tests {
     use super::*;
 
     use crate::perspectives::interpretation_test_support::*;
+
+    /// A body stored by a property with `resolveLanguage` — which `@Property` sets by default — is a
+    /// signed expression envelope, not a bare string. Reading only the bare form made both gathers
+    /// skip every row and report an empty transcript, which is indistinguishable from a conversation
+    /// with nothing in it: no error, no warning, no event.
+    #[test]
+    fn transcript_body_reads_an_expression_envelope() {
+        use ad4m_client::literal::Literal;
+
+        // What `@Optional` (no resolveLanguage) stores.
+        let bare = Literal::from_string("the words".to_string())
+            .to_url()
+            .unwrap();
+        assert_eq!(decode_transcript_body(&bare).as_deref(), Some("the words"));
+
+        // What `@Property` stores: an expression created in the Literal language.
+        let envelope = Literal::from_json(serde_json::json!({
+            "author": "did:key:z6Mkabc",
+            "timestamp": "2026-08-18T16:18:21.287Z",
+            "data": "the words",
+            "proof": { "key": "did:key:z6Mkabc#z6Mkabc", "signature": "deadbeef" },
+        }))
+        .to_url()
+        .unwrap();
+        assert_eq!(
+            decode_transcript_body(&envelope).as_deref(),
+            Some("the words")
+        );
+
+        // Still not a message body: JSON with no string `data`.
+        let other = Literal::from_json(serde_json::json!({ "count": 3 }))
+            .to_url()
+            .unwrap();
+        assert_eq!(decode_transcript_body(&other), None);
+    }
 
     #[tokio::test]
     async fn existing_instance_context_reads_id_and_identity() {


### PR DESCRIPTION
# Read a transcript body out of an expression envelope

Branch: `fix/interpretation-gather-expression-body` → `feature/generic-extraction-ws-ts`
One commit (`0e6083f32`), one file, plus a unit test.

## Summary

An AutoProcessor registered over a WE call registered correctly and produced nothing — no instances,
no `auto-processor-event` of any step, no warning in the executor log. The config was written, the
`ad4m://AutoProcessor` class was registered, the watch loop was running and loading it every tick.
It simply gathered zero turns, every time.

The cause is a mismatch between how the gather reads a body and how the ORM stores one. Both gathers
decode a `literal:` target with `decode_literal_string`, which answers `Some` only for
`LiteralValue::String`. But a property declared with `resolveLanguage` — which **`@Property` sets by
default** — is not stored as `literal:string:…`. Setting it creates an expression in the Literal
language, so the stored target is a signed envelope:

```
literal:json:{"author":"did:key:z6Mki…","timestamp":"2026-08-18T16:18:21.287Z",
              "data":"An upcoming task is testing the auto extraction.","proof":{…}}
```

That is `LiteralValue::Json`, so every row hit `None => continue` and the transcript came back empty.

The failure is invisible by construction: an empty transcript means the tick has nothing to do, so it
emits no event and logs no warning — indistinguishable from a conversation with nothing in it. It
took a locally built executor and temporary instrumentation to find, having first ruled out the
config write, the class registration, the watch loop, and the event plumbing.

`decode_transcript_body` accepts either form, and both gathers now use it.

## Changes

**`interpretation/graph/read.rs`** — the only file.

- **`decode_transcript_body`** (new). A string literal is the body; a JSON envelope carrying a string
  `data` is the body inside it; anything else is still not a message body.
- **Used at both gather sites**: `gather_transcript_sparql` (the AutoProcessor's path) and the
  link-based `gather_transcript`, which had the identical limitation and would have failed the same
  way for any ORM-declared body.
- **`decode_literal_string` is left untouched.** Its third caller is `cursor.rs`, which decodes with a
  raw fallback for a different purpose; widening it there would change behaviour nobody asked to
  change. A separate function keeps the fix to the one question being answered — "what are the words
  in this body".
- **A unit test** covering the three cases: the bare form `@Optional` stores, the envelope
  `@Property` stores, and JSON with no string `data` still yielding `None`. Without it this is
  exactly the kind of fix that regresses silently.

## Why it had not surfaced

`BODY_AUTHOR_TIMESTAMP_SCOPE_QUERY` and the `interpretation_e2e` fixtures write `ns://body` as a
**bare literal**. The gather had only ever been exercised against text that no ORM model produces —
so the whole AutoProcessor path was correct against its fixtures and broken against real data.

The decorator defaults are the reason it affects everything rather than one model
(`core/src/model/decorators.ts`):

```ts
Property(opts) → resolveLanguage: opts.resolveLanguage ?? "literal"   // always set
Optional(opts) → (no resolveLanguage default)
```

Nothing to do with `required` — both default it to `false`. Any body property declared the standard
way is stored as an envelope.

**One-shot `runInterpretation` was never affected**, which is why this looked like an AutoProcessor
problem: its turns are gathered by the *client* through the ORM, which sees `resolveLanguage` and
resolves the expression before interpretation is called. The AutoProcessor has no ORM by design —
that is the point of it running with nobody there — so it reads the raw triple, and the raw triple is
the envelope.

## Known follow-ups

- **The envelope carries better metadata than the reifier.** It already holds `author` and
  `timestamp` — exactly what a `source_scope_query` currently has to scrape off the body link's
  reifier. If the gather preferred them when present, a scope query could collapse to:

  ```sparql
  SELECT ?speaker ?text ?timestamp WHERE { <src> <ns://children> ?m . ?m <ns://body> ?text . }
  ```

  Worth doing on its own merits: a query that binds `?speaker` and `?text` but not `?timestamp`
  **fails the whole gather**, and the reifier pattern is fiddly enough that this is an easy mistake
  to make. Fewer required joins is fewer ways to get it wrong.

- **`parent` on `AddAutoProcessorConfig`.** `basePrefix` confines minted instances to a URI subtree
  but creates no edge, so nothing links a pass's output to the node it came from. Consumers whose
  routes reach content by traversal (WE's do) have to write that edge client-side, which means a pass
  completing with no client listening leaves records nothing lists. A `parent: { id, predicate }`
  applied after `create_subject` would close it server-side.

- **`runInterpretation` takes shape names, `addAutoProcessor` takes target-class URIs.** Converted by
  the caller today. Worth aligning, because passing the wrong one is logged as "skipping class" and
  surfaces as "perspective has no subject classes to extract into" — a wrong argument reading as a
  broken space.

## Test plan

- [x] `cargo test -p ad4m-executor --release --lib perspectives::interpretation_e2e::auto_processor`
      → **5 passed**, with the fix and the new test in place.
- [x] New unit test `transcript_body_reads_an_expression_envelope` → passes.
- [x] Full `perspectives::interpretation` suite → **87 passed, 3 failed**. The three
      (`e2e_longer_standup_conversation`, `e2e_flux_grouping_scoped_incremental_lifecycle`,
      `e2e_flux_grouping_updates_seeded_subgroup_on_topic_continuation`) **fail identically without
      this change** — they are model-quality tests and were run against `gemma3:4b` rather than
      `gemma3:12b`. Worth re-running on a box with the intended model.
- [x] **End to end against a live WE call** on a locally built executor: utterances transcribed, a
      pass firing on the debounce window, and typed instances landing —
      *"An upcoming task is testing the auto extraction"* → a `TaskBlock`;
      *"an upcoming event is going to Bristol this weekend"* → an `EventBlock`.
- [ ] **Not run: over Marvin / multi-peer.** The election and claim paths are covered by the existing
      e2e tests but have not been exercised across two machines with this change.
