### PR TITLE
Feature: Auto processor observability extras

### DIFF
--- a/core/src/perspectives/AutoProcessor.ts
+++ b/core/src/perspectives/AutoProcessor.ts
@@ -187,8 +187,8 @@ export interface RunInterpretationObserveOptions {
    * Also emit `llmRequestSent` / `llmResponseReceived` with the raw prompt
    * and response. Default `false`. These never persist on a one-shot pass —
    * there is no `AutoProcessorConfig` to carry a `persistDebug` opt-in, and
-   * writing tens of KB of prompt into the shared graph on every button press
-   * is not a default worth having.
+   * writing tens of KB of prompt into the shared graph on every call is not a
+   * default worth having.
    */
   emitDebugEvents?: boolean;
 }

--- a/core/src/perspectives/AutoProcessor.ts
+++ b/core/src/perspectives/AutoProcessor.ts
@@ -40,6 +40,25 @@ export type RawScope = { id: string; predicate: string };
  * - `batchReady` → `notCandidate`    — this peer stood down for an earlier author
  * - `claimed` → `shapesMissing`      — a configured class shape hasn't synced
  * - `claimed` → `emptyTranscript`    — the batch drained empty
+ * - any → `failed`                   — the model errored or timed out;
+ *   `detail` carries why. Distinct from the two above, which are the pass
+ *   correctly finding nothing to do — reporting "nothing to extract" when
+ *   the LLM endpoint was unreachable points someone at their transcript
+ *   instead of at their model settings.
+ *
+ * ## Lifecycle (one-shot `runInterpretation`)
+ *
+ * A one-shot pass emits nothing unless the caller passes `observe` (see
+ * {@link PerspectiveProxy.runInterpretation}). With it:
+ *
+ * `runningInterpretation` → [`llmRequestSent` → `llmResponseReceived`] →
+ * `processed` | `failed`
+ *
+ * — plus `claimed` → `finished`/`abandoned` on the neighbourhood stream, so
+ * one-shot and watch passes render through the same consumer code. There is
+ * no `batchReady`, `gatheringTranscript` or claim: the caller supplied the
+ * transcript, and `processorId`/`batchKey` both carry the caller's own
+ * `observationId`.
  *
  * ## Payload fields per step
  *
@@ -49,6 +68,7 @@ export type RawScope = { id: string; predicate: string };
  *
  * - `backedOff`, `notCandidate`         → `detail` = holder / elected-author DID
  * - `shapesMissing`                     → `detail` = comma-joined missing class URIs
+ * - `failed`                            → `detail` = the error
  * - `llmRequestSent`                    → `llmInput` = raw prompt
  * - `llmResponseReceived`               → `llmOutput` = raw LLM response
  * - `processed`                         → `bases[]` = new/updated instance URIs
@@ -65,7 +85,8 @@ export type AutoProcessorStep =
   | "llmResponseReceived"
   | "processed"
   | "shapesMissing"
-  | "emptyTranscript";
+  | "emptyTranscript"
+  | "failed";
 
 /** A single step-signal from one auto-processor pass on one perspective. */
 export interface AutoProcessorEvent {
@@ -139,6 +160,37 @@ export interface AutoProcessorNeighbourhoodStateEvent {
    *  for the same key to render a single row in a UI. */
   batchKey: string;
   phase: NeighbourhoodPhase;
+}
+
+/**
+ * Opt a one-shot `runInterpretation` call into the same event streams a
+ * standing watch produces.
+ *
+ * Without it the call is silent until it resolves — which, on a local model,
+ * is minutes of a UI having nothing to say. With it the pass reports
+ * `runningInterpretation` → `processed`/`failed` on the DID-scoped stream and
+ * `claimed` → `finished`/`abandoned` on the perspective-scoped one.
+ */
+export interface RunInterpretationObserveOptions {
+  /**
+   * The caller's own id for this pass, echoed back as both `processorId` and
+   * `batchKey` on every event it emits.
+   *
+   * Supplied by the caller rather than minted by the executor because
+   * `runInterpretation` is a single blocking call: there is no earlier
+   * response that could hand back a server-side id, so the events would
+   * arrive with nothing to match them against. Any value unique among this
+   * client's in-flight passes will do.
+   */
+  observationId: string;
+  /**
+   * Also emit `llmRequestSent` / `llmResponseReceived` with the raw prompt
+   * and response. Default `false`. These never persist on a one-shot pass —
+   * there is no `AutoProcessorConfig` to carry a `persistDebug` opt-in, and
+   * writing tens of KB of prompt into the shared graph on every button press
+   * is not a default worth having.
+   */
+  emitDebugEvents?: boolean;
 }
 
 /** Configuration for `perspective.addAutoProcessor` (everything but `uuid`). */

--- a/core/src/perspectives/AutoProcessor.ts
+++ b/core/src/perspectives/AutoProcessor.ts
@@ -43,7 +43,8 @@ export type RawScope = { id: string; predicate: string };
  *
  * ## Payload fields per step
  *
- * All steps carry `perspectiveUuid`, `processorId`, `agentDid`, `itemIds[]`.
+ * All steps carry `perspectiveUuid`, `processorId`, `agentDid`, `itemIds[]`
+ * and `batchKey` (the join key to the neighbourhood-state stream).
  * Additional payload:
  *
  * - `backedOff`, `notCandidate`         → `detail` = holder / elected-author DID
@@ -76,6 +77,24 @@ export interface AutoProcessorEvent {
   step: AutoProcessorStep;
   /** The batch's source item ids (present from `batchReady` onward). */
   itemIds: string[];
+  /**
+   * Content hash of the batch — the same value
+   * {@link AutoProcessorNeighbourhoodStateEvent.batchKey} carries, and the
+   * key that joins the two streams.
+   *
+   * A UI that renders one row per pass subscribes to both: the
+   * perspective-scoped neighbourhood stream opens the row (and names the
+   * claimant), while this DID-scoped stream fills in the fine-grained
+   * steps and LLM I/O for the pass this agent is running. Matching them on
+   * `processorId` alone breaks as soon as a processor runs a second pass;
+   * matching on `itemIds` means re-implementing the Rust SHA-256 and its
+   * exact serialization. So both streams carry the same key.
+   *
+   * Present from `batchReady` onward. Optional on the type because a
+   * pre-#903 executor does not send it — treat its absence as "cannot
+   * correlate", not as an error.
+   */
+  batchKey?: string;
   /** Instance base URIs written by the pass (present on `processed`). */
   bases: string[];
   /** Free-form context for the step (a holder/elected DID, an error, …). */

--- a/core/src/perspectives/PerspectiveClient.ts
+++ b/core/src/perspectives/PerspectiveClient.ts
@@ -11,7 +11,7 @@ import { LinkStatus, PerspectiveProxy } from './PerspectiveProxy';
 import { AIClient } from "../ai/AIClient";
 import { AllInstancesResult } from "../model/types";
 import type { TranscriptTurn } from "../generated/api";
-import type { AddAutoProcessorConfig, AutoProcessorEvent, AutoProcessorNeighbourhoodStateEvent, InterpretationOverlayInfo, RawScope } from "./AutoProcessor";
+import type { AddAutoProcessorConfig, AutoProcessorEvent, AutoProcessorNeighbourhoodStateEvent, InterpretationOverlayInfo, RawScope, RunInterpretationObserveOptions } from "./AutoProcessor";
 
 export type PerspectiveHandleCallback = (perspective: PerspectiveHandle) => null
 export type UuidCallback = (uuid: string) => null
@@ -275,11 +275,22 @@ export class PerspectiveClient {
         classes?: string[],
         existingScope?: RawScope,
         mintScope?: RawScope,
+        observe?: RunInterpretationObserveOptions,
     ): Promise<string[]> {
         const RUN_INTERPRETATION_TIMEOUT_MS = 20 * 60 * 1000
         return this.#apiClient.call<string[]>(
             'perspective.runInterpretation',
-            { uuid, transcript, basePrefix, classes, existingScope, mintScope },
+            {
+                uuid, transcript, basePrefix, classes, existingScope, mintScope,
+                // Spread rather than always-present, so a client talking to a pre-#903
+                // executor sends exactly the params it sent before. `serde` would ignore
+                // the extra keys anyway; keeping the wire identical means a bug report
+                // from an older node cannot be about these.
+                ...(observe ? {
+                    observationId: observe.observationId,
+                    emitDebugEvents: observe.emitDebugEvents ?? false,
+                } : {}),
+            },
             RUN_INTERPRETATION_TIMEOUT_MS,
         )
     }

--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -16,7 +16,7 @@ import type { TranscriptTurn } from "../generated/api";
 
 import { SHACLShape } from "../shacl/SHACLShape";
 import { SHACLFlow, LinkPattern } from "../shacl/SHACLFlow";
-import type { AddAutoProcessorConfig, AutoProcessorEvent, AutoProcessorNeighbourhoodStateEvent, InterpretationOverlayInfo } from "./AutoProcessor";
+import type { AddAutoProcessorConfig, AutoProcessorEvent, AutoProcessorNeighbourhoodStateEvent, InterpretationOverlayInfo, RawScope, RunInterpretationObserveOptions } from "./AutoProcessor";
 
 type QueryCallback = (result: AllInstancesResult) => void;
 
@@ -561,8 +561,30 @@ export class PerspectiveProxy {
      * @param basePrefix URI namespace for new instance identities, e.g. `soa://ext/`
      * @param classes local names of the subject classes to extract into; omit for all
      */
-    async runInterpretation(transcript: TranscriptTurn[], basePrefix: string, classes?: string[]): Promise<string[]> {
-        return await this.#client.runInterpretation(this.#handle.uuid, transcript, basePrefix, classes)
+    async runInterpretation(
+        transcript: TranscriptTurn[],
+        basePrefix: string,
+        classes?: string[],
+        options?: {
+            existingScope?: RawScope,
+            mintScope?: RawScope,
+            /** Report progress while the pass runs — see {@link RunInterpretationObserveOptions}. */
+            observe?: RunInterpretationObserveOptions,
+        },
+    ): Promise<string[]> {
+        // Grouped into an options bag rather than continuing the client's positional list.
+        // The scopes were already unreachable from here for that reason, and a fourth, fifth and
+        // sixth positional parameter would have made `undefined, undefined, { … }` the normal way
+        // to ask for the only one of them most callers want.
+        return await this.#client.runInterpretation(
+            this.#handle.uuid,
+            transcript,
+            basePrefix,
+            classes,
+            options?.existingScope,
+            options?.mintScope,
+            options?.observe,
+        )
     }
 
     /**

--- a/rust-executor/src/api/perspectives_ws.rs
+++ b/rust-executor/src/api/perspectives_ws.rs
@@ -1114,11 +1114,14 @@ async fn run_interpretation_handler(
     /*
        Live observability for a one-shot pass (#903 follow-up).
 
-       A watch pass is fully observable and a button press was not, which is backwards: the press
-       is the one a person is sitting and waiting on. `observation_id` is the caller's own row id
-       (see `RunInterpretationRequest`), used as both `processor_id` and `batch_key` so a consumer
-       merging the two event streams handles a one-shot pass with the code it already has for a
-       watch pass.
+       A watch pass is fully observable; this path was not. The asymmetry is worth closing because
+       `runInterpretation` is synchronous for the caller — it blocks for the whole pass, which is
+       seconds to minutes on a local model — so it is the path where progress reporting is most
+       useful and the only one that had none.
+
+       `observation_id` is the caller's own identifier (see `RunInterpretationRequest`), used as
+       both `processor_id` and `batch_key` so a consumer merging the two event streams handles a
+       one-shot pass with the code it already has for a watch pass.
 
        Absent = every emit below is skipped and this handler behaves exactly as it did.
     */

--- a/rust-executor/src/api/perspectives_ws.rs
+++ b/rust-executor/src/api/perspectives_ws.rs
@@ -1111,6 +1111,57 @@ async fn run_interpretation_handler(
         std::collections::HashSet::new()
     };
 
+    /*
+       Live observability for a one-shot pass (#903 follow-up).
+
+       A watch pass is fully observable and a button press was not, which is backwards: the press
+       is the one a person is sitting and waiting on. `observation_id` is the caller's own row id
+       (see `RunInterpretationRequest`), used as both `processor_id` and `batch_key` so a consumer
+       merging the two event streams handles a one-shot pass with the code it already has for a
+       watch pass.
+
+       Absent = every emit below is skipped and this handler behaves exactly as it did.
+    */
+    let observation = body.observation_id.clone();
+    let observer_did = match observation.as_ref() {
+        // Best-effort: telemetry must never be the reason a pass refuses to run, so an
+        // unresolvable DID downgrades to no observation rather than to an error.
+        Some(_) => crate::agent::did_for_context(&agent_context).ok(),
+        None => None,
+    };
+    let observe = observation.as_ref().zip(observer_did.as_ref());
+    let emit_ctx = observe
+        .filter(|_| body.emit_debug_events.unwrap_or(false))
+        .map(
+            |(id, did)| crate::perspectives::auto_processor::events::InterpretationEmitContext {
+                perspective_uuid: uuid.clone(),
+                processor_id: id.clone(),
+                agent_did: did.clone(),
+                // No source item ids: the caller supplied the transcript directly rather than the
+                // watcher gathering it, so there is nothing to list. `batch_key` carries the identity
+                // instead — which is why it is a separate field rather than derived from these.
+                item_ids: Vec::new(),
+                batch_key: id.clone(),
+            },
+        );
+
+    if let Some((id, did)) = observe {
+        emit_one_shot_step(
+            &uuid,
+            id,
+            did,
+            crate::perspectives::auto_processor::events::AutoProcessorStep::RunningInterpretation,
+        )
+        .await;
+        emit_one_shot_phase(
+            &uuid,
+            id,
+            did,
+            crate::perspectives::auto_processor::events::NeighbourhoodPhase::Claimed,
+        )
+        .await;
+    }
+
     // Bound the LLM call: a stalled provider must not pin a WS request slot
     // indefinitely. Matches the pattern used by `query_sparql` /
     // `model_query_handler` / `evaluate_getters_handler`, but with a longer
@@ -1118,7 +1169,7 @@ async fn run_interpretation_handler(
     // `RUN_INTERPRETATION_TIMEOUT_SECS`).
     let bases = match tokio::time::timeout(
         Duration::from_secs(RUN_INTERPRETATION_TIMEOUT_SECS),
-        crate::perspectives::interpretation::run_interpretation(
+        crate::perspectives::interpretation::run_interpretation_observed(
             &mut perspective,
             &shapes,
             &transcript,
@@ -1130,17 +1181,36 @@ async fn run_interpretation_handler(
             // `None` keeps the whole-perspective dedup set — the
             // pre-scope default that #883 originally added the plumbing for.
             body.existing_scope.as_ref(),
+            emit_ctx.as_ref(),
         ),
     )
     .await
     {
         Ok(Ok(bases)) => bases,
-        Ok(Err(e)) => return Err(WsRpcError::internal(e.to_string())),
+        Ok(Err(e)) => {
+            // Both failure arms close the row before returning. A consumer that opened one on
+            // `Claimed` and never heard again would show a pass running forever — and the two
+            // cases a person most wants to see reported (the model errored, the model hung) are
+            // exactly the two that would hang the UI instead.
+            if let Some((id, did)) = observe {
+                emit_one_shot_abandoned(&uuid, id, did, &e.to_string()).await;
+            }
+            return Err(WsRpcError::internal(e.to_string()));
+        }
         Err(_) => {
             log::warn!(
                 "run_interpretation timed out after {}s",
                 RUN_INTERPRETATION_TIMEOUT_SECS
             );
+            if let Some((id, did)) = observe {
+                emit_one_shot_abandoned(
+                    &uuid,
+                    id,
+                    did,
+                    &format!("timed out after {RUN_INTERPRETATION_TIMEOUT_SECS}s"),
+                )
+                .await;
+            }
             return Err(WsRpcError {
                 code: 408,
                 message: format!(
@@ -1182,7 +1252,103 @@ async fn run_interpretation_handler(
         }
     }
 
+    // Emitted after the mint-scope links are written, not before: `Processed` carries the bases,
+    // and a consumer that reads it as "these records exist and are attached" would be reading it
+    // half a write early if it fired the moment interpretation returned.
+    if let Some((id, did)) = observe {
+        emit_one_shot_bases(&uuid, id, did, &bases).await;
+        emit_one_shot_phase(
+            &uuid,
+            id,
+            did,
+            crate::perspectives::auto_processor::events::NeighbourhoodPhase::Finished,
+        )
+        .await;
+    }
+
     Ok(serde_json::to_value(bases)?)
+}
+
+/*
+   One-shot telemetry helpers.
+
+   Separate functions rather than the `signal!` macro the watcher uses, because the two differ in
+   what they can assume: the watcher has a `cfg`, a claim and a gathered batch in scope, and its
+   macro reads all three. Here there is one caller-supplied id standing in for all of it.
+
+   `processor_id` and `batch_key` are deliberately the same value. The pair means "which standing
+   processor" and "which batch of its work" — a distinction a one-shot pass does not have, and
+   collapsing them is more honest than minting a second id that would always be 1:1 with the first.
+*/
+
+/// A lifecycle step with no payload beyond identity.
+async fn emit_one_shot_step(
+    uuid: &str,
+    observation_id: &str,
+    did: &str,
+    step: crate::perspectives::auto_processor::events::AutoProcessorStep,
+) {
+    use crate::perspectives::auto_processor::events::{emit, AutoProcessorEvent};
+    emit(
+        AutoProcessorEvent::new(uuid, observation_id, step)
+            .with_agent_did(did)
+            .with_batch_key(observation_id),
+    )
+    .await;
+}
+
+/// `Processed`, carrying what the pass wrote.
+async fn emit_one_shot_bases(uuid: &str, observation_id: &str, did: &str, bases: &[String]) {
+    use crate::perspectives::auto_processor::events::{
+        emit, AutoProcessorEvent, AutoProcessorStep,
+    };
+    emit(
+        AutoProcessorEvent::new(uuid, observation_id, AutoProcessorStep::Processed)
+            .with_agent_did(did)
+            .with_batch_key(observation_id)
+            .with_bases(bases),
+    )
+    .await;
+}
+
+/// A perspective-scoped phase transition, so peers see the pass without seeing its payload.
+async fn emit_one_shot_phase(
+    uuid: &str,
+    observation_id: &str,
+    did: &str,
+    phase: crate::perspectives::auto_processor::events::NeighbourhoodPhase,
+) {
+    use crate::perspectives::auto_processor::events::{
+        emit_neighbourhood_state, AutoProcessorNeighbourhoodState,
+    };
+    emit_neighbourhood_state(AutoProcessorNeighbourhoodState::new(
+        uuid,
+        observation_id,
+        did,
+        observation_id,
+        phase,
+    ))
+    .await;
+}
+
+/// Both halves of a failure: the reason on the owner's stream, the bare fact on everyone's.
+///
+/// Split that way because `detail` is where an LLM provider's error text ends up, and that can
+/// name a model, an endpoint or an account. The neighbourhood stream carries no free-form field
+/// at all, which is what keeps this honest — peers learn the pass ended without committing, and
+/// the person who ran it learns why.
+async fn emit_one_shot_abandoned(uuid: &str, observation_id: &str, did: &str, reason: &str) {
+    use crate::perspectives::auto_processor::events::{
+        emit, AutoProcessorEvent, AutoProcessorStep, NeighbourhoodPhase,
+    };
+    emit(
+        AutoProcessorEvent::new(uuid, observation_id, AutoProcessorStep::Failed)
+            .with_agent_did(did)
+            .with_batch_key(observation_id)
+            .with_detail(reason),
+    )
+    .await;
+    emit_one_shot_phase(uuid, observation_id, did, NeighbourhoodPhase::Abandoned).await;
 }
 
 /// Register a neighbourhood auto-processor on a perspective. Writes the

--- a/rust-executor/src/api/types.rs
+++ b/rust-executor/src/api/types.rs
@@ -569,6 +569,32 @@ pub struct RunInterpretationRequest {
     #[serde(default)]
     #[ts(optional, type = "any")]
     pub mint_scope: Option<crate::perspectives::model_query::types::Scope>,
+    /// Opt into live observability for this one-shot pass, under an id the
+    /// **caller** chooses.
+    ///
+    /// A watch pass is identified by its `batch_key` — a hash of the source
+    /// items the watcher gathered. A one-shot pass has neither: the caller
+    /// supplies the transcript directly, so there are no source item ids to
+    /// hash and no claim to key off. Rather than invent a server-side id the
+    /// caller would then have to correlate by guesswork (the pass is one
+    /// blocking RPC, so there is no earlier response to carry it), the caller
+    /// names the pass and gets its own id back on every event.
+    ///
+    /// Present: the pass emits `RunningInterpretation` → `Processed` on the
+    /// `auto-processor-event` topic, plus `Claimed` → `Finished`/`Abandoned`
+    /// on the neighbourhood topic, all carrying this value as both
+    /// `processor_id` and `batch_key`. Absent: the pass is silent, exactly as
+    /// before — no existing caller changes behaviour.
+    #[serde(default)]
+    #[ts(optional)]
+    pub observation_id: Option<String>,
+    /// Emit `LlmRequestSent` / `LlmResponseReceived` (carrying the raw prompt
+    /// and response) for this pass. Ignored without `observation_id` — there
+    /// would be nothing to correlate the payloads to. Same switch, same
+    /// reasons, as `AutoProcessorConfig.emit_debug_events`.
+    #[serde(default)]
+    #[ts(optional)]
+    pub emit_debug_events: Option<bool>,
 }
 
 /// Register a neighbourhood auto-processor on a perspective. The executor's

--- a/rust-executor/src/perspectives/auto_processor/config.rs
+++ b/rust-executor/src/perspectives/auto_processor/config.rs
@@ -34,6 +34,31 @@ use crate::perspectives::perspective_instance::{PerspectiveInstance, SubjectClas
 use super::scalar_string;
 use crate::perspectives::hardwired_class::{ensure_subject_class, subject_class_registered};
 
+/// Instances already reported as unloadable, so each is complained about once.
+///
+/// The watch loop polls `load_processors` several times a second on every perspective, and a
+/// rejected instance is rejected identically every time — so an unthrottled warning emits the same
+/// line thousands of times a minute, per instance. That is not merely untidy: it buries the log a
+/// person is reading to find out *why*, which is the exact situation the warning exists to serve.
+///
+/// Keyed by instance URI and never cleared. A processor whose config is repaired starts loading and
+/// stops reaching this path at all; one that is deleted never returns. The set is therefore bounded
+/// by the number of distinct broken instances, which is small and finite.
+static REPORTED_BAD_INSTANCES: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashSet<String>>,
+> = std::sync::OnceLock::new();
+
+/// Whether this is the first time this instance has failed to load.
+fn first_report_for(instance_id: &str) -> bool {
+    REPORTED_BAD_INSTANCES
+        .get_or_init(Default::default)
+        .lock()
+        .map(|mut seen| seen.insert(instance_id.to_string()))
+        // A poisoned mutex means another thread panicked mid-report. Log rather than swallow: a
+        // repeated line is a smaller problem than a silent one.
+        .unwrap_or(true)
+}
+
 /// Local subject-class name of a processor config.
 pub(crate) const AUTO_PROCESSOR_CLASS: &str = "AutoProcessor";
 /// Target-class URI of [`AUTO_PROCESSOR_CLASS`] — used to detect prior
@@ -395,11 +420,37 @@ pub async fn load_processors(
     for instance in result["instances"].as_array().into_iter().flatten() {
         match config_from_instance(instance) {
             Some(cfg) => out.push(cfg),
-            None => log::warn!(
-                "load_processors: AutoProcessor instance `{}` has missing / unparseable \
-                 fields; skipping",
-                instance["id"].as_str().unwrap_or("<no id>")
-            ),
+            /*
+               The instance itself, not just the fact that it failed.
+
+               "has missing / unparseable fields" names neither the field nor its value, and this
+               fires once per watch tick forever — so the symptom is an endless stream of a message
+               that cannot be acted on. Diagnosing one meant reading three files and guessing, and
+               the guesses were wrong twice.
+
+               Every branch that returns `None` from `config_from_instance` is a statement about one
+               property's value, so printing the whole instance answers the question outright: which
+               field is absent, and how the ones that are present are actually encoded. That second
+               half matters more than it looks — a scalar that arrives in an unexpected encoding
+               reads as "missing" here, and nothing else in the message would distinguish the two.
+
+               At `warn` alongside the existing line rather than `debug`, because a processor that
+               silently stops running is exactly the situation where nobody has debug logging on
+               yet, and the instance is a few hundred bytes once per skip.
+            */
+            None => {
+                let id = instance["id"].as_str().unwrap_or("<no id>");
+                if first_report_for(id) {
+                    log::warn!(
+                        "load_processors: AutoProcessor instance `{}` has missing / unparseable \
+                         fields; skipping (further occurrences suppressed). Instance as read: {}",
+                        id,
+                        instance
+                    );
+                } else {
+                    log::debug!("load_processors: still skipping `{}`", id);
+                }
+            }
         }
     }
     out.sort_by(|a, b| a.processor_id.cmp(&b.processor_id));

--- a/rust-executor/src/perspectives/auto_processor/config.rs
+++ b/rust-executor/src/perspectives/auto_processor/config.rs
@@ -30,6 +30,7 @@
 use crate::agent::AgentContext;
 use crate::perspectives::model_query::types::Scope;
 use crate::perspectives::perspective_instance::{PerspectiveInstance, SubjectClassOption};
+use crate::types::{Link, LinkStatus};
 
 use super::scalar_string;
 use crate::perspectives::hardwired_class::{ensure_subject_class, subject_class_registered};
@@ -244,12 +245,14 @@ pub async fn write_processor(
     emit_debug_events_write: Option<bool>,
     context: &AgentContext,
 ) -> anyhow::Result<()> {
-    let Some((first_class, more_classes)) = cfg.interpretation_classes.split_first() else {
+    // Emptiness is still a hard error — a processor with no classes materialises nothing — but the
+    // members themselves are written as links below rather than through the values map.
+    if cfg.interpretation_classes.is_empty() {
         anyhow::bail!(
             "write_processor: `{}` has no interpretation_classes",
             cfg.processor_id
         );
-    };
+    }
     ensure_auto_processor_class(perspective, context).await?;
 
     let node = processor_node(&cfg.processor_id);
@@ -261,7 +264,6 @@ pub async fn write_processor(
     let mut values = serde_json::json!({
         "processorId": cfg.processor_id,
         "sourceScopeQuery": cfg.source_scope_query,
-        "interpretationClasses": first_class,
         "debounceMs": cfg.debounce_ms.to_string(),
         "batchMin": cfg.batch_min.to_string(),
         "batchMax": cfg.batch_max.to_string(),
@@ -328,22 +330,41 @@ pub async fn write_processor(
             )
             .await
             .map_err(|e| anyhow::anyhow!("write_processor: create_subject failed: {e:#}"))?;
-        // `create_subject` applies one value per property, so the remaining
-        // members of the `interpretation_class` collection go through the same
-        // `addLink` setter one at a time — still on the same batch so they
-        // commit atomically with the base instance.
-        for class in more_classes {
+        /*
+           The classes are written as links, not through the values map.
+
+           `create_subject` and `update_subject` resolve a property by looking up its
+           `ad4m://setter` actions, and a *collection* has none — it carries `ad4m://adder`
+           instead. So every value handed to them for `interpretationClasses` was silently
+           discarded, and the instance came back without the one property `load_processors`
+           requires first. Every scalar landed, so the write reported success and the failure
+           surfaced only as the reader calling the instance malformed, once per watch tick,
+           forever.
+
+           Adding the links directly is what the collection's own `addLink` action would do,
+           and it needs no shape lookup to get there. Same batch as the instance, so the classes
+           and the config it belongs to still commit atomically — a half-written processor is
+           precisely the state that produced this bug.
+
+           `Shared`, matching every other link this class writes: the processor set is neighbourhood
+           state, and a local-only class list would make one peer's view of what to extract differ
+           from everyone else's.
+        */
+        for class in cfg.interpretation_classes.iter() {
             perspective
-                .update_subject(
-                    class_option(),
-                    node.clone(),
-                    serde_json::json!({ "interpretationClasses": class }),
+                .add_link(
+                    Link {
+                        source: node.clone(),
+                        predicate: Some("ad4m://interpretation_class".to_string()),
+                        target: format!("literal:string:{}", class),
+                    },
+                    LinkStatus::Shared,
                     Some(batch_id.clone()),
                     context,
                 )
                 .await
                 .map_err(|e| {
-                    anyhow::anyhow!("write_processor: update_subject(class) failed: {e:#}")
+                    anyhow::anyhow!("write_processor: add_link(interpretation_class) failed: {e:#}")
                 })?;
         }
         Ok(())

--- a/rust-executor/src/perspectives/auto_processor/events.rs
+++ b/rust-executor/src/perspectives/auto_processor/events.rs
@@ -82,6 +82,20 @@ pub struct AutoProcessorEvent {
     /// The batch's source item ids (present from `BatchReady` onward).
     #[serde(default)]
     pub item_ids: Vec<String>,
+    /// Content hash of the batch — the same
+    /// [`super::claim::batch_key`] value the perspective-scoped
+    /// [`AutoProcessorNeighbourhoodState`] carries.
+    ///
+    /// Present from `BatchReady` onward, and it is what makes the two
+    /// streams joinable. Without it a consumer holding both has no way to
+    /// say "this `LlmRequestSent` belongs to the row I opened on that
+    /// `Claimed`" — the fine-grained stream carries `item_ids` and the
+    /// neighbourhood stream carries only the hash of them, so correlating
+    /// meant re-implementing this hash client-side and matching the Rust
+    /// serialization exactly. A consumer that merges a peer's coarse
+    /// phases with its own fine ones needs one shared key, and this is it.
+    #[serde(default)]
+    pub batch_key: Option<String>,
     /// Instance base URIs written by the pass (present on `Processed`).
     #[serde(default)]
     pub bases: Vec<String>,
@@ -114,6 +128,7 @@ impl AutoProcessorEvent {
             agent_did: None,
             step,
             item_ids: Vec::new(),
+            batch_key: None,
             bases: Vec::new(),
             detail: None,
             llm_input: None,
@@ -126,6 +141,15 @@ impl AutoProcessorEvent {
     }
     pub fn with_items(mut self, item_ids: &[String]) -> Self {
         self.item_ids = item_ids.to_vec();
+        self
+    }
+    /// Tag this event with the batch it belongs to, so a consumer can join
+    /// it to the perspective-scoped neighbourhood stream. Callers pass the
+    /// [`super::claim::batch_key`] of the same `item_ids` — derived once
+    /// per pass rather than recomputed per event, since the hash is over a
+    /// set that does not change mid-pass.
+    pub fn with_batch_key(mut self, batch_key: &str) -> Self {
+        self.batch_key = Some(batch_key.to_string());
         self
     }
     pub fn with_bases(mut self, bases: &[String]) -> Self {
@@ -323,4 +347,10 @@ pub struct InterpretationEmitContext {
     pub processor_id: String,
     pub agent_did: String,
     pub item_ids: Vec<String>,
+    /// The pass's batch key, so the mid-pass LLM events join to the same
+    /// row as the watcher's own signals. Carried here rather than
+    /// recomputed from `item_ids` because the caller already has it, and
+    /// because the one-shot path (which has no claim and no batch) supplies
+    /// a synthetic key instead — see `run_interpretation_handler`.
+    pub batch_key: String,
 }

--- a/rust-executor/src/perspectives/auto_processor/events.rs
+++ b/rust-executor/src/perspectives/auto_processor/events.rs
@@ -63,6 +63,16 @@ pub enum AutoProcessorStep {
     ShapesMissing,
     /// Won the claim, but the batch transcript was empty — nothing to interpret.
     EmptyTranscript,
+    /// The pass ran and did not complete: the model errored, the provider
+    /// timed out, or a write failed. `detail` carries the reason.
+    ///
+    /// Distinct from [`AutoProcessorStep::EmptyTranscript`] and
+    /// [`AutoProcessorStep::ShapesMissing`], which are the pass correctly
+    /// deciding there is nothing to do. Those are answers; this is a
+    /// failure, and a UI reporting "nothing to extract" when the LLM
+    /// endpoint was unreachable sends someone looking at their transcript
+    /// instead of at their model configuration.
+    Failed,
 }
 
 /// A single step-signal from one auto-processor pass on one perspective.

--- a/rust-executor/src/perspectives/auto_processor/watcher.rs
+++ b/rust-executor/src/perspectives/auto_processor/watcher.rs
@@ -477,12 +477,22 @@ pub async fn run_one_pass(
         .map_err(|e| anyhow::anyhow!("run_one_pass: did_for_context: {e:#}"))?;
     let item_ids: Vec<String> = turns.iter().map(|t| t.id.clone()).collect();
     let batch_authors: Vec<String> = turns.iter().map(|t| t.speaker.clone()).collect();
+    /*
+       Derived once, up here, rather than at the claim below where it used to be.
+
+       Every signal this pass emits carries it, including the ones emitted *before* a claim is
+       attempted (`BatchReady`, `NotCandidate`, `AwaitingAuthor`, `BackedOff`). Computing it at
+       the claim would have left exactly the stand-down signals — the ones a consumer most wants
+       to attribute to a batch — as the only ones it could not join to a row.
+    */
+    let batch_key_hex = batch_key(&item_ids);
     macro_rules! signal {
         ($step:expr) => {
             emit(
                 AutoProcessorEvent::new(&uuid, &cfg.processor_id, $step)
                     .with_agent_did(&me)
-                    .with_items(&item_ids),
+                    .with_items(&item_ids)
+                    .with_batch_key(&batch_key_hex),
             )
             .await
         };
@@ -491,6 +501,7 @@ pub async fn run_one_pass(
                 AutoProcessorEvent::new(&uuid, &cfg.processor_id, $step)
                     .with_agent_did(&me)
                     .with_items(&item_ids)
+                    .with_batch_key(&batch_key_hex)
                     .with_detail($d),
             )
             .await
@@ -500,6 +511,7 @@ pub async fn run_one_pass(
                 AutoProcessorEvent::new(&uuid, &cfg.processor_id, $step)
                     .with_agent_did(&me)
                     .with_items(&item_ids)
+                    .with_batch_key(&batch_key_hex)
                     .with_bases($b),
             )
             .await
@@ -602,7 +614,6 @@ pub async fn run_one_pass(
     // from `AutoProcessorStep::Claimed` above (which is DID-scoped and
     // carries the batch payload) — this one is delivered to every reader
     // of the perspective, and carries only the claimant + batch key.
-    let batch_key_hex = batch_key(&item_ids);
     emit_neighbourhood_state(AutoProcessorNeighbourhoodState::new(
         &uuid,
         &cfg.processor_id,
@@ -712,6 +723,7 @@ pub async fn run_one_pass(
             processor_id: cfg.processor_id.clone(),
             agent_did: me.clone(),
             item_ids: item_ids.clone(),
+            batch_key: batch_key_hex.clone(),
         });
     let outcome = run_interpretation_with_strategy_and_model(
         perspective,
@@ -775,6 +787,7 @@ pub async fn run_one_pass(
     let ev = AutoProcessorEvent::new(&uuid, &cfg.processor_id, AutoProcessorStep::Processed)
         .with_agent_did(&me)
         .with_items(&item_ids)
+        .with_batch_key(&batch_key_hex)
         .with_bases(&bases);
     emit(ev).await;
     // Neighbourhood-state: pass complete on this executor. Consumers use

--- a/rust-executor/src/perspectives/interpretation/run.rs
+++ b/rust-executor/src/perspectives/interpretation/run.rs
@@ -328,8 +328,9 @@ pub async fn run_interpretation(
 /// call site spelling out eleven arguments — nine of which are the defaults
 /// [`run_interpretation`] already picks — so the handler either duplicated
 /// those defaults (and drifted from them) or the one-shot path stayed silent.
-/// It stayed silent, which is why pressing Extract produced no observable
-/// progress at all while a standing watch produced a full step stream.
+/// It stayed silent — so a caller blocked on `runInterpretation` observed no
+/// progress at all, while the same work under a standing watch produced a full
+/// step stream.
 pub async fn run_interpretation_observed(
     perspective: &mut PerspectiveInstance,
     shapes: &[ModelShape],
@@ -352,7 +353,7 @@ pub async fn run_interpretation_observed(
         // Never persists. A one-shot pass has no `AutoProcessorConfig` to
         // carry a `persist_debug` opt-in, and defaulting it on would write
         // tens of KB of prompt into the shared graph — syncing to every peer,
-        // permanently — every time somebody pressed a button.
+        // permanently — on every call.
         false,
         emit_ctx,
     )

--- a/rust-executor/src/perspectives/interpretation/run.rs
+++ b/rust-executor/src/perspectives/interpretation/run.rs
@@ -315,6 +315,51 @@ pub async fn run_interpretation(
     .await
 }
 
+/// [`run_interpretation`] with live mid-pass telemetry.
+///
+/// Identical pipeline and defaults to [`run_interpretation`]; the only
+/// difference is that `emit_ctx`, when `Some`, makes the engine emit
+/// `LlmRequestSent` (with the prompt) and `LlmResponseReceived` (with the
+/// response) around the model call.
+///
+/// Exists because the one-shot WS path had no way to reach that plumbing.
+/// The parameters already existed on
+/// [`run_interpretation_with_strategy_and_model`], but reaching them meant a
+/// call site spelling out eleven arguments — nine of which are the defaults
+/// [`run_interpretation`] already picks — so the handler either duplicated
+/// those defaults (and drifted from them) or the one-shot path stayed silent.
+/// It stayed silent, which is why pressing Extract produced no observable
+/// progress at all while a standing watch produced a full step stream.
+pub async fn run_interpretation_observed(
+    perspective: &mut PerspectiveInstance,
+    shapes: &[ModelShape],
+    transcript: &[TranscriptTurn],
+    base_prefix: &str,
+    context: &AgentContext,
+    scope: Option<&Scope>,
+    emit_ctx: Option<&crate::perspectives::auto_processor::events::InterpretationEmitContext>,
+) -> anyhow::Result<Vec<String>> {
+    run_interpretation_with_strategy_and_model(
+        perspective,
+        shapes,
+        transcript,
+        base_prefix,
+        context,
+        &DedupStrategy::default(),
+        None,
+        scope,
+        None,
+        // Never persists. A one-shot pass has no `AutoProcessorConfig` to
+        // carry a `persist_debug` opt-in, and defaulting it on would write
+        // tens of KB of prompt into the shared graph — syncing to every peer,
+        // permanently — every time somebody pressed a button.
+        false,
+        emit_ctx,
+    )
+    .await
+    .map(|out| out.bases)
+}
+
 /// [`run_interpretation`] with an explicit [`DedupStrategy`] — same pipeline,
 /// but the identity-dedup safety net switches between normalized-string
 /// matching (default) and semantic (embedding-based) matching per call.

--- a/rust-executor/src/perspectives/interpretation/run.rs
+++ b/rust-executor/src/perspectives/interpretation/run.rs
@@ -469,6 +469,7 @@ pub async fn run_interpretation_with_strategy_and_model(
                     )
                     .with_agent_did(&ctx.agent_did)
                     .with_items(&ctx.item_ids)
+                    .with_batch_key(&ctx.batch_key)
                     .with_llm_input(prompt.clone()),
                 )
                 .await;
@@ -488,6 +489,7 @@ pub async fn run_interpretation_with_strategy_and_model(
                     )
                     .with_agent_did(&ctx.agent_did)
                     .with_items(&ctx.item_ids)
+                    .with_batch_key(&ctx.batch_key)
                     .with_llm_output(result.text.clone()),
                 )
                 .await;

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -4706,6 +4706,27 @@ impl PerspectiveInstance {
                                 });
                             }
                         }
+                    } else {
+                        /*
+                           A value was supplied for a property with no `ad4m://setter`, and until now
+                           that was silently dropped.
+
+                           Silent is the wrong default here: from the caller's side the write
+                           succeeds — the instance is minted, every other property lands, no error is
+                           returned — and the omission only surfaces much later as whatever reads the
+                           instance back deciding it is malformed. Tracing one of those means working
+                           backwards from a reader to a writer that never complained.
+
+                           Warn rather than fail, because dropping an unknown key is legitimate: a
+                           caller may pass a superset of what a class declares. What is not
+                           legitimate is doing it without saying so.
+                        */
+                        log::warn!(
+                            "create_subject: class `{}` declares no setter for property `{}` — \
+                             the supplied value was NOT written",
+                            class_name,
+                            prop
+                        );
                     }
                 }
             }
@@ -4761,6 +4782,16 @@ impl PerspectiveInstance {
                 let Some(setter_commands) =
                     self.get_property_setter_actions(&class_name, prop).await?
                 else {
+                    // Same silent drop as `create_subject`, same reason for saying so out loud —
+                    // see the comment there. `update_subject` is the path a collection's second and
+                    // subsequent members go through, so a class whose collection has no setter
+                    // loses every one of them here without a word.
+                    log::warn!(
+                        "update_subject: class `{}` declares no setter for property `{}` — \
+                         the supplied value was NOT written",
+                        class_name,
+                        prop
+                    );
                     continue;
                 };
                 let target_value = self

--- a/rust-executor/src/perspectives/perspective_instance.rs
+++ b/rust-executor/src/perspectives/perspective_instance.rs
@@ -5726,11 +5726,17 @@ impl PerspectiveInstance {
             let Some(batch) = watcher.drain_ready_batch(cfg, now_ms) else {
                 continue;
             };
+            // Hoisted above the `BatchReady` emit so that signal can carry the batch key too.
+            // It is the first event of a pass, so a consumer that could not key it would have to
+            // buffer everything until the pass's second event told it what row to open.
+            let item_ids: Vec<String> = batch.iter().map(|t| t.id.clone()).collect();
+            let batch_id = crate::perspectives::auto_processor::claim::batch_key(&item_ids);
             // Signal the batch is ready before the pass runs, so listeners
             // (tests, the WS layer) can await "processing started".
             emit(
                 AutoProcessorEvent::new(&uuid, &cfg.processor_id, AutoProcessorStep::BatchReady)
-                    .with_items(&batch.iter().map(|t| t.id.clone()).collect::<Vec<_>>()),
+                    .with_items(&item_ids)
+                    .with_batch_key(&batch_id),
             )
             .await;
             let mut perspective_clone = self.clone();
@@ -5738,8 +5744,6 @@ impl PerspectiveInstance {
             // elected author past `claim_ttl_ms`, escalate past election straight
             // to the claim (the min-DID claim still prevents doubles among peers
             // that escalate together).
-            let item_ids: Vec<String> = batch.iter().map(|t| t.id.clone()).collect();
-            let batch_id = crate::perspectives::auto_processor::claim::batch_key(&item_ids);
             let escalate = watcher.should_escalate(&batch_id, now_ms, cfg.claim_ttl_ms);
             let outcome = match run_one_pass(
                 &mut perspective_clone,


### PR DESCRIPTION
# Observability follow-ups: joinable event streams, and a one-shot pass that reports

Stacked on **#903**, which has since been merged into this branch. Five commits: two API additions,
one review fix, and two that fix a bug stopping auto-processing outright.

## Summary

#903 gives a UI two event streams and everything it needs to render a live extraction, with two gaps
that only show up once you try to build the UI. We hit both while wiring it into WE's call bar.

**The streams cannot be joined.** They are deliberately scoped differently — one DID-filtered and
detailed, one perspective-scoped and coarse — which is right, and is exactly why a consumer wants
both at once: the perspective-scoped one opens a row and names the claimant, the DID-scoped one
fills in the phases and the LLM payload for the pass this agent is running. But they share no
identifier. The first lists `item_ids`; the second carries a SHA-256 of them. Correlating meant
re-implementing `claim::batch_key` in TypeScript and matching the Rust serialization byte for byte.

**The one-shot path is silent.** #903 makes a *watch* fully observable and leaves
`runInterpretation` emitting nothing at all. Worth closing because that path blocks its caller for
the whole pass — seconds to minutes on a local model — so it is where progress reporting is most
useful and the only one that had none. The plumbing already
existed — `run_interpretation_with_strategy_and_model` takes an `emit_ctx` — but reaching it meant a
call site spelling out eleven arguments, nine of them the defaults `run_interpretation` already
picks, so the handler kept calling the silent wrapper.

Both are additive. Existing callers observe no behaviour change.

**And auto-processing was silently broken.** Found while testing the consumer: a processor's
`interpretationClasses` never reached the graph, so `load_processors` rejected every instance and no
pass ever ran. Cause and fix in section 3 — it is unrelated to the two additions above, but it was
found through them and is fixed here because it makes the feature untestable otherwise.

## Changes

### 1. `batchKey` on `AutoProcessorEvent` (`89e51255`)

**`events.rs`** — new `batch_key: Option<String>` field and a `with_batch_key` builder, plus
`batch_key` on `InterpretationEmitContext` so the engine's mid-pass LLM events carry it too.

**`watcher.rs`** — `batch_key_hex` is derived once at the top of `run_one_pass` and attached by all
three `signal!` arms, by `Processed`, and by the emit context.

Deriving it there rather than at the claim is a second, smaller fix. It used to be computed at
`try_claim`, which left the signals emitted *before* that point — `BatchReady`, `BackedOff`,
`NotCandidate`, `AwaitingAuthor` — as the only ones with no batch to attribute them to. Those are
the ones a consumer most wants attributed: a pass that stands down is otherwise indistinguishable
from one that never ran.

**`perspective_instance.rs`** — the `batch_id` computation is hoisted above the `BatchReady` emit so
the first event of a pass carries the key. Otherwise a consumer has to buffer until the second event
tells it which row to open.

**`AutoProcessor.ts`** — `batchKey?: string`, optional because a pre-#903 executor sends none.
Absence means "cannot correlate", not an error.

### 2. One-shot `runInterpretation` observability (`615a78ed`)

**`run.rs`** — `run_interpretation_observed`: `run_interpretation`'s defaults plus `emit_ctx`. Never
persists debug, because a one-shot pass has no `AutoProcessorConfig` to carry a `persist_debug`
opt-in and defaulting it on would write tens of KB of prompt into the shared graph, syncing to every
peer, on every call.

**`types.rs`** — `RunInterpretationRequest` gains `observation_id` and `emit_debug_events`.

The id comes from the caller rather than the executor because `runInterpretation` is a single
blocking RPC: there is no earlier response that could hand back a server-minted id, so events tagged
with one would arrive with nothing to match them against. It is echoed as both `processor_id` and
`batch_key` — a one-shot pass has no standing processor and no batch, and collapsing the pair is
more honest than minting a second id that would always be 1:1 with the first.

**`perspectives_ws.rs`** — the handler builds an emit context when asked, and emits
`RunningInterpretation` → `Processed`/`Failed` on the DID-scoped stream plus `Claimed` →
`Finished`/`Abandoned` on the perspective-scoped one. Absent `observation_id`, every emit is skipped
and the handler behaves exactly as before.

`Processed` fires *after* the mint-scope links are written, not the moment interpretation returns —
it carries the bases, and a consumer reading that as "these records exist and are attached" would be
reading it half a write early.

**`events.rs`** — new `AutoProcessorStep::Failed`.

The enum could say `EmptyTranscript` and `ShapesMissing`, which are the pass correctly deciding
there is nothing to do, but had no way to say the model errored or timed out. Those were being
reported as the former, which sends someone to re-read their transcript when the actual problem is
their LLM configuration. Two very different messages, and the vocabulary could not tell them apart.

Both failure arms close the neighbourhood row before returning. A consumer that opened one on
`Claimed` and never heard again shows the pass running forever — and an error and a timeout are
precisely the two outcomes worth reporting.

The reason goes only to the owner's stream. Provider error text can name a model, an endpoint or an
account; the neighbourhood stream has no free-form field at all, which is what keeps that honest.
Peers learn the pass ended without committing; the person who ran it learns why.

**`PerspectiveProxy.runInterpretation`** — trailing options moved into a bag
(`{ existingScope, mintScope, observe }`). The scopes were already unreachable from the proxy for
want of positional room, and a fourth, fifth and sixth positional parameter would have made
`undefined, undefined, {…}` the normal way to ask for the only one most callers want. The
three-argument form is unchanged.

### 3. Auto-processing never ran (`584e018e`, `3ee2b5bc`, `2bef18e5`)

**The symptom.** Every `AutoProcessor` instance was rejected on load:

    load_processors: AutoProcessor instance `…` has missing / unparseable fields; skipping

once per watch tick, forever. Auto-processing stopped and nothing said why.

**The cause.** `interpretationClasses` is the class's only *collection*, so it carries
`ad4m://adder` rather than `ad4m://setter` — and `create_subject` / `update_subject` resolve only
the latter. Every class handed to them through the values map was discarded. The instance was
written with all eleven scalars intact and the one required collection missing, and the write
returned success.

That last part is why this took so long to find. The failure surfaced as a *reader* calling an
instance malformed, in a message naming neither the field nor its value, while the *writer* that
caused it reported nothing at all. Four plausible causes fitted the evidence equally well and all
four were wrong.

**`2bef18e5`** fixes it: the classes are written as links directly, which is what the collection's
own `addLink` action does, in the same batch as the instance so the two commit atomically.

**`3ee2b5bc`** is the commit that found it, and the one most worth reviewing on its own terms:
`create_subject` and `update_subject` now warn when they drop a supplied value. This is not
scaffolding — an API that accepts a value, returns success and discards it is a bug generator, and
this is the general case for *every* collection, not a quirk of this class. `CollectionBlock.children`,
`.comments`, `.signals` and every other HasMany take the same path today; most callers never notice
because the ORM adds members through `addLink` accessors instead.

**`584e018e`** makes the reader's complaint usable: it prints the instance on first failure and
suppresses repeats. Previously the same line fired several times a second per broken instance and
buried the log it was meant to serve.

**Deliberately not fixed:** `create_subject` still drops collection values for every other caller.
Making it fall back to `ad4m://adder` would change shared write semantics — it would start writing
values that every existing caller currently has dropped — so it wants its own review rather than a
ride on this PR.

## Known follow-ups

- **`observationId` is not validated.** A caller could pass a value colliding with a real
  `processor_id`, which would mix a one-shot pass into a watch's rows on any consumer keying by it.
  Harmless today (nothing keys on `processor_id` alone) and worth a namespace prefix if that changes.
- **`Failed` is only emitted from the one-shot path.** The watcher still reports a pass that errored
  as an abandoned claim with no fine-grained event. Same argument applies there; left out to keep
  this reviewable alongside #903.
- **`create_subject` cannot write collections**, as above. Worth fixing properly, and worth knowing
  about in the meantime for anyone hand-writing a SHACL class with a collection.
- **A stale hardwired SDNA is never refreshed.** `ensure_subject_class` decides a registered class
  is current by probing one path, and for `AutoProcessor` that path predates the properties #903
  added — so a perspective registered before the split keeps a shape without them. Found while
  chasing the above and **not** its cause; left out of this PR as unrelated and untested.
- **No `AwaitingAuthor`/`BackedOff` equivalent for one-shot**, correctly — there is no election —
  but it does mean the two paths emit overlapping-but-different step sets. Documented on the
  `AutoProcessorStep` union rather than papered over.

## Test plan

- [x] `cargo check --lib` — clean
- [x] `cargo fmt --check -p ad4m-executor` — clean
- [x] `tsc --noEmit` on `core/` — clean
- [x] No struct-literal construction of `AutoProcessorEvent` or `InterpretationEmitContext` outside
      `events.rs`, so the new fields break no call site; no exhaustive `match` on
      `AutoProcessorStep` anywhere, so the new variant is additive
- [ ] `cargo test perspectives::auto_processor` — not run (existing suite untouched by these
      changes, but worth a CI pass)
- [x] **Manual verification against a live node** — auto-extraction confirmed working end to end
      after the fix, in a space where it had been failing on every call

## Sequencing

Both commits sit on #903's head and neither touches a line #903 changed after `33f70226`, so the
branch rebases cleanly.

Worth deciding explicitly: **`batchKey` has a compatibility argument for going into #903 itself**
rather than following it. It is a field on a wire type, and adding it after merge is breaking-ish
for anyone who adopts the streams in between — they would build the client-side hash workaround and
then have to unbuild it. Against that, #903 is already approved, and pushing to it disturbs that.

Either is fine from our side. The field is optional on both the Rust and TS types, so arriving late
degrades to "cannot correlate" rather than breaking anything already written.

The one-shot commit has no such argument and is happy as a follow-up.

## Why we needed these

Building the consumer #903 was written for — a live extraction readout under WE's call bar, showing
every member of a call who is extracting, what phase it has reached, and (for the runner) the raw
prompt and response. That work is on `feat/extraction-observability` in the WE repo and is inert
until these land.
