### PR TITLE
fix(ldk): httpFetch returns {status, body} instead of throwing on non-2xx

### DIFF
--- a/ad4m-ldk/js/src/host.d.ts
+++ b/ad4m-ldk/js/src/host.d.ts
@@ -24,7 +24,11 @@ declare module "ad4m:host" {
     export function holochainCallAsync(dnaNick: string, zome: string, fnName: string, params: unknown): Promise<unknown>;
 
     // HTTP fetch (Spec section 7.2b)
-    export function httpFetch(url: string, method: string, headersJson: string, body: string): Promise<string>;
+    export interface HttpFetchResponse {
+        status: number;
+        body: string;
+    }
+    export function httpFetch(url: string, method: string, headersJson: string, body: string): Promise<HttpFetchResponse>;
 
     // Runtime utilities (Spec section 7.7)
     // Canonical AD4M content-address hash: SHA-256 -> CIDv1 -> base58btc,

--- a/ad4m-ldk/rust/src/imports.rs
+++ b/ad4m-ldk/rust/src/imports.rs
@@ -56,9 +56,9 @@ extern "C" {
     // Thin wrapper around Deno's native fetch(). `headers_json` is a JSON
     // string of `{ "Header": "Value", ... }` (empty string for no
     // headers), `body` is a raw request body string (empty for GET/HEAD).
-    // Returns the response body as a string and rejects with a non-2xx
-    // message on error. Callers JSON-encode/decode on either side as
-    // needed.
+    // Returns `{ status: number, body: string }` — the caller decides
+    // how to handle non-2xx status codes. Only rejects on network-level
+    // failures (DNS, connection refused, etc.).
     #[wasm_bindgen(js_name = "httpFetch", catch)]
     pub async fn http_fetch(
         url: &str,
@@ -195,8 +195,43 @@ pub fn agent_create_signed_expression_typed<T: Serialize + ?Sized>(data: &T) -> 
     }
 }
 
+/// Response from `http_fetch_typed`.
+pub struct HttpFetchResponse {
+    pub status: u16,
+    pub body: String,
+}
+
+impl HttpFetchResponse {
+    /// Returns `true` when the status code falls in the 200–299 range.
+    pub fn ok(&self) -> bool {
+        (200..300).contains(&self.status)
+    }
+}
+
+/// Typed wrapper around `http_fetch` — extracts `{ status, body }` from
+/// the JS response object. Only returns `Err` on network-level failures;
+/// HTTP error codes (4xx, 5xx) appear in the `Ok` variant's `status` field.
+pub async fn http_fetch_typed(
+    url: &str,
+    method: &str,
+    headers_json: &str,
+    body: &str,
+) -> Result<HttpFetchResponse, JsValue> {
+    let v = http_fetch(url, method, headers_json, body).await?;
+    let status = js_sys::Reflect::get(&v, &JsValue::from_str("status"))
+        .ok()
+        .and_then(|s| s.as_f64())
+        .unwrap_or(0.0) as u16;
+    let resp_body = js_sys::Reflect::get(&v, &JsValue::from_str("body"))
+        .ok()
+        .and_then(|b| b.as_string())
+        .unwrap_or_default();
+    Ok(HttpFetchResponse { status, body: resp_body })
+}
+
 /// POST a JSON-serializable body to `url` and return the response body as
-/// a String. Sets `Content-Type: application/json` automatically.
+/// a String. Sets `Content-Type: application/json` automatically. Returns
+/// `Err` on non-2xx status codes or network failures.
 pub async fn http_post_json<T: Serialize + ?Sized>(
     url: &str,
     body: &T,
@@ -204,13 +239,25 @@ pub async fn http_post_json<T: Serialize + ?Sized>(
     let body_s = serde_json::to_string(body)
         .map_err(|e| JsValue::from_str(&format!("http_post_json serialize: {}", e)))?;
     let headers = "{\"Content-Type\":\"application/json\"}";
-    let v = http_fetch(url, "POST", headers, &body_s).await?;
-    Ok(v.as_string().unwrap_or_default())
+    let resp = http_fetch_typed(url, "POST", headers, &body_s).await?;
+    if !resp.ok() {
+        return Err(JsValue::from_str(&format!(
+            "http_post_json POST {} -> {}: {}",
+            url, resp.status, resp.body
+        )));
+    }
+    Ok(resp.body)
 }
 
-/// GET `url` with an optional query string (appended as `?k=v&...` if
-/// non-empty) and return the response body as a String.
+/// GET `url` and return the response body as a String. Returns `Err` on
+/// non-2xx status codes or network failures.
 pub async fn http_get(url: &str) -> Result<String, JsValue> {
-    let v = http_fetch(url, "GET", "", "").await?;
-    Ok(v.as_string().unwrap_or_default())
+    let resp = http_fetch_typed(url, "GET", "", "").await?;
+    if !resp.ok() {
+        return Err(JsValue::from_str(&format!(
+            "http_get GET {} -> {}: {}",
+            url, resp.status, resp.body
+        )));
+    }
+    Ok(resp.body)
 }

--- a/rust-executor/src/js_core/host.js
+++ b/rust-executor/src/js_core/host.js
@@ -112,7 +112,8 @@ export async function holochainCallAsync(dnaNick, zome, fnName, params) {
 // HTTP fetch (Spec section 7.2b)
 // ============================================================================
 // Wraps the standard fetch() API so WASM languages can call HTTP APIs
-// without linking against web_sys. Returns the response body as a string.
+// without linking against web_sys. Returns { status, body } so callers
+// can distinguish 200 from 4xx/5xx without catching exceptions.
 
 async function httpFetchImpl(url, method, headersJson, body) {
     var headers = {};
@@ -130,10 +131,7 @@ async function httpFetchImpl(url, method, headersJson, body) {
     }
     var res = await globalThis.fetch(url, init);
     var text = await res.text();
-    if (!res.ok) {
-        throw new Error("http_fetch " + init.method + " " + url + " -> " + res.status + ": " + text);
-    }
-    return text;
+    return { status: res.status, body: text };
 }
 
 export function httpFetch(url, method, headersJson, body) {


### PR DESCRIPTION
## Problem

`httpFetch` in the host bridge (`rust-executor/src/js_core/host.js`) threw an `Error` on any non-2xx HTTP response, encoding the status code in the error message string. Language authors had to regex-scrape the status code from the exception — fragile and prevented proper status-code-based error handling.

The server-link-language worked around this with a regex match in `DenoTransport` (`adapters-deno.ts`), documented as "LDK debt" in [#893](https://github.com/coasys/ad4m/pull/893).

## Fix

`httpFetch` now always returns `{ status, body }`. Callers decide how to handle non-2xx status codes. Only network-level failures (DNS, connection refused) produce exceptions.

### Files changed

| File | Change |
|------|--------|
| `rust-executor/src/js_core/host.js` | `httpFetchImpl` returns `{ status, body }` instead of throwing |
| `ad4m-ldk/js/src/host.d.ts` | `HttpFetchResponse` interface, updated return type |
| `ad4m-ldk/rust/src/imports.rs` | `HttpFetchResponse` struct, `http_fetch_typed()` wrapper, updated `http_post_json`/`http_get` (convenience wrappers still error on non-2xx for backward compat) |

### Backward compatibility

- **Rust convenience wrappers** (`http_post_json`, `http_get`): same behaviour — still return `Err` on non-2xx. Callers wanting raw status use the new `http_fetch_typed()` instead.
- **JS/TS callers**: return type changes from `Promise<string>` to `Promise<HttpFetchResponse>`. No in-tree callers consume `httpFetch` directly except the server-link-language (on the feature branch), which already handled both paths.
- **No external languages ship yet** against the LDK, so no breakage.

### Follow-up

Once this merges into `dev` and `feat/local-bootstrap-and-server-link-language` rebases, the `DenoTransport` regex workaround in `adapters-deno.ts` can drop to a clean `response.status` / `response.body` read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP requests now provide both the response status and body, making error details easier to inspect.
  * Non-successful HTTP responses are handled consistently across request methods.

* **Bug Fixes**
  * Requests now correctly report failures for non-2xx responses instead of treating them as successful responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->