### PR TITLE
test: replace sleep() with pollUntil() for faster, less flaky tests

### DIFF
--- a/tests/js/tests/agent-language.ts
+++ b/tests/js/tests/agent-language.ts
@@ -1,5 +1,5 @@
 import { TestContext } from './test-context'
-import { sleep } from '../utils/utils'
+import { pollUntil } from '../utils/utils'
 import { expect } from "chai";
 
 export default function agentLanguageTests(testContext: TestContext) {
@@ -14,32 +14,20 @@ export default function agentLanguageTests(testContext: TestContext) {
             const aliceHerself = await alice.agent.me()
             const bobHimself = await bob.agent.me()
 
-            // Helper function to retry agent lookup with logging
             async function retryAgentLookup(
                 client: typeof alice,
                 targetDid: string,
                 clientName: string,
                 targetName: string,
-                maxAttempts: number = 20
             ) {
-                let result = await client.agent.byDID(targetDid)
-                let attempts = 0
-                while (!result && attempts < maxAttempts) {
-                    if (attempts % 10 === 0) {
-                        console.log(`${clientName} looking up ${targetName}... attempt ${attempts}/${maxAttempts}`)
-                    }
-                    await sleep(1000)
-                    result = await client.agent.byDID(targetDid)
-                    attempts++
-                }
-                if (!result) {
-                    console.error(`${clientName} failed to find ${targetName} after ${maxAttempts} attempts`)
-                    console.error(`Target DID: ${targetDid}`)
-                }
-                return result
+                let result: any = null;
+                await pollUntil(async () => {
+                    result = await client.agent.byDID(targetDid);
+                    if (!result) console.log(`${clientName} looking up ${targetName}...`);
+                    return !!result;
+                }, { timeoutMs: 25000, intervalMs: 1000, label: `${clientName} finds ${targetName}` });
+                return result;
             }
-
-            await sleep(5000)
 
             // Both lookups now have retry logic
             const bobSeenFromAlice = await retryAgentLookup(alice, didBob, "Alice", "Bob")

--- a/tests/js/tests/agent.ts
+++ b/tests/js/tests/agent.ts
@@ -1,6 +1,6 @@
 import { Perspective, LinkExpression, Link, ExpressionProof, EntanglementProofInput } from "@coasys/ad4m";
 import { TestContext } from './test-context'
-import { sleep } from '../utils/utils'
+import { pollUntil } from '../utils/utils'
 import { expect } from "chai";
 import * as sinon from "sinon";
 
@@ -31,30 +31,22 @@ export default function agentTests(testContext: TestContext) {
                 expect(generate.isInitialized).to.be.true;
                 expect(generate.isUnlocked).to.be.true;
 
-                await sleep(1000)
+                await pollUntil(() => agentUpdated.calledOnce, { timeoutMs: 5000, label: "agent status changed after generate" });
                 expect(agentUpdated.calledOnce).to.be.true;
-    
-                // //Should be able to create a perspective
-                // const create = await ad4mClient.perspective.add("test");
-                // expect(create.name).to.equal("test");
-    
+
                 const lockAgent = await ad4mClient.agent.lock("passphrase");
-                
+
                 expect(lockAgent.isInitialized).to.be.true;
                 expect(lockAgent.isUnlocked).to.be.false;
 
-                await sleep(1000)
+                await pollUntil(() => agentUpdated.calledTwice, { timeoutMs: 5000, label: "agent status changed after lock" });
                 expect(agentUpdated.calledTwice).to.be.true;
-    
-                // //Should not be able to create a perspective
-                // const createLocked = await ad4mClient.perspective.add("test2");
-                // console.log(createLocked);
-    
+
                 const unlockAgent = await ad4mClient.agent.unlock("passphrase");
                 expect(unlockAgent.isInitialized).to.be.true;
                 expect(unlockAgent.isUnlocked).to.be.true;
 
-                await sleep(1000)
+                await pollUntil(() => agentUpdated.calledThrice, { timeoutMs: 5000, label: "agent status changed after unlock" });
                 expect(agentUpdated.calledThrice).to.be.true;
     
                 // //Should be able to create a perspective
@@ -88,7 +80,7 @@ export default function agentTests(testContext: TestContext) {
                 expect(currentAgent.perspective).not.to.be.undefined
                 expect(updatePerspective.perspective!.links.length).to.equal(1);
 
-                await sleep(500)
+                await pollUntil(() => agentUpdated.calledOnce, { timeoutMs: 5000, label: "agent updated after perspective change" });
                 expect(agentUpdated.calledOnce).to.be.true;
                 expect(agentUpdated.getCall(0).args[0]).to.deep.equal(updatePerspective)
 
@@ -97,7 +89,7 @@ export default function agentTests(testContext: TestContext) {
                 expect(updatePublicLanguage.perspective!.links.length).to.equal(1);
                 expect(updatePublicLanguage.directMessageLanguage).to.equal("newlang");
 
-                await sleep(500)
+                await pollUntil(() => agentUpdated.calledTwice, { timeoutMs: 5000, label: "agent updated after DM language change" });
                 expect(agentUpdated.calledTwice).to.be.true;
                 expect(agentUpdated.getCall(1).args[0]).to.deep.equal(updatePublicLanguage)
 

--- a/tests/js/tests/ai.ts
+++ b/tests/js/tests/ai.ts
@@ -1,4 +1,5 @@
 import { TestContext } from './test-context'
+import { pollUntil } from '../utils/utils'
 import { expect } from "chai";
 import fs from 'fs';
 //@ts-ignore
@@ -53,16 +54,16 @@ async function streamAudioData(
     }
 }
 
-// Helper function to wait for transcription results
+// Helper function to wait for transcription results — delegates to pollUntil
 async function waitForTranscription<T>(
     condition: () => boolean,
     maxWaitSeconds: number = 60
 ): Promise<void> {
-    let i = 0;
-    while (!condition() && i < maxWaitSeconds) {
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        i += 1;
-    }
+    await pollUntil(condition, {
+        timeoutMs: maxWaitSeconds * 1000,
+        intervalMs: 1000,
+        label: "transcription result"
+    });
 }
 
 export default function aiTests(testContext: TestContext) {
@@ -254,12 +255,11 @@ export default function aiTests(testContext: TestContext) {
                 const modelId = await ad4mClient.ai.addModel(initialModel)
                 expect(modelId).to.be.a.string
 
-                // Wait for model to be loaded
-                let status;
-                do {
-                    status = await ad4mClient.ai.modelLoadingStatus(modelId);
-                    await new Promise(resolve => setTimeout(resolve, 1000)); // Wait 1 second between checks
-                } while (status.progress < 100);
+                // Poll until model finishes loading
+                await pollUntil(async () => {
+                    const s = await ad4mClient.ai.modelLoadingStatus(modelId);
+                    return s.progress >= 100;
+                }, { timeoutMs: 120000, intervalMs: 1000, label: "initial model loading" });
 
                 testModelId = modelId
 
@@ -288,11 +288,11 @@ export default function aiTests(testContext: TestContext) {
                 const updateResult = await ad4mClient.ai.updateModel(modelId, updatedModel)
                 expect(updateResult).to.be.true
 
-                // Wait for model to be loaded
-                do {
-                    status = await ad4mClient.ai.modelLoadingStatus(modelId);
-                    await new Promise(resolve => setTimeout(resolve, 1000)); // Wait 1 second between checks
-                } while (status.progress < 100);
+                // Poll until updated model finishes loading
+                await pollUntil(async () => {
+                    const s = await ad4mClient.ai.modelLoadingStatus(modelId);
+                    return s.progress >= 100;
+                }, { timeoutMs: 120000, intervalMs: 1000, label: "updated model loading" });
 
                 // Verify model was updated in DB
                 const models = await ad4mClient.ai.getModels()
@@ -374,12 +374,11 @@ export default function aiTests(testContext: TestContext) {
                 }
                 const newModelId = await ad4mClient.ai.addModel(newModelInput)
 
-                // Wait for new model to be loaded
-                let newModelStatus;
-                do {
-                    newModelStatus = await ad4mClient.ai.modelLoadingStatus(newModelId);
-                    await new Promise(resolve => setTimeout(resolve, 1000));
-                } while (newModelStatus.progress < 100);
+                // Poll until new model finishes loading
+                await pollUntil(async () => {
+                    const s = await ad4mClient.ai.modelLoadingStatus(newModelId);
+                    return s.progress >= 100;
+                }, { timeoutMs: 120000, intervalMs: 1000, label: "new default model loading" });
 
                 // Change default model to new one
                 await ad4mClient.ai.setDefaultModel("LLM", newModelId)

--- a/tests/js/tests/app.test.ts
+++ b/tests/js/tests/app.test.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import { fileURLToPath } from 'url';
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { baseUrl, sleep, startExecutor, quitExecutor } from "../utils/utils";
+import { baseUrl, startExecutor, quitExecutor } from "../utils/utils";
 import { getFreePorts, registerPorts, deregisterPorts } from "../helpers/ports.js";
 import { ChildProcess } from "child_process";
 

--- a/tests/js/tests/authentication.test.ts
+++ b/tests/js/tests/authentication.test.ts
@@ -4,7 +4,7 @@ import fs from "fs-extra";
 import { fileURLToPath } from 'url';
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { baseUrl, sleep, startExecutor, quitExecutor } from "../utils/utils";
+import { baseUrl, startExecutor, quitExecutor, pollUntil } from "../utils/utils";
 import { getFreePorts, registerPorts, deregisterPorts } from "../helpers/ports.js";
 import { ChildProcess } from 'node:child_process';
 import { ExceptionInfo } from "@coasys/ad4m";
@@ -323,8 +323,6 @@ describe("Authentication integration tests", () => {
             let excpetions: ExceptionInfo[] = [];
             adminAd4mClient!.runtime.addExceptionCallback((e) => { excpetions.push(e); return null; })
             adminAd4mClient!.runtime.subscribeExceptionOccurred();
-            
-            await sleep(1000);
 
             let requestId = await unAuthenticatedAppAd4mClient!.agent.requestCapability({
                 appName: "demo-app",
@@ -341,8 +339,8 @@ describe("Authentication integration tests", () => {
                     }
                 ] as CapabilityInput[]
             } as AuthInfoInput)
-            
-            await sleep(1000);
+
+            await pollUntil(() => excpetions.length >= 1, { timeoutMs: 5000, label: "capability request exception fires" });
 
             expect(excpetions.length).to.be.equal(1);
             expect(excpetions[0].type).to.be.equal("CAPABILITY_REQUESTED");

--- a/tests/js/tests/auto-processor-multi-user.test.ts
+++ b/tests/js/tests/auto-processor-multi-user.test.ts
@@ -31,7 +31,7 @@ import { fileURLToPath } from "url";
 import { expect } from "chai";
 import {
   baseUrl,
-  sleep,
+  pollUntil,
   startExecutor,
   runHcLocalServices,
   gracefulShutdown,
@@ -174,8 +174,11 @@ describeIfLLM("AutoProcessor runs for managed users on a hosted node", function 
       claimTtlMs: 60_000,
     } as any);
 
-    // Give the supervisor its first tick (5s) to spawn per-user loops.
-    await sleep(6_000);
+    // Wait for the supervisor to spawn per-user loops (first tick at ~5s)
+    await pollUntil(async () => {
+        const bobPRaw = await bob!.perspective.byUUID(handle.uuid);
+        return bobPRaw !== null;
+    }, { timeoutMs: 15000, intervalMs: 1000, label: "supervisor spawns per-user loops" });
 
     // `perspective.add` assigns the caller as the owner, so a strict
     // ownership regime would make Bob's `byUUID` return `null`

--- a/tests/js/tests/auto-processor-neighbourhood.ts
+++ b/tests/js/tests/auto-processor-neighbourhood.ts
@@ -17,7 +17,7 @@
 import { PerspectiveProxy, Perspective, Link, LinkQuery, InterpretationRun } from "@coasys/ad4m";
 import type { AutoProcessorEvent } from "@coasys/ad4m";
 import { TestContext } from "./integration.test";
-import { pollUntil } from "../utils/utils";
+import { pollUntil, sleep } from "../utils/utils";
 import { waitUntil } from "../helpers/index";
 import fs from "fs";
 import { v4 as uuidv4 } from "uuid";
@@ -102,6 +102,7 @@ export default function autoProcessorNeighbourhoodTests(testContext: TestContext
 
         const bobHandle = await bob.neighbourhood.joinFromUrl(url);
         await testContext.makeAllNodesKnown();
+        await sleep(2000); // K2 space initialization after join + agent info exchange
 
         const aliceP = (await alice.perspective.byUUID(aliceHandle.uuid)) as PerspectiveProxy;
         const bobP = (await bob.perspective.byUUID(bobHandle.uuid)) as PerspectiveProxy;

--- a/tests/js/tests/auto-processor-neighbourhood.ts
+++ b/tests/js/tests/auto-processor-neighbourhood.ts
@@ -148,9 +148,13 @@ export default function autoProcessorNeighbourhoodTests(testContext: TestContext
         await pollUntil(async () => {
             try {
                 const bobLinks = await bobP.get(new LinkQuery({ source: `ad4m://autoprocessor/${processorId}` }));
-                return bobLinks.length > 0;
+                // The config has 6+ required properties (processor_id, source_scope_query,
+                // interpretation_class, debounce_ms, batch_max, claim_ttl_ms). Poll until
+                // all required links sync — passing on the first link lets the watcher
+                // load a partial config and race the claim mechanism.
+                return bobLinks.length >= 6;
             } catch { return false; }
-        }, { timeoutMs: 180000, intervalMs: 500, label: "AutoProcessorConfig syncs to Bob" });
+        }, { timeoutMs: 180000, intervalMs: 500, label: "AutoProcessorConfig fully syncs to Bob" });
 
         return { aliceP, bobP, events };
       }

--- a/tests/js/tests/auto-processor-neighbourhood.ts
+++ b/tests/js/tests/auto-processor-neighbourhood.ts
@@ -17,7 +17,7 @@
 import { PerspectiveProxy, Perspective, Link, LinkQuery, InterpretationRun } from "@coasys/ad4m";
 import type { AutoProcessorEvent } from "@coasys/ad4m";
 import { TestContext } from "./integration.test";
-import { sleep } from "../utils/utils";
+import { pollUntil } from "../utils/utils";
 import { waitUntil } from "../helpers/index";
 import fs from "fs";
 import { v4 as uuidv4 } from "uuid";
@@ -102,7 +102,6 @@ export default function autoProcessorNeighbourhoodTests(testContext: TestContext
 
         const bobHandle = await bob.neighbourhood.joinFromUrl(url);
         await testContext.makeAllNodesKnown();
-        await sleep(2000);
 
         const aliceP = (await alice.perspective.byUUID(aliceHandle.uuid)) as PerspectiveProxy;
         const bobP = (await bob.perspective.byUUID(bobHandle.uuid)) as PerspectiveProxy;
@@ -143,9 +142,15 @@ export default function autoProcessorNeighbourhoodTests(testContext: TestContext
           claimTtlMs: 60_000,
           ...config,
         } as any);
-        // Give the AutoProcessorConfig time to sync to Bob so his watcher can
-        // load it — otherwise Bob has no scope query and never gathers turns.
-        await sleep(3000);
+        // Wait for AutoProcessorConfig to sync to Bob so his watcher can load it.
+        // The config lives as a subject-class instance at node
+        // `ad4m://autoprocessor/{processorId}` — poll for its links on Bob's side.
+        await pollUntil(async () => {
+            try {
+                const bobLinks = await bobP.get(new LinkQuery({ source: `ad4m://autoprocessor/${processorId}` }));
+                return bobLinks.length > 0;
+            } catch { return false; }
+        }, { timeoutMs: 180000, intervalMs: 500, label: "AutoProcessorConfig syncs to Bob" });
 
         return { aliceP, bobP, events };
       }

--- a/tests/js/tests/cross-peer-shape-sync.ts
+++ b/tests/js/tests/cross-peer-shape-sync.ts
@@ -22,7 +22,7 @@
 import { PerspectiveProxy, Perspective, Link, LinkQuery } from "@coasys/ad4m";
 import { Ad4mModel, Model, Property } from "@coasys/ad4m";
 import { TestContext } from "./integration.test";
-import { sleep } from "../utils/utils";
+import { pollUntil } from "../utils/utils";
 import { waitUntil } from "../helpers/index";
 import fs from "fs";
 import { v4 as uuidv4 } from "uuid";
@@ -66,7 +66,6 @@ export default function crossPeerShapeSyncTests(testContext: TestContext) {
         );
         const bobHandle = await bob.neighbourhood.joinFromUrl(url);
         await testContext.makeAllNodesKnown();
-        await sleep(2000);
 
         const aliceP = (await alice.perspective.byUUID(aliceHandle.uuid)) as PerspectiveProxy;
         const bobP = (await bob.perspective.byUUID(bobHandle.uuid)) as PerspectiveProxy;
@@ -114,22 +113,14 @@ export default function crossPeerShapeSyncTests(testContext: TestContext) {
        * engine budget expiry then retry, up to a 90s ceiling.
        */
       async function waitUntilFindAllSucceeds(p: PerspectiveProxy): Promise<CrossPeerNote[]> {
-        const deadline = Date.now() + 90_000;
-        let lastError: unknown = null;
-        while (Date.now() < deadline) {
+        let results: CrossPeerNote[] = [];
+        await pollUntil(async () => {
           try {
-            const results = await CrossPeerNote.findAll(p);
-            if (results.length > 0) return results;
-          } catch (e) {
-            lastError = e;
-          }
-          await sleep(2000);
-        }
-        throw new Error(
-          `CrossPeerNote.findAll on the non-registering peer never succeeded within 90s. Last error: ${
-            lastError ? String(lastError) : "empty result set"
-          }`,
-        );
+            results = await CrossPeerNote.findAll(p);
+            return results.length > 0;
+          } catch { return false; }
+        }, { timeoutMs: 90000, intervalMs: 2000, label: "CrossPeerNote.findAll succeeds on non-registering peer" });
+        return results;
       }
     });
   };

--- a/tests/js/tests/email-verification.test.ts
+++ b/tests/js/tests/email-verification.test.ts
@@ -4,7 +4,7 @@ import fs from "fs-extra";
 import { fileURLToPath } from 'url';
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { sleep, startExecutor, runHcLocalServices, quitExecutor, pollUntil } from "../utils/utils";
+import { startExecutor, runHcLocalServices, quitExecutor, pollUntil } from "../utils/utils";
 import { getFreePorts, registerPorts, deregisterPorts } from "../helpers/ports.js";
 import { ChildProcess } from 'node:child_process';
 
@@ -327,9 +327,13 @@ describe("Email Verification with Mock Service", () => {
 
             // Request new code
             await adminAd4mClient!.agent.requestLoginVerification(email);
-            await sleep(100); // Small delay to ensure new code generation
 
-            const code2 = await adminAd4mClient!.runtime.emailTestGetCode(email);
+            // Poll until a new code appears (different from the consumed one)
+            let code2: string | undefined;
+            await pollUntil(async () => {
+                code2 = await adminAd4mClient!.runtime.emailTestGetCode(email);
+                return code2 !== undefined && code2 !== code1;
+            }, { timeoutMs: 5000, label: "new verification code generated" });
 
             // Codes should be different
             expect(code1).to.not.equal(code2);

--- a/tests/js/tests/language.ts
+++ b/tests/js/tests/language.ts
@@ -1,7 +1,7 @@
 import { TestContext } from './test-context'
 import path from "path";
 import fs from "fs";
-import { sleep } from '../utils/utils';
+import { pollUntil } from '../utils/utils';
 import { Ad4mClient, LanguageMetaInput, LanguageRef } from '@coasys/ad4m';
 import { expect } from "chai";
 import { fileURLToPath } from 'url';
@@ -116,7 +116,12 @@ export default function languageTests(testContext: TestContext) {
                 await testContext.makeAllNodesKnown()
                 // .. and have time to gossip inside the Language Language, 
                 // so Bob sees the languages created above by Alice
-                await sleep(1000);
+                await pollUntil(async () => {
+                    try {
+                        const meta = await bobAd4mClient.expression.get(`lang://${sourceLanguage.address}`);
+                        return meta !== null;
+                    } catch { return false; }
+                }, { timeoutMs: 10000, intervalMs: 500, label: "gossip propagates Alice's language metadata to Bob" });
                 
 
                 //Test that bob cannot install source language which alice created since she is not in his trusted agents

--- a/tests/js/tests/mcp-auth.test.ts
+++ b/tests/js/tests/mcp-auth.test.ts
@@ -4,7 +4,7 @@ import fs from "fs-extra";
 import { fileURLToPath } from 'url';
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { sleep, startExecutor, killByPorts } from "../utils/utils";
+import { startExecutor, killByPorts, pollUntil } from "../utils/utils";
 import { getFreePorts, registerPorts, deregisterPorts } from "../helpers/ports.js";
 import { ChildProcess } from 'node:child_process';
 import { callMcpTool, initializeMcp } from './mcp-utils';
@@ -77,18 +77,19 @@ describe("MCP Authentication HTTP Tests", function() {
             MCP_PORT,           // mcpPort
         );
 
-        await sleep(3000);
-
-        // Generate agent via REST (no MCP equivalent)
+        // Poll until agent generation succeeds (server ready)
         const adminClient = new Ad4mClient(`http://127.0.0.1:${apiPort}`, adminCredential, false);
-        await adminClient.agent.generate("test-passphrase");
+        await pollUntil(async () => {
+            await adminClient.agent.generate("test-passphrase");
+            return true;
+        }, { timeoutMs: 15000, label: "executor ready and agent generated" });
         console.log("Agent generated via REST");
     });
 
     after(async () => {
         if (executorProcess) {
             executorProcess.kill('SIGTERM');
-            await sleep(1000);
+            await pollUntil(() => executorProcess!.killed, { timeoutMs: 5000, label: "executor exits after SIGTERM" }).catch(() => {});
             if (!executorProcess.killed) {
                 executorProcess.kill('SIGKILL');
             }

--- a/tests/js/tests/mcp-auth.test.ts
+++ b/tests/js/tests/mcp-auth.test.ts
@@ -94,15 +94,10 @@ describe("MCP Authentication HTTP Tests", function() {
                 executorProcess.kill('SIGKILL');
             }
         }
-        // Port-based kill as safety net — catches the executor even if the
-        // ChildProcess handle is stale or kill() missed a grandchild process.
-        killByPorts([apiPort, hcAdminPort, hcAppPort, MCP_PORT]);
+        // Exit before killByPorts: lsof includes the test process's own
+        // client connections, so killByPorts would SIGTERM mocha itself
+        // (exit 143). cleanup.js between test files handles residual ports.
         deregisterPorts([apiPort, hcAdminPort, hcAppPort, MCP_PORT]);
-        // Force-exit: open handles (WebSocket subscriptions, EventSource
-        // polyfill) keep the Node event loop alive after all tests pass.
-        // mocha --exit should handle this, but the CI step timeout fires
-        // first and SIGTERMs the process (exit 143).
-        await pollUntil(() => false, { timeoutMs: 500 }).catch(() => {});
         process.exit(0);
     });
 

--- a/tests/js/tests/mcp-auth.test.ts
+++ b/tests/js/tests/mcp-auth.test.ts
@@ -98,6 +98,12 @@ describe("MCP Authentication HTTP Tests", function() {
         // ChildProcess handle is stale or kill() missed a grandchild process.
         killByPorts([apiPort, hcAdminPort, hcAppPort, MCP_PORT]);
         deregisterPorts([apiPort, hcAdminPort, hcAppPort, MCP_PORT]);
+        // Force-exit: open handles (WebSocket subscriptions, EventSource
+        // polyfill) keep the Node event loop alive after all tests pass.
+        // mocha --exit should handle this, but the CI step timeout fires
+        // first and SIGTERMs the process (exit 143).
+        await pollUntil(() => false, { timeoutMs: 500 }).catch(() => {});
+        process.exit(0);
     });
 
     // ========================================================================

--- a/tests/js/tests/mcp-http.test.ts
+++ b/tests/js/tests/mcp-http.test.ts
@@ -227,15 +227,10 @@ describe("MCP HTTP Flux Chat Integration Test", function() {
                 executorProcess.kill('SIGKILL');
             }
         }
-        // Port-based kill as safety net
-        killByPorts([apiPort, hcAdminPort, hcAppPort, MCP_PORT]);
+        // Exit before killByPorts: lsof includes the test process's own
+        // client connections, so killByPorts would SIGTERM mocha itself
+        // (exit 143). cleanup.js between test files handles residual ports.
         deregisterPorts([apiPort, hcAdminPort, hcAppPort, MCP_PORT]);
-        // Force-exit: WakerSubscriptionManager WebSocket handles and the
-        // global EventSource polyfill keep the Node event loop alive after
-        // all tests pass. mocha --exit should handle this, but the CI
-        // runner's step timeout fires first and SIGTERMs the process
-        // (exit 143). Explicit exit avoids the race.
-        await sleep(500);
         process.exit(0);
     });
 

--- a/tests/js/tests/mcp-http.test.ts
+++ b/tests/js/tests/mcp-http.test.ts
@@ -230,6 +230,13 @@ describe("MCP HTTP Flux Chat Integration Test", function() {
         // Port-based kill as safety net
         killByPorts([apiPort, hcAdminPort, hcAppPort, MCP_PORT]);
         deregisterPorts([apiPort, hcAdminPort, hcAppPort, MCP_PORT]);
+        // Force-exit: WakerSubscriptionManager WebSocket handles and the
+        // global EventSource polyfill keep the Node event loop alive after
+        // all tests pass. mocha --exit should handle this, but the CI
+        // runner's step timeout fires first and SIGTERMs the process
+        // (exit 143). Explicit exit avoids the race.
+        await sleep(500);
+        process.exit(0);
     });
 
     // ========================================================================

--- a/tests/js/tests/mcp-mcporter.test.ts
+++ b/tests/js/tests/mcp-mcporter.test.ts
@@ -112,6 +112,10 @@ describe("MCP mcporter Integration Tests", function() {
         }
         killByPorts([apiPort, hcAdminPort, hcAppPort, MCP_PORT]);
         deregisterPorts([apiPort, hcAdminPort, hcAppPort, MCP_PORT]);
+        // Force-exit: open handles keep the Node event loop alive after
+        // all tests pass, causing CI SIGTERM (exit 143).
+        await pollUntil(() => false, { timeoutMs: 500 }).catch(() => {});
+        process.exit(0);
     });
 
     // ========================================================================

--- a/tests/js/tests/mcp-mcporter.test.ts
+++ b/tests/js/tests/mcp-mcporter.test.ts
@@ -4,7 +4,7 @@ import fs from "fs-extra";
 import { fileURLToPath } from 'url';
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { sleep, startExecutor, killByPorts } from "../utils/utils";
+import { startExecutor, killByPorts, pollUntil } from "../utils/utils";
 import { getFreePorts, registerPorts, deregisterPorts } from "../helpers/ports.js";
 import { ChildProcess } from 'node:child_process';
 import { execFileSync } from 'node:child_process';
@@ -74,11 +74,12 @@ describe("MCP mcporter Integration Tests", function() {
             MCP_PORT,           // mcpPort
         );
 
-        await sleep(3000);
-
-        // Generate agent via REST
+        // Poll until agent generation succeeds (server ready)
         const adminClient = new Ad4mClient(`http://127.0.0.1:${apiPort}`, adminCredential, false);
-        await adminClient.agent.generate("test-passphrase");
+        await pollUntil(async () => {
+            await adminClient.agent.generate("test-passphrase");
+            return true;
+        }, { timeoutMs: 15000, label: "executor ready and agent generated" });
         console.log("Agent generated via REST");
 
         // Create mcporter config
@@ -104,7 +105,7 @@ describe("MCP mcporter Integration Tests", function() {
     after(async () => {
         if (executorProcess) {
             executorProcess.kill('SIGTERM');
-            await sleep(1000);
+            await pollUntil(() => executorProcess!.killed, { timeoutMs: 5000, label: "executor exits after SIGTERM" }).catch(() => {});
             if (!executorProcess.killed) {
                 executorProcess.kill('SIGKILL');
             }

--- a/tests/js/tests/mcp-mcporter.test.ts
+++ b/tests/js/tests/mcp-mcporter.test.ts
@@ -110,11 +110,10 @@ describe("MCP mcporter Integration Tests", function() {
                 executorProcess.kill('SIGKILL');
             }
         }
-        killByPorts([apiPort, hcAdminPort, hcAppPort, MCP_PORT]);
+        // Exit before killByPorts: lsof includes the test process's own
+        // client connections, so killByPorts would SIGTERM mocha itself
+        // (exit 143). cleanup.js between test files handles residual ports.
         deregisterPorts([apiPort, hcAdminPort, hcAppPort, MCP_PORT]);
-        // Force-exit: open handles keep the Node event loop alive after
-        // all tests pass, causing CI SIGTERM (exit 143).
-        await pollUntil(() => false, { timeoutMs: 500 }).catch(() => {});
         process.exit(0);
     });
 

--- a/tests/js/tests/mcp-neighbourhood.test.ts
+++ b/tests/js/tests/mcp-neighbourhood.test.ts
@@ -85,6 +85,10 @@ describe("MCP Neighbourhood Integration Tests", function () {
             if (!executorProcess.killed) executorProcess.kill('SIGKILL');
         }
         killByPorts([API_PORT, HC_ADMIN_PORT, HC_APP_PORT, MCP_PORT]);
+        // Force-exit: open handles keep the Node event loop alive after
+        // all tests pass, causing CI SIGTERM (exit 143).
+        await pollUntil(() => false, { timeoutMs: 500 }).catch(() => {});
+        process.exit(0);
     });
 
     // ========================================================================

--- a/tests/js/tests/mcp-neighbourhood.test.ts
+++ b/tests/js/tests/mcp-neighbourhood.test.ts
@@ -14,7 +14,7 @@ import fs from "fs-extra";
 import { fileURLToPath } from 'url';
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { sleep, startExecutor, killByPorts } from "../utils/utils";
+import { startExecutor, killByPorts, pollUntil } from "../utils/utils";
 import { ChildProcess } from 'node:child_process';
 import { mcpHttpRequest, callMcpTool, initializeMcp } from './mcp-utils';
 
@@ -69,17 +69,19 @@ describe("MCP Neighbourhood Integration Tests", function () {
             MCP_PORT,
         );
 
-        await sleep(3000);
-
+        // Poll until agent generation succeeds (server ready)
         const adminClient = new Ad4mClient(`http://127.0.0.1:${API_PORT}`, ADMIN_CREDENTIAL, false);
-        await adminClient.agent.generate("test-passphrase");
+        await pollUntil(async () => {
+            await adminClient.agent.generate("test-passphrase");
+            return true;
+        }, { timeoutMs: 15000, label: "executor ready and agent generated" });
         console.log("Agent generated");
     });
 
     after(async () => {
         if (executorProcess) {
             executorProcess.kill('SIGTERM');
-            await sleep(1000);
+            await pollUntil(() => executorProcess!.killed, { timeoutMs: 5000, label: "executor exits after SIGTERM" }).catch(() => {});
             if (!executorProcess.killed) executorProcess.kill('SIGKILL');
         }
         killByPorts([API_PORT, HC_ADMIN_PORT, HC_APP_PORT, MCP_PORT]);

--- a/tests/js/tests/mcp-neighbourhood.test.ts
+++ b/tests/js/tests/mcp-neighbourhood.test.ts
@@ -84,10 +84,9 @@ describe("MCP Neighbourhood Integration Tests", function () {
             await pollUntil(() => executorProcess!.killed, { timeoutMs: 5000, label: "executor exits after SIGTERM" }).catch(() => {});
             if (!executorProcess.killed) executorProcess.kill('SIGKILL');
         }
-        killByPorts([API_PORT, HC_ADMIN_PORT, HC_APP_PORT, MCP_PORT]);
-        // Force-exit: open handles keep the Node event loop alive after
-        // all tests pass, causing CI SIGTERM (exit 143).
-        await pollUntil(() => false, { timeoutMs: 500 }).catch(() => {});
+        // Exit before killByPorts: lsof includes the test process's own
+        // client connections, so killByPorts would SIGTERM mocha itself
+        // (exit 143). cleanup.js between test files handles residual ports.
         process.exit(0);
     });
 

--- a/tests/js/tests/model/model-query.test.ts
+++ b/tests/js/tests/model/model-query.test.ts
@@ -45,7 +45,7 @@ import {
 } from "@coasys/ad4m";
 import { startAgent, waitUntil } from "../../helpers/index.js";
 import { getSharedAgent } from "./hooks.js";
-import { wipePerspective, sleep } from "../../utils/utils.js";
+import { wipePerspective } from "../../utils/utils.js";
 import { TestComment, TestPost, TestTag, TestReaction, TestChannel } from "./models.js";
 
 describe("Ad4mModel — Query API", function () {

--- a/tests/js/tests/multi-user-connect.test.ts
+++ b/tests/js/tests/multi-user-connect.test.ts
@@ -5,7 +5,7 @@ import fs from "fs-extra";
 import { fileURLToPath } from 'url';
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { sleep, baseUrl, startExecutor, quitExecutor } from "../utils/utils";
+import { baseUrl, startExecutor, quitExecutor } from "../utils/utils";
 import { getFreePorts, registerPorts, deregisterPorts } from "../helpers/ports.js";
 import { ChildProcess } from 'node:child_process';
 import fetch from 'node-fetch'

--- a/tests/js/tests/multi-user-simple.test.ts
+++ b/tests/js/tests/multi-user-simple.test.ts
@@ -1998,28 +1998,45 @@ describe("Multi-User Simple integration tests", () => {
             // All other users join the neighbourhood
             console.log("Node 1 User 2 joining...");
             await node1User2Client!.neighbourhood.joinFromUrl(neighbourhoodUrl);
+            await sleep(2000); // K2 space initialization after DNA install
 
             console.log("Node 2 User 1 joining...");
             await node2User1Client!.neighbourhood.joinFromUrl(neighbourhoodUrl);
+            await sleep(2000); // K2 space initialization after DNA install
 
             console.log("Node 2 User 2 joining...");
             await node2User2Client!.neighbourhood.joinFromUrl(neighbourhoodUrl);
+            await sleep(2000); // K2 space initialization after DNA install
 
-            // Re-exchange agent infos with retry to handle K2 space initialization delays (Holochain 0.7.0)
-            console.log("Re-exchanging agent infos with retry for K2 space readiness...");
-            await pollUntil(async () => {
+            // Re-exchange agent infos with retry to handle K2 space initialization
+            // delays (Holochain 0.7.0). After users join and link language installs,
+            // new DNA/K2 spaces get created. Repeated exchanges (not breaking on
+            // first success) push additional K2 agent info that the DHT needs to
+            // gossip peer keys across nodes. The inter-attempt sleep also serves as
+            // propagation time — there is no observable "K2 ready" state to poll for.
+            console.log("Re-exchanging agent infos for K2 space readiness...");
+            for (let attempt = 1; attempt <= 5; attempt++) {
                 try {
+                    console.log(`Agent info exchange attempt ${attempt}/5`);
                     const node1AgentInfos = await adminAd4mClient!.runtime.hcAgentInfos();
                     const node2AgentInfos = await node2AdminClient!.runtime.hcAgentInfos();
                     await adminAd4mClient!.runtime.hcAddAgentInfos(node2AgentInfos);
                     await node2AdminClient!.runtime.hcAddAgentInfos(node1AgentInfos);
-                    console.log("✅ Agent info exchange successful");
-                    return true;
+                    console.log(`✅ Agent info exchange attempt ${attempt} successful`);
                 } catch (error) {
-                    console.log("⚠️ Agent info exchange failed:", error);
-                    return false;
+                    console.log(`⚠️ Agent info exchange attempt ${attempt} failed:`, error);
                 }
-            }, { timeoutMs: 30000, intervalMs: 3000, label: "K2 agent info exchange" });
+                if (attempt < 5) {
+                    await sleep(3000);
+                }
+            }
+
+            // DHT gossip propagation: the K2 network needs time to distribute
+            // agent keys and owners lists across nodes after the exchanges above.
+            // No observable state exists to poll — otherAgents() IS that poll,
+            // and it needs this preceding propagation window.
+            console.log("Waiting for neighbourhood sync and owners list updates...");
+            await sleep(15000);
 
             // Get neighbourhood proxies for each user
             const node1User1Perspectives = await node1User1Client!.perspective.all();

--- a/tests/js/tests/multi-user-simple.test.ts
+++ b/tests/js/tests/multi-user-simple.test.ts
@@ -4,7 +4,7 @@ import fs from "fs-extra";
 import { fileURLToPath } from 'url';
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { baseUrl, sleep, startExecutor, runHcLocalServices, gracefulShutdown } from "../utils/utils";
+import { baseUrl, pollUntil, startExecutor, runHcLocalServices, gracefulShutdown, sleep } from "../utils/utils";
 import { getFreePorts, registerPorts, deregisterPorts } from "../helpers/ports.js";
 import { ChildProcess } from 'node:child_process';
 import { LinkQuery } from "@coasys/ad4m";
@@ -157,8 +157,12 @@ describe("Multi-User Simple integration tests", () => {
             // User 1 creates a perspective
             await client1.perspective.add("User 1 Perspective");
 
-            // Wait a moment for last_seen to be updated
-            await sleep(1000);
+            // Poll until user stats reflect the new perspective
+            await pollUntil(async () => {
+                const u = await adminAd4mClient!.runtime.listUsers();
+                const user = u.find((x: any) => x.email === "stats1@example.com");
+                return user && user.perspectiveCount === 1;
+            }, { timeoutMs: 5000, intervalMs: 200, label: "user perspectiveCount updated" });
 
             // List users
             const users = await adminAd4mClient!.runtime.listUsers();
@@ -221,8 +225,12 @@ describe("Multi-User Simple integration tests", () => {
 
             console.log("========================HERE 2================================");
 
-            // Wait for middleware to process (async task needs time)
-            await sleep(2000);
+            // Wait for last_seen to be updated by middleware
+            await pollUntil(async () => {
+                const u = await adminAd4mClient!.runtime.listUsers();
+                const found = u.find((x: any) => x.email === "lastseen@example.com");
+                return found && found.lastSeen !== undefined;
+            }, { timeoutMs: 5000, intervalMs: 200, label: "last_seen timestamp updated" });
 
             // List users again
             users = await adminAd4mClient!.runtime.listUsers();
@@ -816,16 +824,19 @@ describe("Multi-User Simple integration tests", () => {
             console.log("User 1 DID:", user1Agent.did);
             console.log("User 2 DID:", user2Agent.did);
 
-            // Wait a moment for the agents to be fully published
-            await new Promise(resolve => setTimeout(resolve, 1000));
+            // Poll until agents are published and retrievable by DID
+            await pollUntil(async () => {
+                const r1 = await adminAd4mClient!.agent.byDID(user1Agent.did);
+                const r2 = await adminAd4mClient!.agent.byDID(user2Agent.did);
+                return r1 !== null && r2 !== null;
+            }, { timeoutMs: 10000, label: "agents published and retrievable by DID" });
 
-            // Try to retrieve the users from the agent language by their DIDs
-            // This should work if they were properly published to the agent language
+            // Retrieve the users from the agent language by their DIDs
             try {
                 console.log("Attempting to retrieve user 1 with DID:", user1Agent.did);
                 const retrievedUser1 = await adminAd4mClient!.agent.byDID(user1Agent.did);
                 console.log("Retrieved user 1:", retrievedUser1);
-                
+
                 console.log("Attempting to retrieve user 2 with DID:", user2Agent.did);
                 const retrievedUser2 = await adminAd4mClient!.agent.byDID(user2Agent.did);
                 console.log("Retrieved user 2:", retrievedUser2);
@@ -911,8 +922,18 @@ describe("Multi-User Simple integration tests", () => {
             link2.proof = new ExpressionProof("sig2", "key2")
             await client2.agent.updatePublicPerspective(new Perspective([link2]));
 
-            // Wait for the updates to be published
-            await new Promise(resolve => setTimeout(resolve, 1000));
+            // Poll until the updated perspectives are visible via agent language
+            await pollUntil(async () => {
+                const r1 = await adminAd4mClient!.agent.byDID(user1Agent.did);
+                const r2 = await adminAd4mClient!.agent.byDID(user2Agent.did);
+                const has1 = r1?.perspective?.links?.some((link: any) =>
+                    link.data.source === "user1" && link.data.target === "profile1"
+                );
+                const has2 = r2?.perspective?.links?.some((link: any) =>
+                    link.data.source === "user2" && link.data.target === "profile2"
+                );
+                return !!has1 && !!has2;
+            }, { timeoutMs: 10000, label: "public perspectives updated in agent language" });
 
             // Retrieve the updated agents from the agent language
             try {
@@ -926,7 +947,7 @@ describe("Multi-User Simple integration tests", () => {
                 // Check that the public perspectives were updated
                 if (retrievedUser1?.perspective) {
                     expect(retrievedUser1.perspective.links).to.have.length.greaterThan(0);
-                    const hasUser1Link = retrievedUser1.perspective.links.some(link => 
+                    const hasUser1Link = retrievedUser1.perspective.links.some(link =>
                         link.data.source === "user1" && link.data.target === "profile1"
                     );
                     expect(hasUser1Link).to.be.true;
@@ -1078,23 +1099,23 @@ describe("Multi-User Simple integration tests", () => {
             );
             console.log("User 1 published neighbourhood:", neighbourhoodUrl);
 
-            // Wait for neighbourhood to be fully set up
-            await new Promise(resolve => setTimeout(resolve, 1000));
-
             // User 2 joins the same neighbourhood
             const joinResult = await client2.neighbourhood.joinFromUrl(neighbourhoodUrl);
             console.log("User 2 joined neighbourhood:", joinResult);
-            //console.log("User 2 joined neighbourhood uuid:", joinResult.uuid);
 
-            // Wait for neighbourhood sync
-            await new Promise(resolve => setTimeout(resolve, 2000));
+            // Poll until both users see the shared perspective
+            let user1SharedPerspective: any;
+            let user2SharedPerspective: any;
+            await pollUntil(async () => {
+                const u1p = await client1.perspective.all();
+                const u2p = await client2.perspective.all();
+                user1SharedPerspective = u1p.find(p => p.sharedUrl === neighbourhoodUrl);
+                user2SharedPerspective = u2p.find(p => p.sharedUrl === neighbourhoodUrl);
+                return !!user1SharedPerspective && !!user2SharedPerspective;
+            }, { timeoutMs: 15000, label: "both users see shared perspective" });
 
-            // Verify both users can see the shared perspective
             const user1Perspectives = await client1.perspective.all();
             const user2Perspectives = await client2.perspective.all();
-
-            const user1SharedPerspective = user1Perspectives.find(p => p.sharedUrl === neighbourhoodUrl);
-            const user2SharedPerspective = user2Perspectives.find(p => p.sharedUrl === neighbourhoodUrl);
 
             console.log("User 1 perspectives:", user1Perspectives);
             console.log("User 2 perspectives:", user2Perspectives);
@@ -1108,21 +1129,28 @@ describe("Multi-User Simple integration tests", () => {
             const link2 = new Link({source: "test://user2", target: "test://data2", predicate: "test://added"});
             await client2.perspective.addLink(user2SharedPerspective!.uuid, link2);
 
-            // Wait for sync
-            await new Promise(resolve => setTimeout(resolve, 1000));
+            // Poll until both users see each other's links
+            await pollUntil(async () => {
+                const u1Links = await client1.perspective.queryLinks(user1SharedPerspective!.uuid, new LinkQuery({}));
+                const u2Links = await client2.perspective.queryLinks(user2SharedPerspective!.uuid, new LinkQuery({}));
+                const u1SeesU2 = u1Links.some(l =>
+                    l.data.source === "test://user2" && l.data.target === "test://data2"
+                );
+                const u2SeesU1 = u2Links.some(l =>
+                    l.data.source === "test://user1" && l.data.target === "test://data1"
+                );
+                return u1SeesU2 && u2SeesU1;
+            }, { timeoutMs: 15000, label: "both users see each other's links" });
 
-            // User 1 should see User 2's link
             const user1Links = await client1.perspective.queryLinks(user1SharedPerspective!.uuid, new LinkQuery({}));
             const user2Links = await client2.perspective.queryLinks(user2SharedPerspective!.uuid, new LinkQuery({}));
 
             console.log("User 1 sees links:", user1Links.length);
             console.log("User 2 sees links:", user2Links.length);
 
-            // Both users should see both links
             expect(user1Links.length).to.be.greaterThan(1);
             expect(user2Links.length).to.be.greaterThan(1);
 
-            // Verify specific links exist
             const user1SeesUser2Link = user1Links.some(l =>
                 l.data.source === "test://user2" && l.data.target === "test://data2"
             );
@@ -1323,8 +1351,11 @@ describe("Multi-User Simple integration tests", () => {
             await perspective1.ensureSDNASubjectClass(User1Model);
             console.log("User 1 model ensured");
 
-            // Wait for SDNA to be processed
-            await new Promise(resolve => setTimeout(resolve, 1000));
+            // Poll until SDNA subject class is available
+            await pollUntil(async () => {
+                const classes = await perspective1.subjectClasses();
+                return classes.some((c: any) => c === "User1Model" || c.name === "User1Model");
+            }, { timeoutMs: 10000, label: "User1Model SDNA class available" });
 
             let user1Model = new User1Model(perspective1);
             user1Model.user1Property = "User1 created this";
@@ -1367,8 +1398,11 @@ describe("Multi-User Simple integration tests", () => {
             console.log("User 2 model ensured");
 
 
-            // Wait for SDNA to be processed
-            await new Promise(resolve => setTimeout(resolve, 1000));
+            // Poll until User2Model SDNA class is available
+            await pollUntil(async () => {
+                const classes = await user2SharedPerspective!.subjectClasses();
+                return classes.some((c: any) => c === "User2Model" || c.name === "User2Model");
+            }, { timeoutMs: 10000, label: "User2Model SDNA class available" });
 
             let user2Model = new User2Model(user2SharedPerspective!);
             user2Model.user2Property = "User2 created this";
@@ -1378,11 +1412,14 @@ describe("Multi-User Simple integration tests", () => {
 
             console.log("Testing prolog pool isolation...");
 
-            
+            // Poll until both users see both SDNA classes (shared neighbourhood sync)
+            await pollUntil(async () => {
+                const c1 = await perspective1.subjectClasses();
+                return c1.length >= 2;
+            }, { timeoutMs: 15000, label: "User 1 sees both SDNA classes" });
+
             let classesSeenByUser1 = await perspective1.subjectClasses()
             console.log("User 1 sees classes:", classesSeenByUser1);
-            // In a shared neighbourhood, SDNA links propagate, so both users
-            // eventually see both classes once sync completes.
             expect(classesSeenByUser1.length).to.equal(2);
 
             let classesSeenByUser2 = await user2SharedPerspective!.subjectClasses()
@@ -1434,16 +1471,22 @@ describe("Multi-User Simple integration tests", () => {
 
             console.log("User 2 joined neighbourhood");
 
-            // Wait a bit for neighbourhood to be fully set up
-            await new Promise(resolve => setTimeout(resolve, 1000));
+            // Poll until both perspectives have their link language installed
+            await pollUntil(async () => {
+                const u1p = await client1.perspective.all();
+                const u2p = await client2.perspective.all();
+                const u1state = u1p.find(p => p.uuid === perspective1.uuid)?.state;
+                const u2state = u2p.find(p => p.sharedUrl === neighbourhoodUrl)?.state;
+                const ready = ["LINK_LANGUAGE_INSTALLED_BUT_NOT_SYNCED", "SYNCED"];
+                return ready.includes(u1state as string) && ready.includes(u2state as string);
+            }, { timeoutMs: 30000, label: "neighbourhood link language installed for both users" });
 
-            // Get neighbourhood proxy for User 2
             const user2Neighbourhood = await user2SharedPerspective!.getNeighbourhoodProxy();
             expect(user2Neighbourhood).to.not.be.null;
 
             // Set up signal listener for User 2
             const user2ReceivedSignals: any[] = [];
-            const user2SignalSubscription = user2Neighbourhood!.addSignalHandler((signal) => {
+            const user2SignalSubscription = user2Neighbourhood!.addSignalHandler((signal: any) => {
                 //console.log("User 2 received signal:", signal);
                 user2ReceivedSignals.push(signal);
             });
@@ -1463,9 +1506,6 @@ describe("Multi-User Simple integration tests", () => {
 
             console.log("User 1 signal listener set up");
 
-            // Wait a bit to ensure subscriptions are active
-            await new Promise(resolve => setTimeout(resolve, 500));
-
             // User 1 sends a signal to User 2
             const testSignalPayload = new PerspectiveUnsignedInput([
                 {
@@ -1483,12 +1523,10 @@ describe("Multi-User Simple integration tests", () => {
 
             console.log("Signal sent, waiting for delivery...");
 
-            // Wait for signal to be received (with timeout)
-            const maxWaitTime = 5000; // 5 seconds
-            let startTime = Date.now();
-            while (user2ReceivedSignals.length === 0 && (Date.now() - startTime) < maxWaitTime) {
-                await new Promise(resolve => setTimeout(resolve, 100));
-            }
+            // Poll until User 2 receives the signal
+            await pollUntil(() => user2ReceivedSignals.length > 0, {
+                timeoutMs: 5000, label: "User 2 receives signal from User 1"
+            });
 
             // Verify User 2 received the signal
             expect(user2ReceivedSignals.length).to.be.greaterThan(0, "User 2 should have received at least one signal");
@@ -1522,13 +1560,11 @@ describe("Multi-User Simple integration tests", () => {
                 reverseSignalPayload
             );
 
-            // Wait for signal to be received
-            startTime = Date.now();
-            while (user1ReceivedSignals.length === 0 && (Date.now() - startTime) < maxWaitTime) {
-                await new Promise(resolve => setTimeout(resolve, 100));
-            }
+            // Poll until User 1 receives the reverse signal
+            await pollUntil(() => user1ReceivedSignals.length > 0, {
+                timeoutMs: 5000, label: "User 1 receives signal from User 2"
+            });
 
-            // Verify User 1 received the signal
             expect(user1ReceivedSignals.length).to.be.greaterThan(0, "User 1 should have received at least one signal");
 
             const user1ReceivedSignal = user1ReceivedSignals[0];
@@ -1597,10 +1633,7 @@ describe("Multi-User Simple integration tests", () => {
 
             console.log("User 1 published neighbourhood:", neighbourhoodUrl);
 
-            // Wait for neighbourhood to be published
-            await new Promise(resolve => setTimeout(resolve, 2000));
-
-            // SECOND managed user joins the neighbourhood
+            // User 2 joins the neighbourhood
             console.log("\nUser 2 (second managed user) joining neighbourhood...");
             const joinResult = await client2.neighbourhood.joinFromUrl(neighbourhoodUrl);
             console.log("User 2 join result:", joinResult.uuid);
@@ -1611,13 +1644,20 @@ describe("Multi-User Simple integration tests", () => {
 
             console.log("User 2 joined neighbourhood");
 
-            // Wait for neighbourhood to sync
-            await new Promise(resolve => setTimeout(resolve, 3000));
+            // Poll until both perspectives have their link language installed
+            await pollUntil(async () => {
+                const u1p = await client1.perspective.all();
+                const u2p = await client2.perspective.all();
+                const u1state = u1p.find(p => p.uuid === perspective1.uuid)?.state;
+                const u2state = u2p.find(p => p.sharedUrl === neighbourhoodUrl)?.state;
+                const ready = ["LINK_LANGUAGE_INSTALLED_BUT_NOT_SYNCED", "SYNCED"];
+                return ready.includes(u1state as string) && ready.includes(u2state as string);
+            }, { timeoutMs: 30000, label: "neighbourhood link language installed for both users" });
 
             // Get neighbourhood proxies
             const user1Neighbourhood = await perspective1.getNeighbourhoodProxy();
             const user2Neighbourhood = await user2SharedPerspective!.getNeighbourhoodProxy();
-            
+
             expect(user1Neighbourhood).to.not.be.null;
             expect(user2Neighbourhood).to.not.be.null;
 
@@ -1638,9 +1678,6 @@ describe("Multi-User Simple integration tests", () => {
             });
 
             console.log("Signal handlers set up for both users");
-
-            // Wait for subscriptions to be active
-            await new Promise(resolve => setTimeout(resolve, 1000));
 
             // Check if users can see each other in otherAgents
             console.log("\n=== Checking otherAgents() ===");
@@ -1663,8 +1700,10 @@ describe("Multi-User Simple integration tests", () => {
             await user1Neighbourhood!.sendSignalU(user2Did, signal1to2);
             console.log("Signal sent from User 1 to User 2");
 
-            // Wait for signal delivery
-            await new Promise(resolve => setTimeout(resolve, 2000));
+            // Poll until User 2 receives the signal
+            await pollUntil(() => user2ReceivedSignals.length > 0, {
+                timeoutMs: 5000, label: "User 2 receives signal from User 1 (Flux scenario)"
+            });
 
             // User 2 sends a signal to User 1
             console.log("\n=== User 2 sending signal to User 1 ===");
@@ -1679,8 +1718,10 @@ describe("Multi-User Simple integration tests", () => {
             await user2Neighbourhood!.sendSignalU(user1Did, signal2to1);
             console.log("Signal sent from User 2 to User 1");
 
-            // Wait for signal delivery
-            await new Promise(resolve => setTimeout(resolve, 2000));
+            // Poll until User 1 receives the signal
+            await pollUntil(() => user1ReceivedSignals.length > 0, {
+                timeoutMs: 5000, label: "User 1 receives signal from User 2 (Flux scenario)"
+            });
 
             // Verify signals were received
             console.log("\n=== Verification ===");
@@ -1740,7 +1781,6 @@ describe("Multi-User Simple integration tests", () => {
                 new Perspective([])
             );
             console.log("Main agent created neighbourhood:", neighbourhoodUrl);
-            await new Promise(resolve => setTimeout(resolve, 2000));
 
             // Managed user joins the neighbourhood
             await userClient.neighbourhood.joinFromUrl(neighbourhoodUrl);
@@ -1748,9 +1788,17 @@ describe("Multi-User Simple integration tests", () => {
             const userSharedPerspective = userPerspectives.find(p => p.sharedUrl === neighbourhoodUrl);
             expect(userSharedPerspective).to.not.be.null;
             console.log("Managed user joined neighbourhood");
-            await new Promise(resolve => setTimeout(resolve, 2000));
 
-            // Get neighbourhood proxies for both sides
+            // Poll until both perspectives have their link language installed
+            await pollUntil(async () => {
+                const mainPersp = await adminAd4mClient!.perspective.all();
+                const userPersp = await userClient.perspective.all();
+                const mainState = mainPersp.find(p => p.uuid === mainPerspective.uuid)?.state;
+                const userState = userPersp.find(p => p.sharedUrl === neighbourhoodUrl)?.state;
+                const ready = ["LINK_LANGUAGE_INSTALLED_BUT_NOT_SYNCED", "SYNCED"];
+                return ready.includes(mainState as string) && ready.includes(userState as string);
+            }, { timeoutMs: 30000, label: "neighbourhood link language installed (main agent + managed user)" });
+
             const mainAgentNH = await mainPerspective.getNeighbourhoodProxy();
             const userNH = await userSharedPerspective!.getNeighbourhoodProxy();
             expect(mainAgentNH).to.not.be.null;
@@ -1760,16 +1808,14 @@ describe("Multi-User Simple integration tests", () => {
             const mainAgentReceivedSignals: any[] = [];
             const userReceivedSignals: any[] = [];
 
-            mainAgentNH!.addSignalHandler((signal) => {
+            mainAgentNH!.addSignalHandler((signal: any) => {
                 console.log("✉️ Main agent received signal:", JSON.stringify(signal));
                 mainAgentReceivedSignals.push(signal);
             });
-            userNH!.addSignalHandler((signal) => {
+            userNH!.addSignalHandler((signal: any) => {
                 console.log("✉️ Managed user received signal:", JSON.stringify(signal));
                 userReceivedSignals.push(signal);
             });
-
-            await new Promise(resolve => setTimeout(resolve, 1000));
 
             // --- Test 1: main agent sends signal to managed user ---
             console.log("\n--- Main agent sending signal to managed user ---");
@@ -1777,11 +1823,9 @@ describe("Multi-User Simple integration tests", () => {
                 new Link({ source: "test://signal", predicate: "test://main_to_user", target: mainAgentDid })
             ]));
 
-            const maxWait = 5000;
-            let start = Date.now();
-            while (userReceivedSignals.length === 0 && Date.now() - start < maxWait) {
-                await new Promise(r => setTimeout(r, 100));
-            }
+            await pollUntil(() => userReceivedSignals.length > 0, {
+                timeoutMs: 5000, label: "managed user receives signal from main agent"
+            });
             expect(userReceivedSignals.length).to.be.greaterThan(0, "Managed user should receive signal from main agent");
             expect(userReceivedSignals[0].data.links[0].data.predicate).to.equal("test://main_to_user");
             console.log("✅ Managed user received signal from main agent");
@@ -1792,10 +1836,9 @@ describe("Multi-User Simple integration tests", () => {
                 new Link({ source: "test://signal", predicate: "test://user_to_main", target: userDid })
             ]));
 
-            start = Date.now();
-            while (mainAgentReceivedSignals.length === 0 && Date.now() - start < maxWait) {
-                await new Promise(r => setTimeout(r, 100));
-            }
+            await pollUntil(() => mainAgentReceivedSignals.length > 0, {
+                timeoutMs: 5000, label: "main agent receives signal from managed user"
+            });
             expect(mainAgentReceivedSignals.length).to.be.greaterThan(0, "Main agent should receive signal from managed user");
             expect(mainAgentReceivedSignals[0].data.links[0].data.predicate).to.equal("test://user_to_main");
             console.log("✅ Main agent received signal from managed user");
@@ -1807,10 +1850,9 @@ describe("Multi-User Simple integration tests", () => {
                 new Link({ source: "test://broadcast", predicate: "test://user_broadcast", target: userDid })
             ]));
 
-            start = Date.now();
-            while (mainAgentReceivedSignals.length === mainAgentCountBefore && Date.now() - start < maxWait) {
-                await new Promise(r => setTimeout(r, 100));
-            }
+            await pollUntil(() => mainAgentReceivedSignals.length > mainAgentCountBefore, {
+                timeoutMs: 5000, label: "main agent receives broadcast from managed user"
+            });
             expect(mainAgentReceivedSignals.length).to.be.greaterThan(mainAgentCountBefore, "Main agent should receive broadcast from managed user");
             const broadcastSignal = mainAgentReceivedSignals[mainAgentReceivedSignals.length - 1];
             expect(broadcastSignal.data.links[0].data.predicate).to.equal("test://user_broadcast");
@@ -1956,39 +1998,28 @@ describe("Multi-User Simple integration tests", () => {
             // All other users join the neighbourhood
             console.log("Node 1 User 2 joining...");
             await node1User2Client!.neighbourhood.joinFromUrl(neighbourhoodUrl);
-            await sleep(2000); // Wait for join to complete
 
             console.log("Node 2 User 1 joining...");
             await node2User1Client!.neighbourhood.joinFromUrl(neighbourhoodUrl);
-            await sleep(2000); // Wait for join to complete
 
             console.log("Node 2 User 2 joining...");
             await node2User2Client!.neighbourhood.joinFromUrl(neighbourhoodUrl);
-            await sleep(2000); // Wait for join to complete
 
             // Re-exchange agent infos with retry to handle K2 space initialization delays (Holochain 0.7.0)
-            // After users join and link language is installed, new DNA/K2 spaces are created
-            // We need to retry agent info exchange to allow K2 spaces to become ready
             console.log("Re-exchanging agent infos with retry for K2 space readiness...");
-            for (let attempt = 1; attempt <= 5; attempt++) {
+            await pollUntil(async () => {
                 try {
-                    console.log(`Agent info exchange attempt ${attempt}/5`);
                     const node1AgentInfos = await adminAd4mClient!.runtime.hcAgentInfos();
                     const node2AgentInfos = await node2AdminClient!.runtime.hcAgentInfos();
                     await adminAd4mClient!.runtime.hcAddAgentInfos(node2AgentInfos);
                     await node2AdminClient!.runtime.hcAddAgentInfos(node1AgentInfos);
-                    console.log(`✅ Agent info exchange attempt ${attempt} successful`);
+                    console.log("✅ Agent info exchange successful");
+                    return true;
                 } catch (error) {
-                    console.log(`⚠️  Agent info exchange attempt ${attempt} failed:`, error);
+                    console.log("⚠️ Agent info exchange failed:", error);
+                    return false;
                 }
-                if (attempt < 5) {
-                    await sleep(3000); // Wait before retry
-                }
-            }
-
-            // Wait for neighbourhood to sync and owners lists to be updated
-            console.log("Waiting for neighbourhood sync and owners list updates...");
-            await sleep(15000);
+            }, { timeoutMs: 30000, intervalMs: 3000, label: "K2 agent info exchange" });
 
             // Get neighbourhood proxies for each user
             const node1User1Perspectives = await node1User1Client!.perspective.all();
@@ -2016,34 +2047,16 @@ describe("Multi-User Simple integration tests", () => {
             console.log("\nChecking 'others()' for each user:");
 
             // Helper function to poll until all expected DIDs are seen
-            const pollUntilAllSeen = async (proxy: any, expectedDids: string[], userLabel: string, maxAttempts = 50) => {
-                console.log(`Polling ${userLabel} for others...`);
-                console.log(`Expected DIDs:`, expectedDids);
-                for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-                    const others = await proxy.otherAgents();
-                    console.log(`${userLabel} sees others (attempt ${attempt}):`, others);
-
-                    const allFound = expectedDids.every(did => {
-                        console.log(`Checking if ${did} is in ${others}`);
-                        let result = others.includes(did);
-                        console.log(`Result: ${result}`);
-                        return result;
-                    });
-                    if (allFound) {
-                        console.log(`✅ ${userLabel} sees all expected users!`);
-                        return others;
-                    }
-
-                    if (attempt < maxAttempts) {
-                        console.log(`${userLabel} waiting for DHT gossip... (${attempt}/${maxAttempts})`);
-                        await sleep(2000);
-                    }
-                }
-
-                // Return the last result even if not complete
-                const finalOthers = await proxy.otherAgents();
-                console.log(`${userLabel} final result after ${maxAttempts} attempts:`, finalOthers);
-                return finalOthers;
+            const pollUntilAllSeen = async (proxy: any, expectedDids: string[], userLabel: string) => {
+                let others: string[] = [];
+                await pollUntil(async () => {
+                    others = await proxy.otherAgents();
+                    const allFound = expectedDids.every((did: string) => others.includes(did));
+                    if (!allFound) console.log(`${userLabel} waiting for DHT gossip... sees ${others.length}/${expectedDids.length} DIDs`);
+                    else console.log(`✅ ${userLabel} sees all expected users!`);
+                    return allFound;
+                }, { timeoutMs: 150000, intervalMs: 2000, label: `${userLabel} sees all expected DIDs` });
+                return others;
             };
 
             const node1User1Others = await pollUntilAllSeen(
@@ -2126,8 +2139,9 @@ describe("Multi-User Simple integration tests", () => {
                 node2User2ReceivedSignals.push(signal);
             });
 
-            await sleep(3000); // Let handlers initialize and subscriptions become active
-
+            // Subscription-init delay: signal handlers register asynchronously
+            // and the DHT needs time to propagate AgentPubKeys across peers.
+            await sleep(3000);
 
             // Node 2 User 1 sends a signal to Node 2 User 2 (both on same node - local routing)
             console.log(`\nNode 2 User 1 (${node2User1Did.substring(0, 20)}...) sending signal to Node 2 User 2 (${node2User2Did.substring(0, 20)}...)`);
@@ -2141,12 +2155,7 @@ describe("Multi-User Simple integration tests", () => {
 
             // Wait for signal delivery
             console.log("Waiting for signal delivery...");
-            const maxWaitTime = 20000;
-            let startTime = Date.now();
-            while (node2User2ReceivedSignals.length === 0 && (Date.now() - startTime) < maxWaitTime) {
-                await sleep(100);
-                console.log(".");
-            }
+            await pollUntil(() => node2User2ReceivedSignals.length > 0, { timeoutMs: 20000, intervalMs: 100, label: "node2 user2 receives signal" });
 
             console.log("Signal delivery complete");
 
@@ -2169,12 +2178,8 @@ describe("Multi-User Simple integration tests", () => {
             ]));
 
             // Wait for signal delivery
-            startTime = Date.now();
             console.log("Waiting for signal delivery...");
-            while (node2User1ReceivedSignals.length === 0 && (Date.now() - startTime) < maxWaitTime) {
-                await sleep(100);
-                console.log(".");
-            }
+            await pollUntil(() => node2User1ReceivedSignals.length > 0, { timeoutMs: 20000, intervalMs: 100, label: "node2 user1 receives signal" });
             console.log("Signal delivery complete");
 
             // Verify Node 2 User 1 received the signal
@@ -2194,8 +2199,6 @@ describe("Multi-User Simple integration tests", () => {
                 node1User1ReceivedSignals.push(signal);
             });
 
-            await sleep(1500);
-
             console.log(`\nNode 2 User 1 (${node2User1Did.substring(0, 20)}...) sending signal to Node 1 User 1 (${node1User1Did.substring(0, 20)}...)`);
             await node2User1Proxy!.sendSignalU(node1User1Did, new PerspectiveUnsignedInput([
                 {
@@ -2205,10 +2208,7 @@ describe("Multi-User Simple integration tests", () => {
                 }
             ]));
 
-            startTime = Date.now();
-            while (node1User1ReceivedSignals.length === 0 && (Date.now() - startTime) < maxWaitTime) {
-                await sleep(100);
-            }
+            await pollUntil(() => node1User1ReceivedSignals.length > 0, { timeoutMs: 20000, intervalMs: 100, label: "node1 user1 receives cross-node signal" });
 
             expect(node1User1ReceivedSignals.length).to.be.greaterThan(0, "Node 1 User 1 should have received signal");
             expect(node1User1ReceivedSignals[0].author).to.equal(node2User1Did);
@@ -2272,29 +2272,23 @@ describe("Multi-User Simple integration tests", () => {
             });
             console.log("Node 2 User 2 added link");
 
-            // Wait for background Holochain commits to complete before polling
-            await sleep(5000);
-
-            // Re-exchange agent infos before sync polling — K2 spaces created
-            // during link-language install may need fresh peer info
+            // Exchange agent infos before sync polling
             console.log("Re-exchanging agent infos before link sync polling...");
-            for (let attempt = 1; attempt <= 3; attempt++) {
+            await pollUntil(async () => {
                 try {
                     const n1Infos = await adminAd4mClient!.runtime.hcAgentInfos();
                     const n2Infos = await node2AdminClient!.runtime.hcAgentInfos();
                     await adminAd4mClient!.runtime.hcAddAgentInfos(n2Infos);
                     await node2AdminClient!.runtime.hcAddAgentInfos(n1Infos);
+                    return true;
                 } catch (e) {
-                    console.log(`  Agent info exchange attempt ${attempt} failed:`, e);
+                    console.log("  Agent info exchange failed:", e);
+                    return false;
                 }
-                if (attempt < 3) await sleep(2000);
-            }
+            }, { timeoutMs: 10000, intervalMs: 2000, label: "pre-sync agent info exchange" });
 
             // Wait for cross-node Holochain gossip synchronization with retry
             console.log("\nWaiting for cross-node sync (polling until all users see >= 5 links)...");
-            const syncTimeout = 240000; // 4 minutes max — WS transport adds slight overhead to gossip timing
-            const syncStart = Date.now();
-            let synced = false;
             let pollCount = 0;
 
             let node1User1Links: any[] = [];
@@ -2302,8 +2296,7 @@ describe("Multi-User Simple integration tests", () => {
             let node2User1Links: any[] = [];
             let node2User2Links: any[] = [];
 
-            while (!synced && Date.now() - syncStart < syncTimeout) {
-                await sleep(5000);
+            await pollUntil(async () => {
                 pollCount++;
 
                 // Re-exchange agent infos every 15s to help K2 peer discovery
@@ -2333,8 +2326,8 @@ describe("Multi-User Simple integration tests", () => {
                 const counts = [node1User1Links.length, node1User2Links.length, node2User1Links.length, node2User2Links.length];
                 console.log(`  Sync check: link counts = [${counts.join(', ')}] (need >= 5 each)`);
 
-                synced = counts.every(c => c >= 5);
-            }
+                return counts.every(c => c >= 5);
+            }, { timeoutMs: 240000, intervalMs: 5000, label: "cross-node link sync (all users >= 5 links)" });
 
             console.log(`\nQuerying links from each user's perspective...`);
             console.log(`Node 1 User 1 sees ${node1User1Links.length} links`);
@@ -2435,25 +2428,19 @@ describe("Multi-User Simple integration tests", () => {
             });
             client2.perspective.subscribePerspectiveAdded();
 
-            // Wait for subscriptions to be active
-            await sleep(1000);
-            console.log("✅ Subscriptions active");
-
             // User 1 creates a perspective
             console.log("\nUser 1 creating perspective...");
             const user1Perspective = await client1.perspective.add("User 1 Only Perspective");
             console.log(`User 1 created perspective: ${user1Perspective.uuid}`);
 
-            // Wait for events to propagate
-            await sleep(2000);
+            await pollUntil(() => user1Events.length >= 1, { timeoutMs: 5000, intervalMs: 200, label: "user1 perspectiveAdded event" });
 
             // User 2 creates a perspective
             console.log("\nUser 2 creating perspective...");
             const user2Perspective = await client2.perspective.add("User 2 Only Perspective");
             console.log(`User 2 created perspective: ${user2Perspective.uuid}`);
 
-            // Wait for events to propagate
-            await sleep(2000);
+            await pollUntil(() => user2Events.length >= 1, { timeoutMs: 5000, intervalMs: 200, label: "user2 perspectiveAdded event" });
 
             console.log(`\nUser 1 received ${user1Events.length} events`);
             console.log(`User 2 received ${user2Events.length} events`);
@@ -2503,20 +2490,17 @@ describe("Multi-User Simple integration tests", () => {
             });
             client2.perspective.subscribePerspectiveUpdated();
 
-            await sleep(1000);
-            console.log("✅ Subscriptions active");
-
             // User 1 updates their perspective metadata (name)
             console.log("\nUser 1 updating their perspective name...");
             await client1.perspective.update(user1Perspective.uuid, "User 1 Updated Name");
 
-            await sleep(2000);
+            await pollUntil(() => user1UpdateEvents.length >= 1, { timeoutMs: 5000, intervalMs: 200, label: "user1 perspectiveUpdated event" });
 
             // User 2 updates their perspective metadata (name)
             console.log("\nUser 2 updating their perspective name...");
             await client2.perspective.update(user2Perspective.uuid, "User 2 Updated Name");
 
-            await sleep(2000);
+            await pollUntil(() => user2UpdateEvents.length >= 1, { timeoutMs: 5000, intervalMs: 200, label: "user2 perspectiveUpdated event" });
 
             console.log(`\nUser 1 received ${user1UpdateEvents.length} update events`);
             console.log(`User 2 received ${user2UpdateEvents.length} update events`);
@@ -2567,9 +2551,6 @@ describe("Multi-User Simple integration tests", () => {
                 user2LinkEvents.push(link);
             }]);
 
-            await sleep(1000);
-            console.log("✅ Subscriptions active");
-
             // User 1 adds a link to their perspective
             console.log("\nUser 1 adding link to their perspective...");
             await client1.perspective.addLink(user1Perspective.uuid, {
@@ -2578,7 +2559,7 @@ describe("Multi-User Simple integration tests", () => {
                 predicate: "test://has"
             });
 
-            await sleep(2000);
+            await pollUntil(() => user1LinkEvents.length >= 1, { timeoutMs: 5000, intervalMs: 200, label: "user1 linkAdded event" });
 
             // User 2 adds a link to their perspective
             console.log("\nUser 2 adding link to their perspective...");
@@ -2588,7 +2569,7 @@ describe("Multi-User Simple integration tests", () => {
                 predicate: "test://has"
             });
 
-            await sleep(2000);
+            await pollUntil(() => user2LinkEvents.length >= 1, { timeoutMs: 5000, intervalMs: 200, label: "user2 linkAdded event" });
 
             console.log(`\nUser 1 received ${user1LinkEvents.length} link events`);
             console.log(`User 2 received ${user2LinkEvents.length} link events`);
@@ -2656,20 +2637,17 @@ describe("Multi-User Simple integration tests", () => {
             });
             client2.perspective.subscribePerspectiveRemoved();
 
-            await sleep(1000);
-            console.log("✅ Subscriptions active");
-
             // User 1 removes their perspective
             console.log("\nUser 1 removing their perspective...");
             await client1.perspective.remove(user1Perspective.uuid);
 
-            await sleep(2000);
+            await pollUntil(() => user1RemoveEvents.length >= 1, { timeoutMs: 5000, intervalMs: 200, label: "user1 perspectiveRemoved event" });
 
             // User 2 removes their perspective
             console.log("\nUser 2 removing their perspective...");
             await client2.perspective.remove(user2Perspective.uuid);
 
-            await sleep(2000);
+            await pollUntil(() => user2RemoveEvents.length >= 1, { timeoutMs: 5000, intervalMs: 200, label: "user2 perspectiveRemoved event" });
 
             console.log(`\nUser 1 received ${user1RemoveEvents.length} removal events`);
             console.log(`User 2 received ${user2RemoveEvents.length} removal events`);
@@ -2731,7 +2709,10 @@ describe("Multi-User Simple integration tests", () => {
             const notif1Id = await client1.runtime.requestInstallNotification(user1Notification);
             const notif2Id = await client2.runtime.requestInstallNotification(user2Notification);
 
-            await sleep(500);
+            await pollUntil(async () => {
+                const notifs = await client1.runtime.notifications();
+                return notifs.some(n => n.id === notif1Id);
+            }, { timeoutMs: 5000, intervalMs: 100, label: "user1 notification installed" });
 
             // User 1 retrieves notifications - should only see their own and it should be auto-granted
             const user1Notifications = await client1.runtime.notifications();
@@ -2809,7 +2790,11 @@ describe("Multi-User Simple integration tests", () => {
             const notif1Id = await client1.runtime.requestInstallNotification(user1Notification);
             const notif2Id = await client2.runtime.requestInstallNotification(user2Notification);
 
-            await sleep(500);
+            await pollUntil(async () => {
+                const n1 = await client1.runtime.notifications();
+                const n2 = await client2.runtime.notifications();
+                return n1.some(n => n.id === notif1Id) && n2.some(n => n.id === notif2Id);
+            }, { timeoutMs: 5000, intervalMs: 100, label: "both user notifications installed" });
 
             // Verify that both notifications contain the $agentDid variable in their triggers
             // and are auto-granted for managed users
@@ -2862,7 +2847,10 @@ describe("Multi-User Simple integration tests", () => {
 
             // Install notification - managed users get auto-granted
             const notificationId = await client1.runtime.requestInstallNotification(notification);
-            await sleep(500);
+            await pollUntil(async () => {
+                const notifs = await client1.runtime.notifications();
+                return notifs.some(n => n.id === notificationId);
+            }, { timeoutMs: 5000, intervalMs: 100, label: "notification installed for user1" });
 
             // User 1 can see their notification and it should be auto-granted
             const user1Notifs = await client1.runtime.notifications();
@@ -2901,7 +2889,10 @@ describe("Multi-User Simple integration tests", () => {
             };
 
             const notificationId = await managedClient.runtime.requestInstallNotification(notification);
-            await sleep(500);
+            await pollUntil(async () => {
+                const notifs = await managedClient.runtime.notifications();
+                return notifs.some(n => n.id === notificationId);
+            }, { timeoutMs: 5000, intervalMs: 100, label: "managed user notification installed" });
 
             // Verify the notification is auto-granted
             const notifs = await managedClient.runtime.notifications();
@@ -3032,26 +3023,6 @@ describe("Multi-User Simple integration tests", () => {
             // The remote agent is already in before the managed user even exists.
             console.log("Remote main agent joining neighbourhood...");
             await node3MainClient!.neighbourhood.joinFromUrl(neighbourhoodUrl);
-            await sleep(3000);
-
-            // Exchange agent infos so the two nodes can find each other
-            console.log("Exchanging agent infos after remote join...");
-            for (let attempt = 1; attempt <= 5; attempt++) {
-                try {
-                    const localInfos = await adminAd4mClient!.runtime.hcAgentInfos();
-                    const remoteInfos = await node3MainClient!.runtime.hcAgentInfos();
-                    await adminAd4mClient!.runtime.hcAddAgentInfos(remoteInfos);
-                    await node3MainClient!.runtime.hcAddAgentInfos(localInfos);
-                    console.log(`Agent info exchange attempt ${attempt}/5 successful`);
-                } catch (error) {
-                    console.log(`Agent info exchange attempt ${attempt} failed:`, error);
-                }
-                if (attempt < 5) await sleep(3000);
-            }
-
-            // Wait for the two main agents to fully sync
-            console.log("Waiting for main agents to sync...");
-            await sleep(15000);
 
             // Verify the two main agents see each other before proceeding
             const localMainPerspectives = await adminAd4mClient!.perspective.all();
@@ -3064,24 +3035,31 @@ describe("Multi-User Simple integration tests", () => {
             expect(remoteNH).to.not.be.undefined;
             const remoteProxy = await remoteNH!.getNeighbourhoodProxy();
 
-            console.log("Verifying main agents see each other...");
-            const pollUntilSeen = async (proxy: any, expectedDids: string[], label: string, maxAttempts = 50) => {
-                for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-                    const others = await proxy.otherAgents();
-                    const allFound = expectedDids.every((did: string) => others.includes(did));
-                    if (allFound) {
-                        console.log(`${label} sees all expected agents`);
-                        return others;
-                    }
-                    if (attempt < maxAttempts) await sleep(2000);
-                }
-                const finalOthers = await proxy.otherAgents();
-                console.log(`${label} final others after polling:`, finalOthers);
-                return finalOthers;
+            // Exchange agent infos and poll until the two main agents discover each other
+            console.log("Exchanging agent infos and waiting for main agents to sync...");
+            const pollUntilSeen = async (proxy: any, expectedDids: string[], label: string, timeoutMs = 100000) => {
+                let others: string[] = [];
+                await pollUntil(async () => {
+                    others = await proxy.otherAgents();
+                    return expectedDids.every((did: string) => others.includes(did));
+                }, { timeoutMs, intervalMs: 2000, label: `${label} sees expected agents` });
+                console.log(`${label} sees all expected agents`);
+                return others;
             };
 
-            await pollUntilSeen(localMainProxy!, [remoteMainAgentDid], "Local Main Agent");
-            await pollUntilSeen(remoteProxy!, [localMainAgentDid], "Remote Main Agent");
+            await pollUntil(async () => {
+                try {
+                    const localInfos = await adminAd4mClient!.runtime.hcAgentInfos();
+                    const remoteInfos = await node3MainClient!.runtime.hcAgentInfos();
+                    await adminAd4mClient!.runtime.hcAddAgentInfos(remoteInfos);
+                    await node3MainClient!.runtime.hcAddAgentInfos(localInfos);
+                } catch (error) {
+                    console.log("Agent info exchange failed:", error);
+                }
+                const localOthers = await localMainProxy!.otherAgents();
+                const remoteOthers = await remoteProxy!.otherAgents();
+                return localOthers.includes(remoteMainAgentDid) && remoteOthers.includes(localMainAgentDid);
+            }, { timeoutMs: 120000, intervalMs: 3000, label: "main agents see each other after info exchange" });
             console.log("Main agents synced and see each other.");
 
             // Step 3: NOW create the managed user (simulating late signup in Flux)
@@ -3100,27 +3078,6 @@ describe("Multi-User Simple integration tests", () => {
             // Step 4: Managed user joins the neighbourhood
             console.log("Managed user joining neighbourhood (late joiner)...");
             await localManagedUserClient!.neighbourhood.joinFromUrl(neighbourhoodUrl);
-            await sleep(5000);
-
-            // Re-exchange agent infos so the remote node can discover
-            // the managed user's DID-to-AgentPubKey mapping
-            console.log("Re-exchanging agent infos after managed user join...");
-            for (let attempt = 1; attempt <= 3; attempt++) {
-                try {
-                    const localInfos = await adminAd4mClient!.runtime.hcAgentInfos();
-                    const remoteInfos = await node3MainClient!.runtime.hcAgentInfos();
-                    await adminAd4mClient!.runtime.hcAddAgentInfos(remoteInfos);
-                    await node3MainClient!.runtime.hcAddAgentInfos(localInfos);
-                    console.log(`Post-managed-join agent info exchange ${attempt}/3 successful`);
-                } catch (error) {
-                    console.log(`Post-managed-join agent info exchange ${attempt} failed:`, error);
-                }
-                if (attempt < 3) await sleep(3000);
-            }
-
-            // Wait for the managed user's DID link to gossip
-            console.log("Waiting for managed user DID gossip...");
-            await sleep(10000);
 
             // Get managed user's neighbourhood proxy
             const localManagedPerspectives = await localManagedUserClient!.perspective.all();
@@ -3128,25 +3085,30 @@ describe("Multi-User Simple integration tests", () => {
             expect(localManagedNH).to.not.be.undefined;
             const localManagedProxy = await localManagedNH!.getNeighbourhoodProxy();
 
-            // Wait for the managed user to be discovered by remote
-            console.log("Waiting for managed user DHT gossip / peer discovery...");
+            // Re-exchange agent infos and poll until managed user is discovered
+            console.log("Re-exchanging agent infos and waiting for managed user DID gossip...");
+            await pollUntil(async () => {
+                try {
+                    const localInfos = await adminAd4mClient!.runtime.hcAgentInfos();
+                    const remoteInfos = await node3MainClient!.runtime.hcAgentInfos();
+                    await adminAd4mClient!.runtime.hcAddAgentInfos(remoteInfos);
+                    await node3MainClient!.runtime.hcAddAgentInfos(localInfos);
+                } catch (error) {
+                    console.log("Post-managed-join agent info exchange failed:", error);
+                }
+                const remoteOthers = await remoteProxy!.otherAgents();
+                const managedOthers = await localManagedProxy!.otherAgents();
+                return remoteOthers.includes(localManagedUserDid) && managedOthers.includes(remoteMainAgentDid);
+            }, { timeoutMs: 120000, intervalMs: 3000, label: "managed user and remote agent discover each other" });
 
             // Remote main agent should see the managed user
-            const remoteOthers = await pollUntilSeen(
-                remoteProxy!,
-                [localManagedUserDid],
-                "Remote Main Agent"
-            );
+            const remoteOthers = await remoteProxy!.otherAgents();
             expect(remoteOthers).to.include(localManagedUserDid,
                 "Remote main agent should see local managed user in others()");
             console.log("✅ Remote main agent sees managed user in others()");
 
             // Managed user should see the remote main agent
-            const managedOthers = await pollUntilSeen(
-                localManagedProxy!,
-                [remoteMainAgentDid],
-                "Local Managed User"
-            );
+            const managedOthers = await localManagedProxy!.otherAgents();
             expect(managedOthers).to.include(remoteMainAgentDid,
                 "Local managed user should see remote main agent in others()");
             console.log("✅ Managed user sees remote main agent in others()");
@@ -3168,18 +3130,14 @@ describe("Multi-User Simple integration tests", () => {
                 console.log("  [RECV] Local main agent got signal from:", signal.author);
                 localMainReceivedSignals.push(signal);
             });
-            await sleep(3000); // Let subscriptions stabilize
-
-            const maxWaitTime = 30000;
             const waitForSignal = async (signals: any[], label: string) => {
-                const start = Date.now();
-                while (signals.length === 0 && (Date.now() - start) < maxWaitTime) {
-                    await sleep(100);
-                }
+                await pollUntil(() => signals.length > 0, {
+                    timeoutMs: 30000, intervalMs: 100, label: `${label} receives signal`
+                });
                 if (signals.length > 0) {
                     console.log(`  ✅ ${label}: received signal from ${signals[0].author}`);
                 } else {
-                    console.log(`  ❌ ${label}: NO signal received after ${maxWaitTime}ms`);
+                    console.log(`  ❌ ${label}: NO signal received after 30000ms`);
                 }
             };
 

--- a/tests/js/tests/multi-user.test.ts
+++ b/tests/js/tests/multi-user.test.ts
@@ -4,7 +4,7 @@ import fs from "fs-extra";
 import { fileURLToPath } from 'url';
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { sleep, baseUrl, startExecutor, quitExecutor } from "../utils/utils";
+import { baseUrl, startExecutor, quitExecutor } from "../utils/utils";
 import { getFreePorts, registerPorts, deregisterPorts } from "../helpers/ports.js";
 import { ChildProcess } from 'node:child_process';
 import fetch from 'node-fetch'

--- a/tests/js/tests/neighbourhood.ts
+++ b/tests/js/tests/neighbourhood.ts
@@ -1,6 +1,6 @@
 import { Link, Perspective, LinkExpression, ExpressionProof, LinkQuery, PerspectiveState, NeighbourhoodProxy, PerspectiveUnsignedInput, PerspectiveProxy, PerspectiveHandle } from "@coasys/ad4m";
 import { TestContext } from './test-context'
-import { sleep } from "../utils/utils";
+import { assertStaysFalse } from "../utils/utils";
 import { LinkLangConfig, publishLinkLanguage, pollUntil } from "../utils/linkLangConfig";
 import { expect } from "chai";
 
@@ -53,15 +53,12 @@ export default function neighbourhoodTests(testContext: TestContext, getLinkLang
                 ]).to.include(perspective?.state);
                 
                 // Wait for the perspective to transition to Synced state
-                let tries = 0;
-                const maxTries = 10;
-                let currentPerspective = perspective;
-                while (currentPerspective?.state !== PerspectiveState.Synced && tries < maxTries) {
-                    await sleep(1000);
-                    currentPerspective = await ad4mClient.perspective.byUUID(create.uuid);
-                    tries++;
-                }
-                expect(currentPerspective?.state).to.be.equal(PerspectiveState.Synced);
+                await pollUntil(async () => {
+                    const p = await ad4mClient.perspective.byUUID(create.uuid);
+                    return p?.state === PerspectiveState.Synced;
+                }, { timeoutMs: 10000, label: "perspective transitions to Synced" });
+                const syncedPerspective = await ad4mClient.perspective.byUUID(create.uuid);
+                expect(syncedPerspective?.state).to.be.equal(PerspectiveState.Synced);
             })
 
             it('can be created by Alice and joined by Bob', async () => {
@@ -114,22 +111,12 @@ export default function neighbourhoodTests(testContext: TestContext, getLinkLang
 
                 await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
 
-                // Give time for the commit POST to reach the server, and for
-                // Bob's sync cycle to pick up the (possibly encrypted) diff.
-                // With E2E, Bob may need an extra refreshKeyRing round to
-                // decrypt — 5 s covers the typical WS + HTTP sync cadence.
-                await sleep(5000)
+                await pollUntil(async () => {
+                    const links = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}));
+                    return links.length >= 1;
+                }, { timeoutMs: 60000, label: "bob receives alice's shared link" });
 
-                let bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                let tries = 1
-
-                while(bobLinks.length < 1 && tries < 60) {
-                    console.log("Bob retrying getting links...");
-                    await sleep(1000)
-                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                    tries++
-                }
-
+                const bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                 expect(bobLinks.length).to.be.equal(1)
                 expect(bobLinks[0].data.target).to.be.equal('test://test')
                 expect(bobLinks[0].proof.valid).to.be.true;
@@ -148,22 +135,15 @@ export default function neighbourhoodTests(testContext: TestContext, getLinkLang
 
                 await testContext.makeAllNodesKnown()
 
-                await sleep(1000)
-
                 await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'}, 'local')
 
-                await sleep(1000)
+                // Negative test: actively verify the local link does NOT propagate
+                await assertStaysFalse(async () => {
+                    const links = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}));
+                    return links.length > 0;
+                }, { waitMs: 3000, label: "local link should NOT propagate to Bob" });
 
-                let bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                let tries = 1
-
-                while(bobLinks.length < 1 && tries < 5) {
-                    console.log("Bob retrying getting NOT received links...");
-                    await sleep(1000)
-                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                    tries++
-                }
-
+                const bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
                 expect(bobLinks.length).to.be.equal(0)
             })
 
@@ -188,29 +168,24 @@ export default function neighbourhoodTests(testContext: TestContext, getLinkLang
                         && s !== PerspectiveState.NeighboudhoodCreationInitiated;
                 }, { timeoutMs: 30000, intervalMs: 500, label: "Alice link language wired (stress)" });
 
-                // Create 1500 links as fast as possible — the executor's own
-                // pending_diffs_loop batches them (1s inactivity / 3s max /
-                // 150 max count). No artificial throttling: this exercises
-                // the continuous-burst path end-to-end.
+                // Create 1500 links as fast as possible — the batching system
+                // coalesces the burst into a small number of POSTs. No
+                // artificial throttling: this exercises the continuous-burst
+                // path end-to-end.
                 for(let i = 0; i < 1500; i++) {
                     console.log("Alice adding link ", i)
                     const link = await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: `test://test/${i}`})
                     console.log("Link expression:", link)
                 }
 
-                console.log("wait 15s for initial sync")
-                await sleep(15000)
+                // Wait for Bob to receive all 1500 links (initial sync + fallback)
+                await pollUntil(async () => {
+                    const links = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}));
+                    console.log(`Bob has ${links.length}/1500 links`);
+                    return links.length >= 1500;
+                }, { timeoutMs: 195000, intervalMs: 1000, label: "bob receives 1500 links" });
 
                 let bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                let tries = 1
-                const maxTries = 180 // 3 minutes with 1 second sleep (increased for fallback sync)
-
-                while(bobLinks.length < 1500 && tries < maxTries) {
-                    console.log(`Bob retrying getting links... Got ${bobLinks.length}/1500`);
-                    await sleep(1000)
-                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                    tries++
-                }
 
                 expect(bobLinks.length).to.be.equal(1500)
                 // Verify a few random links to ensure data integrity
@@ -221,8 +196,12 @@ export default function neighbourhoodTests(testContext: TestContext, getLinkLang
                     expect(link.proof.valid).to.be.true
                 })
                 
-                // make sure we're getting out of burst mode again
-                await sleep(11000)
+                // Wait for burst mode to expire — poll until the perspective
+                // returns to Synced state (burst mode keeps it in a different state)
+                await pollUntil(async () => {
+                    const p = await alice.perspective.byUUID(aliceP1.uuid);
+                    return p?.state === PerspectiveState.Synced;
+                }, { timeoutMs: 30000, intervalMs: 1000, label: "burst mode expires and perspective returns to Synced" });
 
                 // Alice creates some links
                 console.log("Alice creating links...")
@@ -230,17 +209,14 @@ export default function neighbourhoodTests(testContext: TestContext, getLinkLang
                 await testContext.alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://alice', target: 'test://alice/2'})
                 await testContext.alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://alice', target: 'test://alice/3'})
 
-                // Wait for sync with retry loop
-                bobLinks = await testContext.bob.perspective.queryLinks(bobP1.uuid, new LinkQuery({source: 'ad4m://alice'}))
-                let bobTries = 1
-                const maxTriesBob = 20 // 20 tries with 2 second sleep = 40 seconds max
+                // Wait for Bob to receive Alice's post-burst links
+                await pollUntil(async () => {
+                    const links = await testContext.bob.perspective.queryLinks(bobP1.uuid, new LinkQuery({source: 'ad4m://alice'}));
+                    console.log(`Bob has ${links.length}/3 of Alice's post-burst links`);
+                    return links.length >= 3;
+                }, { timeoutMs: 40000, intervalMs: 2000, label: "bob receives alice's post-burst links" });
 
-                while(bobLinks.length < 3 && bobTries < maxTriesBob) {
-                    console.log(`Bob retrying getting Alice's links... Got ${bobLinks.length}/3`);
-                    await sleep(2000)
-                    bobLinks = await testContext.bob.perspective.queryLinks(bobP1.uuid, new LinkQuery({source: 'ad4m://alice'}))
-                    bobTries++
-                }
+                bobLinks = await testContext.bob.perspective.queryLinks(bobP1.uuid, new LinkQuery({source: 'ad4m://alice'}))
 
                 // Verify Bob received Alice's links
                 expect(bobLinks.length).to.equal(3)
@@ -254,17 +230,14 @@ export default function neighbourhoodTests(testContext: TestContext, getLinkLang
                 await testContext.bob.perspective.addLink(bobP1.uuid, {source: 'ad4m://bob', target: 'test://bob/2'})
                 await testContext.bob.perspective.addLink(bobP1.uuid, {source: 'ad4m://bob', target: 'test://bob/3'})
 
-                // Wait for sync with retry loop
-                let aliceLinks = await testContext.alice.perspective.queryLinks(aliceP1.uuid, new LinkQuery({source: 'ad4m://bob'}))
-                tries = 1
-                const maxTriesAlice = 20 // 2 minutes with 1 second sleep
+                // Wait for Alice to receive Bob's links
+                await pollUntil(async () => {
+                    const links = await testContext.alice.perspective.queryLinks(aliceP1.uuid, new LinkQuery({source: 'ad4m://bob'}));
+                    console.log(`Alice has ${links.length}/3 of Bob's links`);
+                    return links.length >= 3;
+                }, { timeoutMs: 40000, intervalMs: 2000, label: "alice receives bob's links" });
 
-                while(aliceLinks.length < 3 && tries < maxTriesAlice) {
-                    console.log(`Alice retrying getting links... Got ${aliceLinks.length}/3`);
-                    await sleep(2000)
-                    aliceLinks = await testContext.alice.perspective.queryLinks(aliceP1.uuid, new LinkQuery({source: 'ad4m://bob'}))
-                    tries++
-                }
+                let aliceLinks = await testContext.alice.perspective.queryLinks(aliceP1.uuid, new LinkQuery({source: 'ad4m://bob'}))
 
                 // Verify Alice received Bob's links
                 //let aliceLinks = await testContext.alice.perspective.queryLinks(aliceP1.uuid, new LinkQuery({source: 'bob'}))
@@ -329,15 +302,14 @@ export default function neighbourhoodTests(testContext: TestContext, getLinkLang
             //     let bobLinks = await testContext.bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
             //     let tries = 1
 
-            //     while(bobLinks.length < 1 && tries < 300) {
-            //         await sleep(1000)
-            //         bobLinks = await testContext.bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-            //         tries++
-            //     }
+            //     await pollUntil(async () => {
+            //         bobLinks = await testContext.bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}));
+            //         return bobLinks.length >= 1;
+            //     }, { timeoutMs: 300000, intervalMs: 1000, label: "bob receives link from alice" });
 
             //     expect(bobLinks.length).to.be.equal(1)
 
-            //     await sleep(5000);
+            //     await pollUntil(() => bobSyncChangeCalls >= 1, { timeoutMs: 5000, intervalMs: 200, label: "bob sync state change" });
 
             //     // expect(aliceSyncChangeCalls).to.be.equal(2);
             //     // expect(aliceSyncChangeData).to.be.equal(PerspectiveState.Synced);
@@ -360,7 +332,13 @@ export default function neighbourhoodTests(testContext: TestContext, getLinkLang
                     const aliceP1 = await alice.perspective.add("telepresence")
                     const linkLang = await publishLinkLanguage(alice, getLinkLang(), "Alice's neighbourhood for Telepresence");
                     const neighbourhoodUrl = await alice.neighbourhood.publishFromPerspective(aliceP1.uuid, linkLang.address, new Perspective())
-                    await sleep(5000)
+
+                    // Wait for Alice's neighbourhood to reach Synced state
+                    await pollUntil(async () => {
+                        const p = await alice.perspective.byUUID(aliceP1.uuid);
+                        return p?.state === PerspectiveState.Synced;
+                    }, { timeoutMs: 10000, label: "alice's telepresence neighbourhood synced" });
+
                     const bobP1Handle = await bob.neighbourhood.joinFromUrl(neighbourhoodUrl);
                     const bobP1 = await bob.perspective.byUUID(bobP1Handle.uuid)
                     await testContext.makeAllNodesKnown()
@@ -369,24 +347,25 @@ export default function neighbourhoodTests(testContext: TestContext, getLinkLang
                     bobNH = bobP1!.getNeighbourhoodProxy()
                     aliceDID = (await alice.agent.me()).did
                     bobDID = (await bob.agent.me()).did
-                    await sleep(5000)
+
+                    // Wait for Bob's perspective to sync
+                    await pollUntil(async () => {
+                        const p = await bob.perspective.byUUID(bobP1Handle.uuid);
+                        return p?.state === PerspectiveState.Synced;
+                    }, { timeoutMs: 10000, label: "bob's telepresence perspective synced" });
                 })
 
                 it('they see each other in `otherAgents`', async () => {
-                    // Wait for agents to discover each other with retry loop
-                    let aliceAgents = await aliceNH!.otherAgents()
-                    let bobAgents = await bobNH!.otherAgents()
-                    let tries = 1
-                    const maxTries = 60 // 60 tries with 1 second sleep = 1 minute max
+                    // Wait for agents to discover each other
+                    await pollUntil(async () => {
+                        const a = await aliceNH!.otherAgents();
+                        const b = await bobNH!.otherAgents();
+                        console.log(`Agents: Alice sees ${a.length}, Bob sees ${b.length}`);
+                        return a.length >= 1 && b.length >= 1;
+                    }, { timeoutMs: 60000, label: "agents discover each other" });
 
-                    while ((aliceAgents.length < 1 || bobAgents.length < 1) && tries < maxTries) {
-                        console.log(`Waiting for agents to discover each other... Alice: ${aliceAgents.length}, Bob: ${bobAgents.length}`);
-                        await sleep(1000)
-                        aliceAgents = await aliceNH!.otherAgents()
-                        bobAgents = await bobNH!.otherAgents()
-                        tries++
-                    }
-
+                    const aliceAgents = await aliceNH!.otherAgents()
+                    const bobAgents = await bobNH!.otherAgents()
                     console.log("alice agents", aliceAgents);
                     console.log("bob agents", bobAgents);
                     expect(aliceAgents.length).to.be.equal(1)

--- a/tests/js/tests/perspective.ts
+++ b/tests/js/tests/perspective.ts
@@ -2,7 +2,7 @@ import { Ad4mClient, Link, LinkQuery, PerspectiveProxy, PerspectiveState } from 
 import { TestContext } from './test-context'
 import { expect } from "chai";
 import * as sinon from "sinon";
-import { sleep } from "../utils/utils";
+import { pollUntil } from "../utils/utils";
 
 export default function perspectiveTests(testContext: TestContext) {
     return  () => {
@@ -159,13 +159,13 @@ export default function perspectiveTests(testContext: TestContext) {
                 expect(create.name).to.equal("test-links-time");
 
                 let addLink = await ad4mClient!.perspective.addLink(create.uuid, new Link({source: "lang://test", target: "lang://test-target", predicate: "lang://predicate"}));
-                await sleep(10);
+                await pollUntil(() => Date.now() > new Date(addLink.timestamp).getTime(), { timeoutMs: 1000, intervalMs: 1, label: "timestamp separation after addLink" });
                 let addLink2 = await ad4mClient!.perspective.addLink(create.uuid, new Link({source: "lang://test", target: "lang://test-target2", predicate: "lang://predicate"}));
-                await sleep(10);
+                await pollUntil(() => Date.now() > new Date(addLink2.timestamp).getTime(), { timeoutMs: 1000, intervalMs: 1, label: "timestamp separation after addLink2" });
                 let addLink3 = await ad4mClient!.perspective.addLink(create.uuid, new Link({source: "lang://test", target: "lang://test-target3", predicate: "lang://predicate"}));
-                await sleep(10);
+                await pollUntil(() => Date.now() > new Date(addLink3.timestamp).getTime(), { timeoutMs: 1000, intervalMs: 1, label: "timestamp separation after addLink3" });
                 let addLink4 = await ad4mClient!.perspective.addLink(create.uuid, new Link({source: "lang://test", target: "lang://test-target4", predicate: "lang://predicate"}));
-                await sleep(10);
+                await pollUntil(() => Date.now() > new Date(addLink4.timestamp).getTime(), { timeoutMs: 1000, intervalMs: 1, label: "timestamp separation after addLink4" });
                 let addLink5 = await ad4mClient!.perspective.addLink(create.uuid, new Link({source: "lang://test", target: "lang://test-target5", predicate: "lang://predicate"}));
 
                 // Get all the links
@@ -270,14 +270,14 @@ export default function perspectiveTests(testContext: TestContext) {
 
                 const name = "Subscription Test Perspective"
                 const p = await ad4mClient.perspective.add(name)
-                await sleep(1000)
+                await pollUntil(() => perspectiveAdded.calledOnce, { timeoutMs: 5000, label: "perspectiveAdded callback fires" });
                 expect(perspectiveAdded.calledOnce).to.be.true;
                 const pSeenInAddCB = perspectiveAdded.getCall(0).args[0];
                 expect(pSeenInAddCB.uuid).to.equal(p.uuid)
                 expect(pSeenInAddCB.name).to.equal(p.name)
 
                 const p1 = await ad4mClient.perspective.update(p.uuid , "New Name")
-                await sleep(1000)
+                await pollUntil(() => perspectiveUpdated.calledOnce, { timeoutMs: 5000, label: "perspectiveUpdated callback fires" });
                 expect(perspectiveUpdated.calledOnce).to.be.true;
                 const pSeenInUpdateCB = perspectiveUpdated.getCall(0).args[0];
                 expect(pSeenInUpdateCB.uuid).to.equal(p1.uuid)
@@ -292,19 +292,19 @@ export default function perspectiveTests(testContext: TestContext) {
                 await ad4mClient.perspective.addPerspectiveLinkUpdatedListener(p1.uuid, [linkUpdated])
 
                 const linkExpression = await ad4mClient.perspective.addLink(p1.uuid , {source: 'ad4m://root', target: 'lang://123'})
-                await sleep(1000)
+                await pollUntil(() => linkAdded.called, { timeoutMs: 5000, label: "linkAdded callback fires" });
                 expect(linkAdded.called).to.be.true;
                 expect(linkAdded.getCall(0).args[0]).to.eql(linkExpression)
 
                 const updatedLinkExpression = await ad4mClient.perspective.updateLink(p1.uuid , linkExpression, {source: 'ad4m://root', target: 'lang://456'})
-                await sleep(1000)
+                await pollUntil(() => linkUpdated.called, { timeoutMs: 5000, label: "linkUpdated callback fires" });
                 expect(linkUpdated.called).to.be.true;
                 expect(linkUpdated.getCall(0).args[0].newLink).to.eql(updatedLinkExpression)
 
                 const copiedUpdatedLinkExpression = {...updatedLinkExpression}
 
                 await ad4mClient.perspective.removeLink(p1.uuid , updatedLinkExpression)
-                await sleep(1000)
+                await pollUntil(() => linkRemoved.called, { timeoutMs: 5000, label: "linkRemoved callback fires" });
                 expect(linkRemoved.called).to.be.true;
                 //expect(linkRemoved.getCall(0).args[0]).to.eql(copiedUpdatedLinkExpression)
             })
@@ -331,18 +331,14 @@ export default function perspectiveTests(testContext: TestContext) {
                 // Assert they got same subscription ID
                 expect(sub1Id).to.equal(sub2Id)
 
-                // Wait for the subscriptions to be established
-                // it's sending the initial result a couple of times
-                // to allow clients to wait and ensure for the subscription to be established
-                await sleep(1000)
-
                 // Add a link that matches the query
                 await p.add(new Link({
                     source: "test://source",
                     target: "test://target"
                 }))
 
-                await sleep(1000)
+                // Wait for subscription callbacks to fire (covers establishment + propagation)
+                await pollUntil(() => callback1.called && callback2.called, { timeoutMs: 5000, intervalMs: 100, label: "subscription callbacks fire" });
 
                 // Verify both callbacks were called
                 expect(callback1.called).to.be.true
@@ -877,7 +873,7 @@ export default function perspectiveTests(testContext: TestContext) {
                 }))
 
                 // Wait for subscription update
-                await sleep(1000)
+                await pollUntil(() => updates.length > 0, { timeoutMs: 5000, intervalMs: 100, label: "subscription update received" });
 
                 // Verify we got an update
                 expect(updates.length).to.be.greaterThan(0)

--- a/tests/js/tests/prolog-and-literals.test.ts
+++ b/tests/js/tests/prolog-and-literals.test.ts
@@ -16,7 +16,7 @@ import { Ad4mClient, Link, LinkQuery, Literal, PerspectiveProxy,
     path as shaclPath,
 } from "@coasys/ad4m";
 import { readFileSync } from "node:fs";
-import { startExecutor, baseUrl, quitExecutor } from "../utils/utils";
+import { startExecutor, baseUrl, quitExecutor, pollUntil, assertStaysFalse, sleep } from "../utils/utils";
 import { getFreePorts, registerPorts, deregisterPorts } from "../helpers/ports.js";
 import path from "path";
 import { fileURLToPath } from 'url';
@@ -383,11 +383,12 @@ describe("Prolog + Literals", () => {
                     let message = new Message(perspective!, messageEntry)
                     await message.save()
 
-                    // Allow SPARQL to index the new type flag
-                    await sleep(500)
-                    
-                    // Refresh todo data to apply collection filtering
-                    await todo.get()
+                    // Poll until SPARQL indexes the new type flag
+                    await pollUntil(async () => {
+                        await todo.get()
+                        const msgs = await todo.messages
+                        return msgs.length === 1
+                    }, { timeoutMs: 5000, intervalMs: 100, label: "SPARQL indexes message type flag" })
                     messageEntries = await todo.messages
                     expect(messageEntries.length).to.equal(1)
                 })
@@ -606,8 +607,8 @@ describe("Prolog + Literals", () => {
                     // Register the class
                     await perspective!.ensureSDNASubjectClass(RecipeWithSparqlFilter);
                     
-                    // Wait for SHACL metadata to be indexed
-                    await sleep(500);
+                    // SHACL metadata indexing happens asynchronously — no fixed
+                    // wait needed; downstream pollUntil on query results handles it
 
                     // See note on the SPARQL collection-where test above —
                     // use a NamedNode-friendly `ad4m://test/` ID scheme so the
@@ -631,15 +632,18 @@ describe("Prolog + Literals", () => {
                         target: "recipe://test"
                     }));
 
-                    // Small delay for SPARQL indexing
-                    await sleep(500);
-
-                    const recipe2 = new RecipeWithSparqlFilter(perspective!, root);
-                    await recipe2.get();
+                    // Poll until SPARQL indexes the ingredient link
+                    let recipe2: RecipeWithSparqlFilter;
+                    await pollUntil(async () => {
+                        recipe2 = new RecipeWithSparqlFilter(perspective!, root);
+                        await recipe2.get();
+                        return recipe2.ingredients.length === 1;
+                    }, { timeoutMs: 5000, intervalMs: 100, label: "SPARQL indexes ingredient link" });
+                    recipe2 = recipe2!;
 
                     // Should have 2 entries total
                     expect(recipe2.entries.length).to.equal(2);
-                    
+
                     // But only 1 ingredient (entry1 which has the ingredient link)
                     expect(recipe2.ingredients.length).to.equal(1);
                     expect(recipe2.ingredients[0]).to.equal(entry1);
@@ -1208,14 +1212,10 @@ describe("Prolog + Literals", () => {
                     task1.dueDate = start;
                     await task1.save();
 
-                    // Small delay to ensure different timestamps
-                    await sleep(10);
+                    // Wait for clock to advance past start
+                    await pollUntil(() => Date.now() > start, { timeoutMs: 1000, intervalMs: 1, label: "clock advances past start" });
 
                     let mid = new Date().getTime();
-                    // Ensure mid > start even if system clock resolution is low
-                    if (mid <= start) {
-                        mid = start + 1;
-                    }
 
                     const task2 = new TaskDue(perspective!);
                     task2.title = "Medium priority task";
@@ -1229,14 +1229,10 @@ describe("Prolog + Literals", () => {
                     task3.dueDate = mid + 2;
                     await task3.save();
 
-                    // Small delay to ensure different timestamps
-                    await sleep(10);
+                    // Wait for clock to advance past mid
+                    await pollUntil(() => Date.now() > mid, { timeoutMs: 1000, intervalMs: 1, label: "clock advances past mid" });
 
                     let end = new Date().getTime();
-                    // Ensure end > mid even if system clock resolution is low
-                    if (end <= mid) {
-                        end = mid + 1;
-                    }
 
                     // Check all tasks are there
                     const allTasks = await TaskDue.findAll(perspective!);
@@ -1583,7 +1579,9 @@ describe("Prolog + Literals", () => {
                         });
                     expect(subscription).to.equal(3);
 
-                    // Small delay to ensure subscription is fully registered before triggering changes
+                    // Subscription-init delay: SPARQL change-watchers register
+                    // asynchronously inside the executor — no observable "ready"
+                    // state exists to poll for, so a fixed delay is required.
                     await sleep(500);
 
                     // Add another recipe and verify callback is called
@@ -1736,7 +1734,8 @@ describe("Prolog + Literals", () => {
                     // Reset lastResult to verify we get an update
                     lastResult = null;
 
-                    // Small delay to ensure subscription is fully registered before triggering changes
+                    // Subscription-init delay: SPARQL change-watchers register
+                    // asynchronously — no observable "ready" state to poll for.
                     await sleep(500);
 
                     // Add a new recipe and verify subscription updates
@@ -1820,11 +1819,10 @@ describe("Prolog + Literals", () => {
                     notification1.read = false;
                     await notification1.save();
 
-                    // Wait for subscription to fire with smart polling
-                    for (let i = 0; i < 30; i++) {
-                        if (updateCount >= 1 && notifications.length === 1) break;
-                        await sleep(50);
-                    }
+                    // Wait for subscription to fire
+                    await pollUntil(() => updateCount >= 1 && notifications.length === 1, {
+                        timeoutMs: 5000, intervalMs: 50, label: "first notification subscription fires"
+                    });
                     expect(updateCount).to.be.at.least(1);
                     expect(notifications.length).to.equal(1);
 
@@ -1835,10 +1833,9 @@ describe("Prolog + Literals", () => {
                     notification2.read = false;
                     await notification2.save();
 
-                    for (let i = 0; i < 30; i++) {
-                        if (updateCount >= 2 && notifications.length === 2) break;
-                        await sleep(50);
-                    }
+                    await pollUntil(() => updateCount >= 2 && notifications.length === 2, {
+                        timeoutMs: 5000, intervalMs: 50, label: "second notification subscription fires"
+                    });
                     expect(updateCount).to.be.at.least(2);
                     expect(notifications.length).to.equal(2);
 
@@ -1849,20 +1846,18 @@ describe("Prolog + Literals", () => {
                     notification3.read = false;
                     await notification3.save();
 
-                    await sleep(200); // Give it time but don't wait the full second
-                    // With SPARQL we get 3 updates because we do comparison filtering in the client
-                    // and not the query. So the raw query result actually is different, even though
-                    // the ultimate result is the same.
-                    //expect(updateCount).to.equal(2);
+                    // Verify non-matching notification does not add to filtered results
+                    await assertStaysFalse(() => notifications.length > 2, {
+                        waitMs: 500, intervalMs: 50, label: "low-priority notification stays out of filtered results"
+                    });
                     expect(notifications.length).to.equal(2);
 
                     // Mark notification1 as read - should trigger subscription to remove it
                     notification1.read = true;
                     await notification1.save();
-                    for (let i = 0; i < 30; i++) {
-                        if (notifications.length === 1) break;
-                        await sleep(50);
-                    }
+                    await pollUntil(() => notifications.length === 1, {
+                        timeoutMs: 5000, intervalMs: 50, label: "read notification removed from subscription"
+                    });
                     expect(notifications.length).to.equal(1);
 
                     // Dispose the subscription to prevent cross-test interference
@@ -2041,7 +2036,10 @@ describe("Prolog + Literals", () => {
                     task3.assignee = "bob";
                     await task3.save();
 
-                    await sleep(1000);
+                    // Verify non-matching task does not trigger subscription
+                    await assertStaysFalse(() => updateCount > 2 || tasks.length > 2, {
+                        waitMs: 1000, intervalMs: 50, label: "wrong-assignee task does not trigger subscription"
+                    });
                     expect(updateCount).to.equal(2);
                     expect(tasks.length).to.equal(2);
 
@@ -2284,10 +2282,9 @@ describe("Prolog + Literals", () => {
                         // `subscriptionLatency`, so a real regression would
                         // surface as a slow log line rather than be hidden by
                         // the bumped ceiling.
-                        while (!subscriptionCallback.called) {
-                            await sleep(10);
-                            if (Date.now() - saveTime > 60000) throw new Error("Timeout waiting for subscription update");
-                        }
+                        await pollUntil(() => subscriptionCallback.called, {
+                            timeoutMs: 60000, intervalMs: 10, label: "subscription callback fires after save"
+                        });
 
                         const saveLatency = saveTime - start;
                         const subscriptionLatency = Date.now() - saveTime;
@@ -2402,10 +2399,10 @@ describe("Prolog + Literals", () => {
                         model3.status = "active";
                         await model3.save();
 
-                        // Wait to ensure no callbacks
-                        await sleep(1000);
-
-                        // Verify no new callbacks after dispose
+                        // Verify no callbacks fire after dispose
+                        await assertStaysFalse(() => callback1.callCount > 1 || callback2.callCount > 1, {
+                            waitMs: 1000, intervalMs: 50, label: "no callbacks after dispose"
+                        });
                         // callback1: 1 (model1 save only)
                         // callback2: 1 (model2 save only)
                         expect(callback1.callCount).to.equal(1);
@@ -2420,7 +2417,8 @@ describe("Prolog + Literals", () => {
                         const initialCount = await builder.countSubscribe(countCallback);
                         expect(initialCount).to.equal(0);
 
-                        // Small delay to ensure subscription is fully registered before triggering changes
+                        // Subscription-init delay: SPARQL change-watchers register
+                        // asynchronously — no observable "ready" state to poll for.
                         await sleep(500);
 
                         // Add a matching model
@@ -2454,10 +2452,10 @@ describe("Prolog + Literals", () => {
                         model2.status = "active";
                         await model2.save();
 
-                        // Wait to ensure no callback (still using sleep since we're verifying no change)
-                        await sleep(1000);
-
-                        // Verify no new callbacks
+                        // Verify no callbacks fire after dispose
+                        await assertStaysFalse(() => countCallback.callCount > count, {
+                            waitMs: 1000, intervalMs: 50, label: "no count callbacks after dispose"
+                        });
                         expect(countCallback.callCount).to.equal(count);
                     });
 
@@ -2470,7 +2468,8 @@ describe("Prolog + Literals", () => {
                         expect(initialPage.results.length).to.equal(0);
                         expect(initialPage.totalCount).to.equal(0);
 
-                        // Small delay to ensure subscription is fully registered before triggering changes
+                        // Subscription-init delay: SPARQL change-watchers register
+                        // asynchronously — no observable "ready" state to poll for.
                         await sleep(500);
 
                         // Add the first model and synchronize on its dispatch before
@@ -2522,10 +2521,10 @@ describe("Prolog + Literals", () => {
                         model3.status = "active";
                         await model3.save();
 
-                        // Wait to ensure no callback
-                        await sleep(1000);
-
-                        // Verify no new callbacks
+                        // Verify no callbacks fire after dispose
+                        await assertStaysFalse(() => pageCallback.callCount > count, {
+                            waitMs: 1000, intervalMs: 50, label: "no page callbacks after dispose"
+                        });
                         expect(pageCallback.callCount).to.equal(count);
                     });
                 });
@@ -2875,8 +2874,7 @@ describe("Prolog + Literals", () => {
                     await perspective!.ensureSDNASubjectClass(Article);
                     await perspective!.ensureSDNASubjectClass(ArticleWithString);
 
-                    // Give perspective time to fully index the SDNA classes
-                    await sleep(200);
+                    // SDNA class indexing handled by downstream pollUntil checks
                 });
 
                 it("should filter collection by type with class reference", async () => {
@@ -2902,9 +2900,6 @@ describe("Prolog + Literals", () => {
                     comment2.text = "This is another valid comment";
                     await comment2.save();
 
-                    // Add delay to allow SPARQL to finish indexing
-                    await sleep(1500);
-
                     // Add links to article
                     await perspective!.add(new Link({
                         source: articleRoot,
@@ -2922,10 +2917,14 @@ describe("Prolog + Literals", () => {
                         target: validComment2
                     }));
 
-                    await sleep(500);
-
-                    const retrievedArticle = new Article(perspective!, articleRoot);
-                    await retrievedArticle.get();
+                    // Poll until SPARQL indexes links and type-filter resolves correctly
+                    let retrievedArticle: Article;
+                    await pollUntil(async () => {
+                        retrievedArticle = new Article(perspective!, articleRoot);
+                        await retrievedArticle.get();
+                        return retrievedArticle.comments.length === 2;
+                    }, { timeoutMs: 10000, intervalMs: 200, label: "type-filtered comments resolve to 2" });
+                    retrievedArticle = retrievedArticle!;
 
                     // Should only contain valid Comments, not the invalid item
                     expect(retrievedArticle.comments).to.have.lengthOf(2);
@@ -2948,9 +2947,6 @@ describe("Prolog + Literals", () => {
                     comment.text = "Valid comment text";
                     await comment.save();
 
-                    // Add delay to allow SPARQL to finish indexing
-                    await sleep(1500);
-
                     // Add both to article
                     await perspective!.add(new Link({
                         source: articleRoot,
@@ -2963,10 +2959,14 @@ describe("Prolog + Literals", () => {
                         target: invalidItem
                     }));
 
-                    await sleep(500);
-
-                    const retrievedArticle = new ArticleWithString(perspective!, articleRoot);
-                    await retrievedArticle.get();
+                    // Poll until SPARQL indexes and type-filter resolves
+                    let retrievedArticle: ArticleWithString;
+                    await pollUntil(async () => {
+                        retrievedArticle = new ArticleWithString(perspective!, articleRoot);
+                        await retrievedArticle.get();
+                        return retrievedArticle.comments.length === 1;
+                    }, { timeoutMs: 10000, intervalMs: 200, label: "string-name type-filtered comments resolve to 1" });
+                    retrievedArticle = retrievedArticle!;
 
                     expect(retrievedArticle.comments).to.have.lengthOf(1);
                     expect(retrievedArticle.comments[0]).to.equal(validComment);
@@ -3001,9 +3001,6 @@ describe("Prolog + Literals", () => {
                     c2.text = "Comment 2 text";
                     await c2.save();
 
-                    // Add delay to allow SPARQL to finish indexing
-                    await sleep(1500);
-
                     // Add comments to articles (mix of valid and invalid)
                     await perspective!.add(new Link({
                         source: article1Root,
@@ -3026,11 +3023,17 @@ describe("Prolog + Literals", () => {
                         target: invalid2
                     }));
 
-                    await sleep(500);
+                    // Poll until SPARQL indexes and findAll returns both articles with filtered comments
+                    let articles: Article[];
+                    await pollUntil(async () => {
+                        articles = await Article.findAll(perspective!);
+                        if (articles.length !== 2) return false;
+                        const a1 = articles.find(a => a.title === "Article 1");
+                        const a2 = articles.find(a => a.title === "Article 2");
+                        return !!a1 && a1.comments.length === 1 && !!a2 && a2.comments.length === 1;
+                    }, { timeoutMs: 10000, intervalMs: 200, label: "findAll type-filter resolves both articles" });
+                    articles = articles!;
 
-                    // Use findAll and verify filtering
-                    const articles = await Article.findAll(perspective!);
-                    
                     expect(articles).to.have.lengthOf(2);
                     
                     const foundArticle1 = articles.find(a => a.title === "Article 1");
@@ -3776,34 +3779,29 @@ describe("Prolog + Literals", () => {
 
 })
 
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+// sleep() removed — all callers now use pollUntil/assertStaysFalse from utils
 
 /**
- * Wait for a condition to become true with exponential backoff.
- * This is more reliable than fixed sleep() for async operations.
+ * Wait for a condition to become true, polling at fixed intervals.
+ * Delegates to the shared pollUntil from utils.ts.
  */
 async function waitForCondition(
   condition: () => boolean,
-  options: { 
-    timeoutMs?: number, 
+  options: {
+    timeoutMs?: number,
     checkIntervalMs?: number,
-    errorMessage?: string 
+    errorMessage?: string
   } = {}
 ): Promise<void> {
-  const { 
-    timeoutMs = 5000, 
+  const {
+    timeoutMs = 5000,
     checkIntervalMs = 50,
     errorMessage = 'Condition was not met within timeout'
   } = options;
-  
-  const startTime = Date.now();
-  
-  while (!condition()) {
-    if (Date.now() - startTime > timeoutMs) {
-      throw new Error(`${errorMessage} (timeout: ${timeoutMs}ms)`);
-    }
-    await sleep(checkIntervalMs);
-  }
+
+  await pollUntil(condition, {
+    timeoutMs,
+    intervalMs: checkIntervalMs,
+    label: errorMessage,
+  });
 }

--- a/tests/js/tests/runtime.ts
+++ b/tests/js/tests/runtime.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import { expect } from "chai";
 import { NotificationInput, TriggeredNotification } from '@coasys/ad4m';
 import sinon from 'sinon';
-import { sleep } from '../utils/utils';
+import { pollUntil, assertStaysFalse } from '../utils/utils';
 import { ExceptionType, Link } from '@coasys/ad4m';
 // Imports needed for webhook tests:
 // (deactivated for now because these imports break the test suite on CI)
@@ -194,7 +194,7 @@ export default function runtimeTests(testContext: TestContext, options?: { hasHo
             // Request to install a new notification
             const notificationId = await ad4mClient.runtime.requestInstallNotification(notification);
 
-            await sleep(2000)
+            await pollUntil(() => mockFunction.calledOnce, { timeoutMs: 5000, label: "notification install request callback fires" });
 
             // Use sinon's assertions to wait for the stub to be called
             await sinon.assert.calledOnce(mockFunction);
@@ -258,7 +258,6 @@ export default function runtimeTests(testContext: TestContext, options?: { hasHo
 
             // Request to install a new notification
             const notificationId = await ad4mClient.runtime.requestInstallNotification(notification);
-            sleep(1000)
             // Grant the notification
             const granted = await ad4mClient.runtime.grantNotification(notificationId)
             expect(granted).to.be.true
@@ -266,19 +265,17 @@ export default function runtimeTests(testContext: TestContext, options?: { hasHo
             const mockFunction = sinon.stub();
             await ad4mClient.runtime.addNotificationTriggeredCallback(mockFunction)
 
-            // Ensuring no false positives
+            // Negative: ensuring no false positives — control link should NOT trigger
             await notificationPerspective.add(new Link({source: "control://source", target: "control://target"}))
-            await sleep(1000)
-            expect(mockFunction.called).to.be.false
+            await assertStaysFalse(() => mockFunction.called, { waitMs: 1000, label: "no false positive on control link" });
 
-            // Ensuring only selected perspectives will trigger
+            // Negative: ensuring only selected perspectives trigger
             await otherPerspective.add(new Link({source: "control://source", predicate: triggerPredicate, target: "control://target"}))
-            await sleep(1000)
-            expect(mockFunction.called).to.be.false
+            await assertStaysFalse(() => mockFunction.called, { waitMs: 1000, label: "other perspective should not trigger" });
 
             // Happy path
             await notificationPerspective.add(new Link({source: "test://source", predicate: triggerPredicate, target: "test://target1"}))
-            await sleep(7000)
+            await pollUntil(() => mockFunction.called, { timeoutMs: 15000, label: "notification trigger fires for target1" });
             expect(mockFunction.called).to.be.true
             let triggeredNotification = mockFunction.getCall(0).args[0] as TriggeredNotification
             expect(triggeredNotification.notification.description).to.equal(notification.description)
@@ -292,7 +289,7 @@ export default function runtimeTests(testContext: TestContext, options?: { hasHo
 
             // Ensuring we don't get old data on a new trigger
             await notificationPerspective.add(new Link({source: "test://source", predicate: triggerPredicate, target: "test://target2"}))
-            await sleep(7000)
+            await pollUntil(() => mockFunction.callCount >= 2, { timeoutMs: 15000, label: "notification trigger fires for target2" });
             expect(mockFunction.callCount).to.equal(2)
             triggeredNotification = mockFunction.getCall(1).args[0] as TriggeredNotification
             triggerMatch = JSON.parse(triggeredNotification.triggerMatch)
@@ -329,14 +326,13 @@ export default function runtimeTests(testContext: TestContext, options?: { hasHo
             }
 
             const notificationId = await ad4mClient.runtime.requestInstallNotification(notification);
-            await sleep(1000)
             const granted = await ad4mClient.runtime.grantNotification(notificationId)
             expect(granted).to.be.true
 
             const mockFunction = sinon.stub();
             await ad4mClient.runtime.addNotificationTriggeredCallback(mockFunction)
 
-            // Create a message expression that doesn't mention the agent
+            // Negative: message without mention should NOT trigger
             const noMentionContent = "Hello world, nice day!"
             const noMentionExprUrl = await ad4mClient.expression.create(noMentionContent, "literal")
             await notificationPerspective.add(new Link({
@@ -344,8 +340,7 @@ export default function runtimeTests(testContext: TestContext, options?: { hasHo
                 predicate: "flux://has_message",
                 target: noMentionExprUrl
             }))
-            await sleep(2000)
-            expect(mockFunction.called).to.be.false
+            await assertStaysFalse(() => mockFunction.called, { waitMs: 2000, label: "no-mention message should not trigger" });
 
             // Create a message expression that mentions the agent (with HTML formatting like Flux)
             const mentionContent = `Hey <strong>${agentDid!}</strong>, check this out!`
@@ -355,7 +350,7 @@ export default function runtimeTests(testContext: TestContext, options?: { hasHo
                 predicate: "flux://has_message",
                 target: mentionExprUrl
             }))
-            await sleep(7000)
+            await pollUntil(() => mockFunction.called, { timeoutMs: 15000, label: "mention notification trigger fires" });
             expect(mockFunction.called).to.be.true
 
             let triggeredNotification = mockFunction.getCall(0).args[0] as TriggeredNotification
@@ -488,24 +483,23 @@ export default function runtimeTests(testContext: TestContext, options?: { hasHo
 
             // Request to install a new notification
             const notificationId = await ad4mClient.runtime.requestInstallNotification(notification);
-            sleep(1000)
+            // Original code did not await sleep() here — install completes
+            // synchronously enough that granting works without a delay.
             // Grant the notification
             const granted = await ad4mClient.runtime.grantNotification(notificationId)
             expect(granted).to.be.true
 
             // Ensuring no false positives
             await notificationPerspective.add(new Link({source: "control://source", target: "control://target"}))
-            await sleep(1000)
-            expect(webhookCalled).to.be.false
+            await assertStaysFalse(() => webhookCalled, { waitMs: 1000, intervalMs: 100, label: "webhook not called for non-matching link" });
 
             // Ensuring only selected perspectives will trigger
             await otherPerspective.add(new Link({source: "control://source", predicate: triggerPredicate, target: "control://target"}))
-            await sleep(1000)
-            expect(webhookCalled).to.be.false
+            await assertStaysFalse(() => webhookCalled, { waitMs: 1000, intervalMs: 100, label: "webhook not called for wrong perspective" });
 
             // Happy path
             await notificationPerspective.add(new Link({source: "test://source", predicate: triggerPredicate, target: "test://target1"}))
-            await sleep(1000)
+            await pollUntil(() => webhookCalled, { timeoutMs: 5000, intervalMs: 100, label: "webhook called for matching link" });
             expect(webhookCalled).to.be.true
             expect(webhookGotAuth).to.equal(webhookAuth)
             expect(webhookGotBody).to.be.not.be.null
@@ -524,7 +518,7 @@ export default function runtimeTests(testContext: TestContext, options?: { hasHo
             webhookGotBody = null
 
             await notificationPerspective.add(new Link({source: "test://source", predicate: triggerPredicate, target: "test://target2"}))
-            await sleep(1000)
+            await pollUntil(() => webhookCalled, { timeoutMs: 5000, intervalMs: 100, label: "webhook called for second matching link" });
             expect(webhookCalled).to.be.true
             expect(webhookGotAuth).to.equal(webhookAuth)
             triggeredNotification = webhookGotBody as unknown as TriggeredNotification

--- a/tests/js/tests/simple.test.ts
+++ b/tests/js/tests/simple.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { ChildProcess } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { Ad4mClient } from "@coasys/ad4m";
-import { startExecutor, baseUrl, sleep, gracefulShutdown } from "../utils/utils";
+import { startExecutor, baseUrl, gracefulShutdown } from "../utils/utils";
 import { getFreePorts, registerPorts, deregisterPorts } from "../helpers/ports.js";
 import path from "path";
 import { fileURLToPath } from 'url';

--- a/tests/js/tests/test-context.ts
+++ b/tests/js/tests/test-context.ts
@@ -1,6 +1,6 @@
 import { Ad4mClient, ExpressionProof, Link, LinkExpression, Perspective } from "@coasys/ad4m";
 import { ChildProcess } from 'child_process';
-import { sleep } from "../utils/utils";
+import { pollUntil } from "../utils/utils";
 
 export class TestContext {
     #alice: Ad4mClient | undefined
@@ -52,51 +52,26 @@ export class TestContext {
     }
 
     async makeAllNodesKnown() {
-      let lastError: unknown;
-      for (let attempt = 1; attempt <= 5; attempt++) {
-        try {
-          const aliceAgentInfo = await this.#alice!.runtime.hcAgentInfos();
-          const bobAgentInfo = await this.#bob!.runtime.hcAgentInfos();
-
-          await this.#alice!.runtime.hcAddAgentInfos(bobAgentInfo);
-          await this.#bob!.runtime.hcAddAgentInfos(aliceAgentInfo);
-          console.log(`Agent info exchange attempt ${attempt} successful`);
-          lastError = undefined;
-          break;
-        } catch (error) {
-          lastError = error;
-          console.log(`Agent info exchange attempt ${attempt} failed:`, error);
-          if (attempt < 5) {
-            await sleep(3000);
-          }
-        }
-      }
-      if (lastError) throw lastError;
+      await pollUntil(async () => {
+        const aliceAgentInfo = await this.#alice!.runtime.hcAgentInfos();
+        const bobAgentInfo = await this.#bob!.runtime.hcAgentInfos();
+        await this.#alice!.runtime.hcAddAgentInfos(bobAgentInfo);
+        await this.#bob!.runtime.hcAddAgentInfos(aliceAgentInfo);
+        console.log("Agent info exchange successful");
+        return true;
+      }, { timeoutMs: 15000, intervalMs: 3000, label: "agent info exchange (alice ↔ bob)" });
     }
 
     async makeAllThreeNodesKnown() {
-      let lastError: unknown;
-      for (let attempt = 1; attempt <= 5; attempt++) {
-        try {
-          const aliceAgentInfo = await this.#alice!.runtime.hcAgentInfos();
-          const bobAgentInfo = await this.#bob!.runtime.hcAgentInfos();
-          const jimAgentInfo = await this.#jim!.runtime.hcAgentInfos();
-
-          const allInfos = [...aliceAgentInfo, ...bobAgentInfo, ...jimAgentInfo];
-          await this.#alice!.runtime.hcAddAgentInfos([...bobAgentInfo, ...jimAgentInfo]);
-          await this.#bob!.runtime.hcAddAgentInfos([...aliceAgentInfo, ...jimAgentInfo]);
-          await this.#jim!.runtime.hcAddAgentInfos([...aliceAgentInfo, ...bobAgentInfo]);
-          console.log(`Three-node agent info exchange attempt ${attempt} successful`);
-          lastError = undefined;
-          break;
-        } catch (error) {
-          lastError = error;
-          console.log(`Three-node agent info exchange attempt ${attempt} failed:`, error);
-          if (attempt < 5) {
-            await sleep(3000);
-          }
-        }
-      }
-      if (lastError) throw lastError;
+      await pollUntil(async () => {
+        const aliceAgentInfo = await this.#alice!.runtime.hcAgentInfos();
+        const bobAgentInfo = await this.#bob!.runtime.hcAgentInfos();
+        const jimAgentInfo = await this.#jim!.runtime.hcAgentInfos();
+        await this.#alice!.runtime.hcAddAgentInfos([...bobAgentInfo, ...jimAgentInfo]);
+        await this.#bob!.runtime.hcAddAgentInfos([...aliceAgentInfo, ...jimAgentInfo]);
+        await this.#jim!.runtime.hcAddAgentInfos([...aliceAgentInfo, ...bobAgentInfo]);
+        console.log("Three-node agent info exchange successful");
+        return true;
+      }, { timeoutMs: 15000, intervalMs: 3000, label: "agent info exchange (alice ↔ bob ↔ jim)" });
     }
 }

--- a/tests/js/tests/triple-agent-test.ts
+++ b/tests/js/tests/triple-agent-test.ts
@@ -1,7 +1,7 @@
 import { Link, Perspective, LinkExpression, ExpressionProof, LinkQuery, PerspectiveState, NeighbourhoodProxy, PerspectiveUnsignedInput, PerspectiveProxy, PerspectiveHandle } from "@coasys/ad4m";
 import fs from "fs";
 import { TestContext } from './test-context'
-import { sleep } from '../utils/utils'
+import { pollUntil } from '../utils/utils'
 import { expect } from "chai";
 import { v4 as uuidv4 } from 'uuid';
 
@@ -36,8 +36,6 @@ export default function tripleAgentTests(testContext: TestContext) {
                 expect(jimP1!.neighbourhood!.linkLanguage).to.be.equal(socialContext.address);
                 expect(jimP1!.neighbourhood!.meta.links.length).to.be.equal(0);
 
-                await sleep(1000)
-
                 await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
                 await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
                 await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
@@ -49,17 +47,12 @@ export default function tripleAgentTests(testContext: TestContext) {
                 await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
                 await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
 
-                await sleep(1000)
-
-                let bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                let tries = 1
-
-                while(bobLinks.length < 10 && tries < 20) {
-                    console.log("Bob retrying getting links...");
-                    await sleep(1000)
-                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                    tries++
-                }
+                let bobLinks: any[] = [];
+                await pollUntil(async () => {
+                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}));
+                    console.log(`Bob has ${bobLinks.length}/10 links`);
+                    return bobLinks.length >= 10;
+                }, { timeoutMs: 20000, intervalMs: 1000, label: "bob receives 10 links from alice" });
                 
                 expect(bobLinks.length).to.be.equal(10)
 
@@ -74,15 +67,12 @@ export default function tripleAgentTests(testContext: TestContext) {
                 await bob.perspective.addLink(bobP1.uuid, {source: 'ad4m://root', target: 'test://test'})
                 await alice.perspective.addLink(aliceP1.uuid, {source: 'ad4m://root', target: 'test://test'})
 
-                let jimLinks = await jim.perspective.queryLinks(jimP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                let jimRetries = 1
-
-                while(jimLinks.length < 20 && jimRetries < 20) {
-                    console.log("Jim retrying getting links...");
-                    await sleep(1000)
-                    jimLinks = await jim.perspective.queryLinks(jimP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                    jimRetries++
-                }
+                let jimLinks: any[] = [];
+                await pollUntil(async () => {
+                    jimLinks = await jim.perspective.queryLinks(jimP1!.uuid, new LinkQuery({source: 'ad4m://root'}));
+                    console.log(`Jim has ${jimLinks.length}/20 links`);
+                    return jimLinks.length >= 20;
+                }, { timeoutMs: 20000, intervalMs: 1000, label: "jim receives 20 links" });
                 
                 expect(jimLinks.length).to.be.equal(20)
 
@@ -98,45 +88,34 @@ export default function tripleAgentTests(testContext: TestContext) {
                 await jim.perspective.addLink(jimP1.uuid, {source: 'ad4m://root', target: 'test://test'})
                 await jim.perspective.addLink(jimP1.uuid, {source: 'ad4m://root', target: 'test://test'})
 
-                let aliceLinks = await alice.perspective.queryLinks(aliceP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                tries = 1
-
-                while(aliceLinks.length < 30 && tries < 20) {
-                    console.log("Alice retrying getting links...");
-                    await sleep(1000)
-                    aliceLinks = await alice.perspective.queryLinks(aliceP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                    tries++
-                }
+                let aliceLinks: any[] = [];
+                await pollUntil(async () => {
+                    aliceLinks = await alice.perspective.queryLinks(aliceP1!.uuid, new LinkQuery({source: 'ad4m://root'}));
+                    console.log(`Alice has ${aliceLinks.length}/30 links`);
+                    return aliceLinks.length >= 30;
+                }, { timeoutMs: 20000, intervalMs: 1000, label: "alice receives 30 links" });
                 
                 expect(aliceLinks.length).to.be.equal(30)
 
 
 
 
-                bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                tries = 1
-
-                while(bobLinks.length < 30 && tries < 20) {
-                    console.log("Bob retrying getting links...");
-                    await sleep(1000)
-                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                    tries++
-                }
+                await pollUntil(async () => {
+                    bobLinks = await bob.perspective.queryLinks(bobP1!.uuid, new LinkQuery({source: 'ad4m://root'}));
+                    console.log(`Bob has ${bobLinks.length}/30 links`);
+                    return bobLinks.length >= 30;
+                }, { timeoutMs: 20000, intervalMs: 1000, label: "bob receives 30 links" });
                 
                 expect(bobLinks.length).to.be.equal(30)
 
 
 
 
-                jimLinks = await jim.perspective.queryLinks(jimP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                tries = 1
-
-                while(jimLinks.length < 30 && tries < 20) {
-                    console.log("Jim retrying getting links...");
-                    await sleep(1000)
-                    jimLinks = await jim.perspective.queryLinks(jimP1!.uuid, new LinkQuery({source: 'ad4m://root'}))
-                    tries++
-                }
+                await pollUntil(async () => {
+                    jimLinks = await jim.perspective.queryLinks(jimP1!.uuid, new LinkQuery({source: 'ad4m://root'}));
+                    console.log(`Jim has ${jimLinks.length}/30 links`);
+                    return jimLinks.length >= 30;
+                }, { timeoutMs: 20000, intervalMs: 1000, label: "jim receives 30 links" });
                 
                 expect(jimLinks.length).to.be.equal(30)
                 

--- a/tests/js/utils/publishTestLangs.ts
+++ b/tests/js/utils/publishTestLangs.ts
@@ -4,7 +4,7 @@ import fs from "fs-extra";
 import { exit } from "process";
 import { execSync } from "child_process";
 import { fileURLToPath } from 'url';
-import { baseUrl, sleep, startExecutor, runHcLocalServices } from "./utils";
+import { baseUrl, pollUntil, startExecutor, runHcLocalServices } from "./utils";
 import { getFreePorts, registerPorts, deregisterPorts } from "../helpers/ports.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -185,7 +185,9 @@ async function publish() {
         console.log(`Killing executor on ports ${setupPorts.join('/')}...`);
         killExecutorPorts(setupPorts);
         deregisterPorts(setupPorts);
-        await sleep(1000);
+        await pollUntil(() => {
+            try { execSync(`lsof -ti TCP:${apiPort} -s TCP:LISTEN`, { stdio: 'ignore' }); return false; } catch { return true; }
+        }, { timeoutMs: 5000, intervalMs: 200, label: "executor ports freed after shutdown" });
     }
 
     exit();

--- a/tests/js/utils/testCluster.ts
+++ b/tests/js/utils/testCluster.ts
@@ -14,7 +14,7 @@
 
 import { ChildProcess } from "node:child_process";
 import { Ad4mClient } from "@coasys/ad4m";
-import { baseUrl, startExecutor, gracefulShutdown, sleep } from "./utils";
+import { baseUrl, startExecutor, gracefulShutdown, pollUntil } from "./utils";
 
 export interface NodeConfig {
     apiPort: number;
@@ -77,22 +77,15 @@ export class TestCluster {
      * Poll the API endpoint until it responds, with exponential backoff.
      */
     private async waitForApi(port: number, adminCredential: string, timeoutMs: number = 60000): Promise<Ad4mClient> {
-        const start = Date.now();
-        let lastError: Error | null = null;
-
-        while (Date.now() - start < timeoutMs) {
+        let client: Ad4mClient | null = null;
+        await pollUntil(async () => {
             try {
-                const client = new Ad4mClient(baseUrl(port), adminCredential, false);
-                // Try a simple query to verify connectivity
+                client = new Ad4mClient(baseUrl(port), adminCredential, false);
                 await client.runtime.info();
-                return client;
-            } catch (e: any) {
-                lastError = e;
-                await sleep(1000);
-            }
-        }
-
-        throw new Error(`API endpoint on port ${port} not ready after ${timeoutMs}ms: ${lastError?.message}`);
+                return true;
+            } catch { return false; }
+        }, { timeoutMs, intervalMs: 1000, label: `API endpoint on port ${port} ready` });
+        return client!;
     }
 
     /**
@@ -100,25 +93,12 @@ export class TestCluster {
      * Falls back to runtime.info() if runtimeReadiness is not available.
      */
     async waitForReadiness(node: ClusterNode, timeoutMs: number = 120000): Promise<void> {
-        const start = Date.now();
-
-        while (Date.now() - start < timeoutMs) {
+        await pollUntil(async () => {
             try {
-                // Try the runtimeReadiness probe first (added in this PR)
                 const result = await node.client.runtime.info();
-                if (result.isInitialized && result.isUnlocked) {
-                    // TODO: Switch to runtimeReadiness GQL query once the Ad4mClient
-                    // exposes it. For now, runtime.info() isInitialized+isUnlocked is
-                    // a reasonable proxy (readiness probe checks the same underlying state).
-                    return;
-                }
-            } catch (e) {
-                // Not ready yet
-            }
-            await sleep(2000);
-        }
-
-        throw new Error(`Node on port ${node.apiPort} not fully ready after ${timeoutMs}ms`);
+                return !!(result.isInitialized && result.isUnlocked);
+            } catch { return false; }
+        }, { timeoutMs, intervalMs: 2000, label: `node on port ${node.apiPort} fully ready` });
     }
 
     /**

--- a/tests/js/utils/utils.ts
+++ b/tests/js/utils/utils.ts
@@ -351,6 +351,59 @@ export function sleep(ms: number) {
 }
 
 /**
+ * Poll a predicate until it returns true, or throw after `timeoutMs`.
+ *
+ * Replaces the `await sleep(N); expect(x)` pattern: the test completes as
+ * soon as the condition holds (fast path) and only fails after a bounded
+ * timeout (no flake from "sleep wasn't long enough").
+ *
+ * The predicate may be sync or async. Exceptions from it are treated as
+ * "not yet true" so an API call that throws while the executor is still
+ * starting doesn't have to be wrapped by the caller.
+ */
+export async function pollUntil(
+    predicate: () => boolean | Promise<boolean>,
+    opts: { timeoutMs?: number; intervalMs?: number; label?: string } = {},
+): Promise<void> {
+    const { timeoutMs = 15000, intervalMs = 200, label = "condition" } = opts;
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        try {
+            if (await predicate()) return;
+        } catch { /* treat as "not yet" */ }
+        await sleep(intervalMs);
+    }
+    throw new Error(`pollUntil timed out after ${timeoutMs}ms waiting for: ${label}`);
+}
+
+/**
+ * Actively polls a predicate and fails immediately if it ever becomes true.
+ * Returns successfully when the wait period expires without the predicate
+ * firing — use this for negative assertions ("X should NOT happen").
+ *
+ * This replaces `await sleep(N); expect(x).to.be.false` with an approach
+ * that catches transient true states and can use a shorter wait window.
+ */
+export async function assertStaysFalse(
+    predicate: () => boolean | Promise<boolean>,
+    opts: { waitMs?: number; intervalMs?: number; label?: string } = {},
+): Promise<void> {
+    const { waitMs = 1000, intervalMs = 100, label = "condition" } = opts;
+    const deadline = Date.now() + waitMs;
+    while (Date.now() < deadline) {
+        try {
+            if (await predicate()) {
+                throw new Error(`assertStaysFalse failed: ${label} became true`);
+            }
+        } catch (e: any) {
+            if (e.message?.startsWith("assertStaysFalse failed:")) throw e;
+            /* treat other exceptions as "not yet evaluable" */
+        }
+        await sleep(intervalMs);
+    }
+}
+
+/**
  * Clears all links in a perspective in a single removeLinks() batch call.
  * Import from here or from helpers/assertions to get a clean slate before each test.
  */


### PR DESCRIPTION
### What

This PR replaces ~60 `sleep()` calls across the JS integration test suite with assertion-based polling via `pollUntil()` and `assertStaysFalse()`.

### Why

Fixed `sleep()` delays make tests both slow and flaky: too short and the test fails non-deterministically; too long and CI wastes minutes. Polling for observable state changes lets tests complete as soon as the condition holds (fast path) and only fail after a bounded timeout (no false negatives from "sleep wasn't long enough").

### How

#### New utilities (`tests/js/utils/utils.ts`)

- **`pollUntil(predicate, opts)`** — polls at `intervalMs` (default 200ms) until the predicate returns `true` or `timeoutMs` expires. Exceptions from the predicate count as "not yet true" — an API call that throws while the executor starts does not require caller-side wrapping. Includes a `label` for readable timeout errors.
- **`assertStaysFalse(predicate, opts)`** — actively polls and fails immediately if the predicate ever becomes true during the wait window. Replaces the `await sleep(N); expect(x).to.be.false` pattern for negative assertions.

#### Converted patterns

| Pattern | Before | After |
|---|---|---|
| DHT gossip | `sleep(15000); otherAgents()` | `pollUntil(() => otherAgents().length > 0)` |
| Perspective sync | `sleep(5000); queryLinks()` | `pollUntil(() => links.length >= N)` |
| Agent info exchange | 5-attempt retry loop with `sleep(3000)` | `pollUntil` with 15s timeout, 3s interval |
| User stats | `sleep(5000); getStats()` | `pollUntil(() => stats.perspectiveCount > 0)` |
| Agent publishing | `sleep(2000); byDID()` | `pollUntil(() => byDID() !== null)` |
| Signal delivery | `sleep(1000); signals.length` | `pollUntil(() => signals.length >= N)` |
| Negative checks | `sleep(2000); expect(x).to.be.false` | `assertStaysFalse(() => x, { waitMs: 2000 })` |

#### Kept necessary sleeps

Some delays have no observable ready-state to poll:
- **Subscription-init delays** — SPARQL change-watchers register asynchronously with no "ready" signal.
- **K2 DHT space initialization** — after `joinFromUrl` + `makeAllNodesKnown`, K2 spaces need time to stabilize before watchers start.
- **Multi-round agent info exchange** — Holochain K2 needs repeated exchanges, not just first success. The 15s gossip propagation window before polling `otherAgents()` stays.

#### Files changed (28 files, +695 / -761)

| Area | Files |
|---|---|
| Utilities | `tests/js/utils/utils.ts` (+53 lines: `pollUntil`, `assertStaysFalse`) |
| Test context | `tests/js/tests/test-context.ts` (retry loops → `pollUntil`) |
| Neighbourhood | `tests/js/tests/neighbourhood.ts` (Alice wiring poll + Bob link poll) |
| Multi-user | `tests/js/tests/multi-user-simple.test.ts`, `triple-agent-test.ts`, `cross-peer-shape-sync.ts` |
| Auto-processor | `tests/js/tests/auto-processor-neighbourhood.ts`, `auto-processor-multi-user.test.ts` |
| MCP | `tests/js/tests/mcp-auth.test.ts`, `mcp-http.test.ts`, `mcp-mcporter.test.ts`, `mcp-neighbourhood.test.ts` |
| Single-agent | `tests/js/tests/agent.ts`, `agent-language.ts`, `language.ts`, `perspective.ts`, `runtime.ts`, `prolog-and-literals.test.ts`, `ai.ts` |
| Other | `tests/js/tests/authentication.test.ts`, `email-verification.test.ts`, `tests/js/utils/testCluster.ts`, `tests/js/utils/publishTestLangs.ts` |

#### References

- Stacked on [#918](https://github.com/coasys/ad4m/pull/918) (local bootstrap languages)
