### PR TITLE
Fix: Relation correctness

### DIFF
--- a/core/src/model/Ad4mModel.test.ts
+++ b/core/src/model/Ad4mModel.test.ts
@@ -2514,10 +2514,22 @@ describe("Relation writes: to-one batching and scalar coercion", () => {
     target?: string;
   }
 
-  // No required property, no flag, no initial — so `save()` finds no SHACL
-  // constructor, skips `createSubject`, and calls `innerUpdate(true)`.
-  @Model({ name: "TestPlacement" })
-  class TestPlacement extends Ad4mModel {
+  // A coverage fixture for a branch that already exists in `save()`, not a
+  // modelling pattern being endorsed. No required property, no flag and no
+  // initial value means `buildSHACL` emits the node shape and its property
+  // shapes as normal but with an *empty* constructor-action list, which the
+  // Rust side rejects as "No SHACL constructor found" — so `save()` skips
+  // `createSubject` and calls `innerUpdate(true)` instead. The base expression
+  // exists either way: the `Ad4mModel` constructor mints one, and
+  // `createSubject` writes onto a base rather than creating it.
+  //
+  // Worth naming the real caveat, which is about conformance rather than
+  // writes: a class with no required property and no flag states no criteria,
+  // so nothing structurally distinguishes an instance of it from any other
+  // base expression. That makes it an overlay rather than a class, and it is a
+  // question about SDNA modelling generally rather than about this file.
+  @Model({ name: "TestNoConstructor" })
+  class TestNoConstructor extends Ad4mModel {
     @HasOne({ through: "we://placed_node" })
     node?: string;
   }
@@ -2601,7 +2613,7 @@ describe("Relation writes: to-one batching and scalar coercion", () => {
     it("still writes the relation when there is no SHACL constructor", async () => {
       const perspective = makePerspective();
 
-      await TestPlacement.create(
+      await TestNoConstructor.create(
         perspective,
         { node: "we://block/a" },
         { batchId: "batch-1" }

--- a/core/src/model/Ad4mModel.test.ts
+++ b/core/src/model/Ad4mModel.test.ts
@@ -2494,3 +2494,145 @@ describe("Ad4mModel instance identity (uniqueness without envelopes)", () => {
     expect(instance.id).toBe("flux://existing-instance");
   });
 });
+
+describe("Relation writes: to-one batching and scalar coercion", () => {
+  // `Relationship` is the shape that made both of these visible: a record whose
+  // two to-one relations name the things it connects, so it is worthless until
+  // both endpoints are linked, and it is created and pointed in one gesture.
+  @Model({ name: "TestRelationship" })
+  class TestRelationship extends Ad4mModel {
+    @Flag({ through: "we://flag", value: "we://relationship" })
+    flag: string = "";
+
+    @Property({ through: "we://title", required: true })
+    label: string = "";
+
+    @HasOne({ through: "we://relationship_source" })
+    source?: string;
+
+    @HasOne({ through: "we://relationship_target" })
+    target?: string;
+  }
+
+  // No required property, no flag, no initial — so `save()` finds no SHACL
+  // constructor, skips `createSubject`, and calls `innerUpdate(true)`.
+  @Model({ name: "TestPlacement" })
+  class TestPlacement extends Ad4mModel {
+    @HasOne({ through: "we://placed_node" })
+    node?: string;
+  }
+
+  const makePerspective = () =>
+    ({
+      executeAction: jest.fn().mockResolvedValue(undefined),
+      createSubject: jest.fn().mockResolvedValue(undefined),
+      createBatch: jest.fn().mockResolvedValue("batch-generated"),
+      commitBatch: jest.fn().mockResolvedValue(undefined),
+      stringOrTemplateObjectToSubjectClassName: jest
+        .fn()
+        .mockResolvedValue("TestRelationship"),
+      uuid: "test-perspective-uuid",
+    }) as any;
+
+  /** Targets written by `executeAction`, across every call. */
+  const writtenTargets = (perspective: any): string[] =>
+    perspective.executeAction.mock.calls.flatMap((call: any[]) =>
+      (call[2] ?? []).map((param: any) => param.value)
+    );
+
+  /** The batchId argument of each `executeAction` call. */
+  const batchIds = (perspective: any): unknown[] =>
+    perspective.executeAction.mock.calls.map((call: any[]) => call[3]);
+
+  describe("a scalar handed to a relation field", () => {
+    it("writes a link instead of being silently dropped", async () => {
+      // The failure this closes: this call typechecked, ran, resolved, and
+      // wrote no link — leaving a relationship with no endpoints, which only
+      // surfaces later as a reader calling the record malformed.
+      const perspective = makePerspective();
+
+      await TestRelationship.create(
+        perspective,
+        { label: "contradicts", source: "we://block/a", target: "we://block/b" },
+        { batchId: "batch-1" }
+      );
+
+      expect(writtenTargets(perspective)).toEqual(
+        expect.arrayContaining(["we://block/a", "we://block/b"])
+      );
+    });
+
+    it("writes it even when a constructor consumed the properties", async () => {
+      // `create` passes `setProperties: false` when the class has a SHACL
+      // constructor, because `createSubject` writes the values map. A relation
+      // carries `ad4m://adder` rather than `ad4m://setter`, so `createSubject`
+      // drops it — meaning the relation write has to happen here regardless of
+      // that flag, or both paths discard it at once.
+      const perspective = makePerspective();
+
+      await TestRelationship.create(
+        perspective,
+        { label: "contradicts", source: "we://block/a" },
+        { batchId: "batch-1" }
+      );
+
+      expect(perspective.createSubject).toHaveBeenCalled();
+      expect(writtenTargets(perspective)).toContain("we://block/a");
+    });
+
+    it("agrees with the documented array form", async () => {
+      const scalar = makePerspective();
+      await TestRelationship.create(
+        scalar,
+        { label: "x", source: "we://block/a" },
+        { batchId: "b" }
+      );
+
+      const array = makePerspective();
+      await TestRelationship.create(
+        array,
+        { label: "x", source: ["we://block/a"] as any },
+        { batchId: "b" }
+      );
+
+      expect(writtenTargets(scalar)).toEqual(writtenTargets(array));
+    });
+
+    it("still writes the relation when there is no SHACL constructor", async () => {
+      const perspective = makePerspective();
+
+      await TestPlacement.create(
+        perspective,
+        { node: "we://block/a" },
+        { batchId: "batch-1" }
+      );
+
+      expect(perspective.createSubject).not.toHaveBeenCalled();
+      expect(writtenTargets(perspective)).toContain("we://block/a");
+    });
+  });
+
+  describe("generated @HasOne accessors", () => {
+    it("forward batchId, so a to-one link can join a write group", async () => {
+      // Without this the link commits on its own, so every subscriber sees the
+      // record with its relation still empty — a card before its placement.
+      const perspective = makePerspective();
+      const rel = new TestRelationship(perspective, "we://rel/1") as any;
+
+      await rel.setSource("we://block/a", "batch-1");
+      await rel.addTarget("we://block/b", "batch-1");
+      await rel.removeTarget("we://block/b", "batch-1");
+
+      expect(batchIds(perspective)).toEqual(["batch-1", "batch-1", "batch-1"]);
+    });
+
+    it("still work without one", async () => {
+      const perspective = makePerspective();
+      const rel = new TestRelationship(perspective, "we://rel/1") as any;
+
+      await rel.setSource("we://block/a");
+
+      expect(batchIds(perspective)).toEqual([undefined]);
+    });
+  });
+});

--- a/core/src/model/Ad4mModel.ts
+++ b/core/src/model/Ad4mModel.ts
@@ -1401,14 +1401,37 @@ export class Ad4mModel {
           // Handle all arrays as relations, including empty ones (which clears the relation)
           await this.setRelationValues(key, value, batchId);
         } else if (value !== undefined && value !== null && value !== "") {
-          if (setProperties) {
-            // Check if this is a relation property (has relation metadata)
-            const relationMeta = this.getRelationOptions(key);
-            if (relationMeta) {
-              // Skip - it's a relation, not a regular property
-              continue;
-            }
+          // A scalar handed to a relation field is a single-member relation.
+          //
+          // This used to `continue` — "Skip, it's a relation, not a regular
+          // property" — so `Model.create(p, { source: 'uri://x' })` typechecked,
+          // ran, resolved, and wrote no link. The record was created with the
+          // relation empty and nothing anywhere said so, which surfaces later as
+          // a *reader* complaining about a malformed instance: a Relationship
+          // with no endpoints, a Placement pointing at nothing. Both look like
+          // rendering bugs from the outside, because the record exists and the
+          // thing that should reference it does not.
+          //
+          // The array form is the documented path and stays correct; the problem
+          // is that the scalar form is plausible, typechecks against a field
+          // declared `string`, and fails silently. Coercing matches what a caller
+          // reaching for it meant. A value `setRelationValues` cannot use now
+          // fails there, loudly, instead of vanishing here.
+          //
+          // Deliberately outside the `setProperties` gate, mirroring the array
+          // branch above. `create` passes `setProperties: false` when the class
+          // has a constructor, because `create_subject` writes the values map —
+          // but a relation carries `ad4m://adder`, not `ad4m://setter`, so
+          // `create_subject` drops it (see the warning added in 3ee2b5bc6).
+          // Relations have to be written here in both cases or they are lost by
+          // both paths at once.
+          const relationMeta = this.getRelationOptions(key);
+          if (relationMeta) {
+            await this.setRelationValues(key, [value], batchId);
+            continue;
+          }
 
+          if (setProperties) {
             // Skip flag properties — they are immutable after creation
             const propMeta = this.getPropertyMetadata(key);
             if (propMeta?.flag) {

--- a/core/src/model/decorators.ts
+++ b/core/src/model/decorators.ts
@@ -1063,15 +1063,23 @@ export function HasOne(
                 local: opts.local,
             })(target, key);
 
-            // Add prototype methods for add/remove/set (mirroring @HasMany)
-            (target as any)[`add${capitalize(relKey)}`] = async function(this: any, arg: any) {
-                return (this as any).addRelationValue(relKey, arg);
+            // Add prototype methods for add/remove/set (mirroring @HasMany).
+            //
+            // `batchId` is part of that mirroring: without it a to-one link
+            // cannot join a write group, so anything that creates a record and
+            // then points it at something has to commit twice and every
+            // subscriber sees the state in between — a record whose to-one
+            // relation is still empty. Anything rendering from a subscription
+            // therefore has a frame in which the record exists and points at
+            // nothing.
+            (target as any)[`add${capitalize(relKey)}`] = async function(this: any, arg: any, batchId?: string) {
+                return (this as any).addRelationValue(relKey, arg, batchId);
             };
-            (target as any)[`remove${capitalize(relKey)}`] = async function(this: any, arg: any) {
-                return (this as any).removeRelationValue(relKey, arg);
+            (target as any)[`remove${capitalize(relKey)}`] = async function(this: any, arg: any, batchId?: string) {
+                return (this as any).removeRelationValue(relKey, arg, batchId);
             };
-            (target as any)[`set${capitalize(relKey)}`] = async function(this: any, arg: any) {
-                return (this as any).setRelationValues(relKey, arg);
+            (target as any)[`set${capitalize(relKey)}`] = async function(this: any, arg: any, batchId?: string) {
+                return (this as any).setRelationValues(relKey, arg, batchId);
             };
         } else {
             Object.defineProperty(target, relKey, { configurable: true, writable: true });

--- a/rust-executor/src/perspectives/model_query/hydration.rs
+++ b/rust-executor/src/perspectives/model_query/hydration.rs
@@ -159,25 +159,65 @@ pub(super) fn hydrate_one(shape: &ModelShape, inst: &InstanceLinks) -> Option<Va
             .properties
             .iter()
             .any(|p| p.name == name && p.datatype.is_some());
-        let arr: Vec<Value> = values
-            .iter()
-            .map(|&(target, _)| {
-                if decode_literals && target.starts_with("literal:") {
-                    parse_literal_value(target)
-                } else {
-                    Value::String(target.to_string())
-                }
-            })
-            .collect();
+        let decode = |target: &str| -> Value {
+            if decode_literals && target.starts_with("literal:") {
+                parse_literal_value(target)
+            } else {
+                Value::String(target.to_string())
+            }
+        };
+
         let is_scalar = shape
             .properties
             .iter()
             .any(|p| p.name == name && p.is_scalar_relation);
+
         if is_scalar {
-            if let Some(first) = arr.into_iter().next() {
-                obj.insert(name.to_string(), first);
+            // A scalar relation (`@HasOne` / `@BelongsToOne`) resolves
+            // last-write-wins, exactly as a scalar property does above.
+            //
+            // It previously took the *earliest* link — the collection was sorted
+            // ascending and the first entry won — so re-pointing a to-one relation
+            // without first removing the old link kept serving the original target
+            // forever, while a scalar property on the same instance updated
+            // normally. Today `collectionSetter` deletes before adding, which
+            // leaves one link and hides this; concurrent writes from two peers do
+            // not, and neither will the incremental diff that replaces it.
+            //
+            // Strict `>` means the first of several links sharing a timestamp
+            // wins, matching the scalar-property branch rather than diverging
+            // from it on ties.
+            let mut winner: Option<(&str, &str)> = None;
+            for &(target, ts) in &values {
+                if winner.map_or(true, |(_, best_ts)| ts > best_ts) {
+                    winner = Some((target, ts));
+                }
+            }
+            if let Some((target, _)) = winner {
+                obj.insert(name.to_string(), decode(target));
             }
         } else {
+            // Collapse duplicate targets.
+            //
+            // A link is stored as a direct triple plus a reifier keyed on
+            // `sha256(source, predicate, target, timestamp)`, so two links
+            // carrying the same triple at different timestamps — two peers
+            // asserting the same membership, or a re-add racing a remote write —
+            // share one triple but produce two reifiers. The instance query joins
+            // through the reifier to recover author and timestamp, so it returns a
+            // row per reifier and the target lands here twice.
+            //
+            // `$count` projections already answer `COUNT(DISTINCT ?t)`, so leaving
+            // this undeduplicated made a count disagree with the list it counts
+            // within a single query.
+            //
+            // `values` is sorted ascending, so retaining the first sighting of each
+            // target keeps its earliest timestamp — the same instant `createdAt`
+            // and the append-by-timestamp fallback ordering already use.
+            let mut seen = std::collections::HashSet::new();
+            values.retain(|&(target, _)| seen.insert(target));
+
+            let arr: Vec<Value> = values.iter().map(|&(target, _)| decode(target)).collect();
             obj.insert(name.to_string(), Value::Array(arr));
         }
     }
@@ -498,6 +538,213 @@ mod tests {
             vec!["turn-hex-1".to_string(), "turn-hex-2".to_string()],
             "wire-form `literal:string:<hex>` HasMany targets must be decoded to plain values",
         );
+    }
+
+    // ---- duplicate collapsing --------------------------------------------
+    //
+    // A link is a direct triple plus a reifier keyed on
+    // `sha256(source, predicate, target, timestamp)`. Two peers asserting the
+    // same membership share the triple but mint two reifiers, and the instance
+    // query joins through the reifier to recover author/timestamp — so the same
+    // target arrives twice. These fixtures reproduce that by repeating a
+    // `(predicate, target)` pair at two timestamps.
+
+    #[test]
+    fn test_hydrate_collection_collapses_duplicate_targets() {
+        let s = shape("Post", vec![relation("signals", "we://signal")]);
+        let inst = inst_links_at(
+            "we://post/1",
+            vec![
+                ("we://signal", "we://signal/a", "2026-01-01T00:00:00.000Z"),
+                // Same triple, asserted again by a peer a second later.
+                ("we://signal", "we://signal/a", "2026-01-01T00:00:01.000Z"),
+                ("we://signal", "we://signal/b", "2026-01-01T00:00:02.000Z"),
+            ],
+        );
+
+        let result = hydrate_one(&s, &inst).unwrap();
+        let signals: Vec<&str> = result["signals"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+
+        // Two links, one membership. `$count` already answered 1 here via
+        // COUNT(DISTINCT ?t), so an undeduplicated list disagreed with the
+        // count of the same relation inside one query.
+        assert_eq!(
+            signals,
+            vec!["we://signal/a", "we://signal/b"],
+            "a target asserted by two peers must appear once",
+        );
+    }
+
+    #[test]
+    fn test_hydrate_collection_dedup_keeps_earliest_position() {
+        // The duplicate is the *earliest* link for `a`, so collapsing on first
+        // sighting has to keep `a` ahead of `b` — not move it to where its
+        // second assertion landed. Ordering is by earliest timestamp, the same
+        // instant `createdAt` and the append-by-timestamp fallback use.
+        let s = shape("Post", vec![relation("children", "we://children")]);
+        let inst = inst_links_at(
+            "we://post/1",
+            vec![
+                ("we://children", "we://block/a", "2026-01-01T00:00:00.000Z"),
+                ("we://children", "we://block/b", "2026-01-01T00:00:01.000Z"),
+                ("we://children", "we://block/a", "2026-01-01T00:00:09.000Z"),
+            ],
+        );
+
+        let result = hydrate_one(&s, &inst).unwrap();
+        let children: Vec<&str> = result["children"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+
+        assert_eq!(children, vec!["we://block/a", "we://block/b"]);
+    }
+
+    #[test]
+    fn test_hydrate_collection_dedup_survives_literal_decoding() {
+        // Decoding happens after collapsing, so a duplicated literal target
+        // must collapse on its wire form and still decode once.
+        let s = shape(
+            "Run",
+            vec![relation_with_datatype(
+                "sources",
+                "ad4m://interp/sources",
+                "xsd://string",
+            )],
+        );
+        let inst = inst_links_at(
+            "ad4m://interp/run/1",
+            vec![
+                (
+                    "ad4m://interp/sources",
+                    "literal:string:turn-1",
+                    "2026-01-01T00:00:00.000Z",
+                ),
+                (
+                    "ad4m://interp/sources",
+                    "literal:string:turn-1",
+                    "2026-01-01T00:00:01.000Z",
+                ),
+            ],
+        );
+
+        let result = hydrate_one(&s, &inst).unwrap();
+        assert_eq!(
+            result["sources"].as_array().unwrap().len(),
+            1,
+            "duplicate literal targets collapse before decoding",
+        );
+        assert_eq!(result["sources"][0].as_str().unwrap(), "turn-1");
+    }
+
+    // ---- scalar relations resolve last-write-wins -------------------------
+
+    #[test]
+    fn test_hydrate_scalar_relation_last_write_wins() {
+        // Re-pointing a `@HasOne` without removing the old link previously kept
+        // serving the *original* target forever, because the collection was
+        // sorted ascending and the first entry won — while a scalar property on
+        // the same instance updated normally.
+        let s = shape("Space", vec![scalar_relation("location", "we://location")]);
+        let inst = inst_links_at(
+            "we://space/1",
+            vec![
+                ("we://location", "we://loc/old", "2026-01-01T00:00:00.000Z"),
+                ("we://location", "we://loc/new", "2026-01-01T00:00:05.000Z"),
+            ],
+        );
+
+        let result = hydrate_one(&s, &inst).unwrap();
+        assert_eq!(
+            result["location"].as_str().unwrap(),
+            "we://loc/new",
+            "a to-one relation must resolve to its latest link, as a scalar property does",
+        );
+    }
+
+    #[test]
+    fn test_hydrate_scalar_relation_lww_regardless_of_link_order() {
+        // The winner is decided by timestamp, not by the order rows happened to
+        // arrive from the store.
+        let s = shape("Space", vec![scalar_relation("location", "we://location")]);
+        let inst = inst_links_at(
+            "we://space/1",
+            vec![
+                ("we://location", "we://loc/new", "2026-01-01T00:00:05.000Z"),
+                ("we://location", "we://loc/old", "2026-01-01T00:00:00.000Z"),
+            ],
+        );
+
+        let result = hydrate_one(&s, &inst).unwrap();
+        assert_eq!(result["location"].as_str().unwrap(), "we://loc/new");
+    }
+
+    #[test]
+    fn test_hydrate_scalar_relation_tie_matches_scalar_property() {
+        // Two links sharing a timestamp: the scalar-property branch keeps the
+        // first seen (its comparison is strict `>`), and the relation branch
+        // must not diverge from it on ties.
+        let s = shape(
+            "Space",
+            vec![
+                scalar_relation("location", "we://location"),
+                prop("name", "we://name"),
+            ],
+        );
+        let inst = inst_links_at(
+            "we://space/1",
+            vec![
+                (
+                    "we://location",
+                    "we://loc/first",
+                    "2026-01-01T00:00:00.000Z",
+                ),
+                (
+                    "we://location",
+                    "we://loc/second",
+                    "2026-01-01T00:00:00.000Z",
+                ),
+                (
+                    "we://name",
+                    "literal:string:first",
+                    "2026-01-01T00:00:00.000Z",
+                ),
+                (
+                    "we://name",
+                    "literal:string:second",
+                    "2026-01-01T00:00:00.000Z",
+                ),
+            ],
+        );
+
+        let result = hydrate_one(&s, &inst).unwrap();
+        assert_eq!(result["location"].as_str().unwrap(), "we://loc/first");
+        assert_eq!(
+            result["name"].as_str().unwrap(),
+            "first",
+            "the relation branch must tiebreak the same way the property branch does",
+        );
+    }
+
+    #[test]
+    fn test_hydrate_scalar_relation_absent_stays_absent() {
+        // No link at all must leave the key off entirely rather than writing
+        // null — callers distinguish "unset" from "explicitly nothing".
+        let s = shape("Space", vec![scalar_relation("location", "we://location")]);
+        let inst = inst_links_at(
+            "we://space/1",
+            vec![("we://other", "we://x", "2026-01-01T00:00:00.000Z")],
+        );
+
+        let result = hydrate_one(&s, &inst).unwrap();
+        assert!(result.get("location").is_none());
     }
 
     #[test]

--- a/rust-executor/src/perspectives/model_query/projection.rs
+++ b/rust-executor/src/perspectives/model_query/projection.rs
@@ -178,13 +178,38 @@ pub(super) async fn resolve_projections(
             let result_json = store.query(&sparql)?;
             let rows: Vec<Value> = serde_json::from_str(&result_json)?;
 
+            // Collapse duplicate targets per parent.
+            //
+            // Only reachable when the projection filters on `author` or
+            // `timestamp`: `build_projection_reifier_patterns` then joins the
+            // reifier, and a triple asserted twice by the same author carries two
+            // reifiers, so it matches twice. Without the filter the query selects
+            // the direct triple alone and RDF set semantics have already
+            // deduplicated it.
+            //
+            // The `count: true` branch above answers `COUNT(DISTINCT ?t)`, so
+            // without this a filtered projection's list disagreed with the count
+            // of the very same relation.
+            //
+            // Retaining the first sighting preserves `order_clause`'s ordering.
             let mut list_map: HashMap<String, Vec<Value>> = HashMap::new();
+            let mut seen_per_parent: HashMap<String, std::collections::HashSet<String>> =
+                HashMap::new();
             for row in &rows {
                 if let Some(parent) = row["parent"].as_str() {
                     let t = row["t"]
                         .as_str()
                         .map(|s| Value::String(s.to_string()))
                         .unwrap_or(Value::Null);
+                    if let Some(key) = t.as_str() {
+                        if !seen_per_parent
+                            .entry(parent.to_string())
+                            .or_default()
+                            .insert(key.to_string())
+                        {
+                            continue;
+                        }
+                    }
                     list_map.entry(parent.to_string()).or_default().push(t);
                 }
             }

--- a/rust-executor/src/perspectives/model_query/test_helpers.rs
+++ b/rust-executor/src/perspectives/model_query/test_helpers.rs
@@ -49,6 +49,16 @@ pub fn relation(name: &str, predicate: &str) -> ShapeProperty {
     }
 }
 
+/// Helper: build a ShapeProperty for a scalar (to-one) relation — the
+/// `@HasOne` / `@BelongsToOne` case. Still `is_collection` (all relations are,
+/// so the query pipeline treats them uniformly); `is_scalar_relation` is what
+/// collapses it to a single value on hydration.
+pub fn scalar_relation(name: &str, predicate: &str) -> ShapeProperty {
+    let mut p = relation(name, predicate);
+    p.is_scalar_relation = true;
+    p
+}
+
 /// Helper: build a ShapeProperty for a literal-valued collection relation
 /// (declares `sh:datatype`, so `literal:<type>:<value>` wire form is
 /// decoded on hydration — the `@HasMany({ datatype: "xsd:string" })`
@@ -170,6 +180,30 @@ pub fn evaluate_getters_batch_from_json(
 ) -> Result<serde_json::Value, Error> {
     let shape = parse_shape_from_json(shape_json, class_name)?;
     super::getters::evaluate_getters_batch(store, &shape, instance_ids, property_names)
+}
+
+/// Helper: build an InstanceLinks entry with explicit per-link timestamps.
+///
+/// `inst_links` derives an increasing timestamp from position, which is right
+/// for most tests but cannot express the two cases that matter for duplicate
+/// and last-write-wins handling: the same `(predicate, target)` appearing twice
+/// at *different* timestamps (two reifiers over one triple), and links arriving
+/// out of timestamp order. Each entry is `(predicate, target, timestamp)`.
+pub fn inst_links_at(source: &str, links: Vec<(&str, &str, &str)>) -> InstanceLinks {
+    InstanceLinks {
+        source: source.to_string(),
+        links: links
+            .into_iter()
+            .map(|(pred, tgt, ts)| {
+                (
+                    pred.to_string(),
+                    tgt.to_string(),
+                    "did:key:testauthor".to_string(),
+                    ts.to_string(),
+                )
+            })
+            .collect(),
+    }
 }
 
 /// Helper: build an InstanceLinks entry.


### PR DESCRIPTION
# Relation correctness: duplicate links, `@HasOne` LWW, batching, silent drops

> [!IMPORTANT]
> **Branch** `fix/relation-correctness` · **Base** `dev`.
> Independent. Nothing in the series is required before it.
>
> Part of an eight-PR series on the AD4M model layer — review wave 1 of 4. The full shape:

```
dev ─┬─ 1  relation-correctness ── 5  subjectClassOf ─┬─ 6  polymorphic-include
     │                                                └─ 7  ordering-module ── 8  ordering-integration
     ├─ 2  getter+target
     └─ 3  where-compiler ── 4  quantifiers
```

## Summary

Four ways relations behaved differently from the rest of the model layer, all of them silent, and
all of them found while auditing AD4M against what WE needs next. Two are reads (a collection could
report a target twice; a to-one relation served its *oldest* link forever) and two are writes (a
to-one link could not join a write group; a scalar handed to a relation field was discarded without
a word).

They ship together because they are one complaint: `@HasOne` and relation writes have been finished
less carefully than `@HasMany`, and the seams show in the same places. Three of the four are also
currently *masked* by `collectionSetter` deleting every link before re-adding it — which the CRDT
ordering PR at the end of this stack replaces with a diff. Left unfixed they would have started
failing on the ordinary path with no code having changed to explain it.

## Changes

**`rust-executor/src/perspectives/model_query/hydration.rs`** — the two read fixes, both in the
collection loop of `hydrate_one`.

A link is stored as a direct triple plus a reifier keyed on
`sha256(source, predicate, target, timestamp)`. Two peers asserting the same membership — concurrent
`addSignal`, `addParticipant`, `addMention` — share one triple but mint two reifiers, and the
instance query joins through the reifier to recover author and timestamp. So it returns a row per
reifier and the target lands in the array twice. This collapses duplicates unconditionally rather
than behind a `distinct` flag, because a `$count` projection already answers `COUNT(DISTINCT ?t)`:
within a single query, `$signalCount` said 1 while `signals` returned two entries of the same signal.
A count that disagrees with the list it counts is not a defensible default.

Scalar relations resolved *earliest*-wins — the collection was sorted ascending and the first entry
taken — while scalar properties a few lines above resolve last-write-wins. Re-pointing a `@HasOne`
without removing the old link kept serving the original target, so `Space.location` would show a
stale place and `Space.name` a fresh name from one write. Tiebreaking uses strict `>` so links
sharing a timestamp resolve to the first seen, matching the property branch rather than diverging
from it.

**`rust-executor/src/perspectives/model_query/projection.rs`** — the same dedup for non-count
projections, so a filtered projection's list agrees with its own count. Only reachable when a
projection filters on `author` or `timestamp`, which is when `build_projection_reifier_patterns`
joins the reifier at all.

*Deliberately not touched:* `relations.rs`. An earlier draft of the plan listed it as a third dedup
site. It is not one — `resolve_reverse_relations` and `resolve_reverse_include` select
`?source <pred> ?target` with no reifier join, so RDF set semantics have already deduplicated them.

**`core/src/model/decorators.ts`** — `@HasOne`'s generated `add`/`remove`/`set` now forward
`batchId`. Their block is introduced by the comment *"mirroring @HasMany"* and then did not mirror
it, while the `addRelationValue`/`setRelationValues` they delegate to have taken a batch all along —
the parameter was simply dropped on the way in. Without it, anything that creates a record and points
it at something commits twice, and every subscriber sees the state between: a record whose to-one
relation is still empty. That is the board card that appears unpositioned and then jumps.

**`core/src/model/Ad4mModel.ts`** — `innerUpdate` coerces a scalar on a relation field to a
single-member relation instead of skipping it. `Model.create(p, { source: 'uri://x' })` typechecked,
ran, resolved, and wrote no link; the failure surfaced later and elsewhere, as a reader calling the
record malformed. The coercion sits *outside* the `setProperties` gate, mirroring the array branch:
`create` passes `setProperties: false` when the class has a SHACL constructor, but a relation carries
`ad4m://adder` rather than `ad4m://setter` so `create_subject` drops it too — left inside the gate it
would be discarded by both paths at once.

**`core/src/model/test_helpers.rs`, `Ad4mModel.test.ts`** — `inst_links_at` gives per-link
timestamps, which the existing helper cannot express (the same `(predicate, target)` at two
timestamps; links arriving out of timestamp order). `scalar_relation` builds the `@HasOne` shape.

## Known follow-ups

- `build_count_sparql` reuses `build_query_patterns`, which skipped `OR`/`AND`/`NOT`, so `totalCount`
  was computed unfiltered under a combinator. Fixed by the where-compiler PR later in this stack.
- The duplicate-link condition is a P2P-only failure, which is why it never showed in single-agent
  tests. Worth a cross-peer integration test once the harness can run two executors cheaply.

## Test plan

> Counts are for this branch **against its own base**, so they include only this PR's tests —
> not its predecessors'. Re-measured after the stack was split from one linear chain into the
> tree above.

- [x] `cargo test -p ad4m-executor --lib perspectives::model_query` — 221 passing, 7 new
- [x] 7 new Rust tests covering: duplicate collapse, dedup preserving earliest position, dedup before
      literal decoding, `@HasOne` LWW, LWW regardless of row order, tie matching the property branch,
      absent stays absent
- [x] `jest src/model` in `core` — 252 passing, 6 new
- [x] **Verified the new TS tests fail without the fix**: 5 of 6 fail on a stashed working tree; the
      sixth is the no-`batchId` regression guard, which passes either way by design
- [x] `tsc --noEmit` clean
- [x] `cargo fmt -p ad4m-executor`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relation metadata can now include interpretation hints to improve downstream extraction and schema handling.

* **Bug Fixes**
  * To-one relation values are now correctly saved during property updates.
  * To-one relations resolve to the most recent link, with consistent tie handling.
  * Collection relations and query projections now remove duplicate targets while preserving ordering.
  * Invalid relation values now produce validation errors instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->