### PR TITLE
Refactor: Compile the where clause once; OR and NOT reach SPARQL

### DIFF
--- a/rust-executor/src/perspectives/model_query/filtering.rs
+++ b/rust-executor/src/perspectives/model_query/filtering.rs
@@ -16,9 +16,15 @@ use std::collections::BTreeMap;
 
 /// Test whether an instance passes all conditions in a where clause.
 ///
-/// Conditions that are known to have been pushed to SPARQL (e.g. simple
-/// string equality on `id`, or string/array conditions on collection
-/// relations) are skipped here to avoid redundant work.
+/// `id` and `base` conditions are evaluated here unconditionally, even the
+/// shapes the compiler normally pushes to SPARQL: re-testing one that was
+/// pushed is cheap and cannot reject a row wrongly, whereas assuming it was
+/// pushed is wrong inside any combinator the compiler declined.
+///
+/// String/array conditions on collection relations are still skipped, on the
+/// same assumption — see the comment at that arm. They cannot be made total
+/// the same way, because [`matches_condition`] has no contains-semantics for
+/// the array a hydrated relation holds.
 pub(super) fn matches_where(
     instance: &Value,
     where_clause: &BTreeMap<String, WhereCondition>,
@@ -72,28 +78,44 @@ pub(super) fn matches_where(
         }
 
         if prop_name == "base" || prop_name == "id" {
-            // String and StringArray id conditions are pushed to SPARQL.
-            // Complex ops (Ops, NumberArray, etc.) still need post-hydration.
+            // Total over every condition shape, including the String and
+            // StringArray ones the compiler usually does push to SPARQL.
+            //
+            // Skipping those used to be the fast path, on the assumption that
+            // reaching here at all meant SPARQL had already applied them. That
+            // assumption does not survive a combinator. When one branch of an
+            // `OR` cannot be compiled the whole disjunction is declined and
+            // left to this filter; a branch whose only clause was an id
+            // equality then passed vacuously, `any` was trivially satisfied,
+            // and the id constraint was applied in neither layer.
+            //
+            // Re-testing a condition SPARQL did push is redundant but never
+            // wrong: a hydrated instance's `id` is its own source URI, the
+            // same string the compiler matched on. One string comparison buys
+            // the removal of the coordination.
+            //
             // Hydrated instances use "id" (not "base"), so map "base" → "id".
             let lookup_key = if prop_name == "base" {
                 "id"
             } else {
                 prop_name.as_str()
             };
-            match condition {
-                WhereCondition::String(_) | WhereCondition::StringArray(_) => continue,
-                _ => {
-                    let val = &instance[lookup_key];
-                    if !matches_condition(val, condition) {
-                        return false;
-                    }
-                    continue;
-                }
+            if !matches_condition(&instance[lookup_key], condition) {
+                return false;
             }
+            continue;
         }
 
-        // Relation-based where conditions (String/StringArray on collection props)
-        // are already pushed to SPARQL — skip them here.
+        // Relation-based where conditions (String/StringArray on collection
+        // props) are already pushed to SPARQL — skip them here.
+        //
+        // This is the same coordination the `id` arm above no longer relies on,
+        // and it leaks the same way inside a declined combinator. It is left
+        // alone deliberately: a hydrated relation holds an array, and
+        // `matches_condition` compares a String against one by stringifying,
+        // so making this arm total would reject rows that do match. Closing it
+        // needs contains-semantics for relations, which belongs with the wider
+        // shrinking of this function rather than here.
         if matches!(
             condition,
             WhereCondition::String(_) | WhereCondition::StringArray(_)
@@ -798,16 +820,67 @@ mod tests {
     }
 
     #[test]
-    fn test_matches_where_skips_id_string() {
+    fn test_matches_where_filters_id_string() {
+        // This used to assert the opposite — that a *wrong* id still matched,
+        // because the arm skipped String conditions as "already pushed".
         let instance = json!({"id": "test://1", "name": "X"});
         let s = shape("Test", vec![prop("name", "test://name")]);
 
-        let mut where_clause_wrong = BTreeMap::new();
-        where_clause_wrong.insert(
+        let mut wrong = BTreeMap::new();
+        wrong.insert(
             "id".to_string(),
             WhereCondition::String("test://wrong".to_string()),
         );
-        assert!(matches_where(&instance, &where_clause_wrong, &s));
+        assert!(!matches_where(&instance, &wrong, &s));
+
+        let mut right = BTreeMap::new();
+        right.insert(
+            "id".to_string(),
+            WhereCondition::String("test://1".to_string()),
+        );
+        assert!(matches_where(&instance, &right, &s));
+    }
+
+    #[test]
+    fn test_matches_where_filters_id_string_array() {
+        let instance = json!({"id": "test://1"});
+        let s = shape("Test", vec![]);
+
+        let mut excluded = BTreeMap::new();
+        excluded.insert(
+            "id".to_string(),
+            WhereCondition::StringArray(vec!["test://2".to_string(), "test://3".to_string()]),
+        );
+        assert!(!matches_where(&instance, &excluded, &s));
+
+        let mut included = BTreeMap::new();
+        included.insert(
+            "id".to_string(),
+            WhereCondition::StringArray(vec!["test://1".to_string(), "test://2".to_string()]),
+        );
+        assert!(matches_where(&instance, &included, &s));
+    }
+
+    #[test]
+    fn test_matches_where_filters_base_string() {
+        // "base" is the same constraint under its wire name, and maps to the
+        // hydrated "id" key.
+        let instance = json!({"id": "test://1"});
+        let s = shape("Test", vec![]);
+
+        let mut wrong = BTreeMap::new();
+        wrong.insert(
+            "base".to_string(),
+            WhereCondition::String("test://wrong".to_string()),
+        );
+        assert!(!matches_where(&instance, &wrong, &s));
+
+        let mut right = BTreeMap::new();
+        right.insert(
+            "base".to_string(),
+            WhereCondition::String("test://1".to_string()),
+        );
+        assert!(matches_where(&instance, &right, &s));
     }
 
     #[test]
@@ -1266,5 +1339,107 @@ mod tests {
         assert!(matches_where(&json!({ "a": "2" }), &wc, &shape));
         assert!(matches_where(&json!({ "b": "x" }), &wc, &shape));
         assert!(!matches_where(&json!({ "a": "3", "b": "y" }), &wc, &shape));
+    }
+
+    /// The reproducer for the leak the `id` arm used to have.
+    ///
+    /// Reaching this filter at all means the compiler declined the `OR` — here,
+    /// because the second branch's id is not IRI-valid, so it would emit a
+    /// `FILTER` that tests `?source` rather than a `VALUES` that binds it, and
+    /// a `UNION` branch that does not bind `?source` is not sound to push.
+    ///
+    /// With the arm skipping String conditions, each branch's only clause was
+    /// skipped, every branch returned true vacuously, `any` was satisfied, and
+    /// the whole disjunction admitted every hydrated row.
+    #[test]
+    fn test_or_of_ids_filters_after_the_compiler_declines() {
+        let shape = empty_shape();
+        let wc = make_where(vec![(
+            "OR",
+            WhereCondition::SubClauses(vec![
+                make_where(vec![(
+                    "id",
+                    WhereCondition::String("test://post/1".to_string()),
+                )]),
+                make_where(vec![(
+                    "id",
+                    WhereCondition::String("draft-note".to_string()),
+                )]),
+            ]),
+        )]);
+
+        assert!(matches_where(
+            &json!({ "id": "test://post/1" }),
+            &wc,
+            &shape
+        ));
+        assert!(matches_where(&json!({ "id": "draft-note" }), &wc, &shape));
+        // The one that used to be admitted along with everything else.
+        assert!(!matches_where(
+            &json!({ "id": "test://post/2" }),
+            &wc,
+            &shape
+        ));
+    }
+
+    /// The likelier route to the same place: an `OR` declined not because of
+    /// the id branch but because a *sibling* branch could not compile — a
+    /// getter-computed property has no predicate to emit. The id branch is
+    /// perfectly pushable on its own and still ends up here.
+    #[test]
+    fn test_or_of_id_and_getter_prop_filters_both_branches() {
+        let shape = empty_shape();
+        let wc = make_where(vec![(
+            "OR",
+            WhereCondition::SubClauses(vec![
+                make_where(vec![(
+                    "id",
+                    WhereCondition::String("test://post/1".to_string()),
+                )]),
+                make_where(vec![("computed", WhereCondition::String("x".to_string()))]),
+            ]),
+        )]);
+
+        assert!(matches_where(
+            &json!({ "id": "test://post/1" }),
+            &wc,
+            &shape
+        ));
+        assert!(matches_where(
+            &json!({ "id": "test://post/9", "computed": "x" }),
+            &wc,
+            &shape
+        ));
+        assert!(!matches_where(
+            &json!({ "id": "test://post/9", "computed": "y" }),
+            &wc,
+            &shape
+        ));
+    }
+
+    /// `NOT` over an id inverts properly now that the inner clause is tested
+    /// rather than skipped. Skipping made the inner branch match everything,
+    /// so `NOT` rejected everything.
+    #[test]
+    fn test_not_over_id_excludes_only_that_id() {
+        let shape = empty_shape();
+        let wc = make_where(vec![(
+            "NOT",
+            WhereCondition::SubClause(make_where(vec![(
+                "id",
+                WhereCondition::String("test://post/1".to_string()),
+            )])),
+        )]);
+
+        assert!(!matches_where(
+            &json!({ "id": "test://post/1" }),
+            &wc,
+            &shape
+        ));
+        assert!(matches_where(
+            &json!({ "id": "test://post/2" }),
+            &wc,
+            &shape
+        ));
     }
 }

--- a/rust-executor/src/perspectives/model_query/integration_tests.rs
+++ b/rust-executor/src/perspectives/model_query/integration_tests.rs
@@ -5383,3 +5383,282 @@ async fn test_duplicate_literal_property_values_keep_instances_distinct() {
         "base2's body must be unaffected by base1's independent update"
     );
 }
+
+/// A disjunction filters in SPARQL, and keeps its ordering and limit.
+///
+/// Before the where clause was compiled as one tree, `OR` was skipped by the
+/// emitter and evaluated post-hydration — which also disabled the SPARQL
+/// pagination pushdown entirely, because `all_where_pushable` returned false on
+/// sight of a combinator. The rows were right (the Rust filter ran) but the
+/// `ORDER BY` was not applied at the SPARQL level and the whole class was
+/// hydrated to answer a two-row query.
+///
+/// This is the shape the documented cross-field search box compiles to.
+#[tokio::test]
+async fn test_or_where_filters_in_sparql_with_order_and_limit() {
+    let store = SparqlStore::new(None).unwrap();
+
+    for (base, title, body, ts) in [
+        ("we://post/1", "Alpha", "about cats", "1700000000000"),
+        ("we://post/2", "Beta", "about dogs", "1700000000001"),
+        ("we://post/3", "Gamma", "about cats", "1700000000002"),
+    ] {
+        store
+            .add_link(&make_link(base, "we://flag", "we://post", ts))
+            .unwrap();
+        store
+            .add_link(&make_link(
+                base,
+                "we://title",
+                &format!("literal:string:{}", literal_percent_encode(title)),
+                ts,
+            ))
+            .unwrap();
+        store
+            .add_link(&make_link(
+                base,
+                "we://body",
+                &format!("literal:string:{}", literal_percent_encode(body)),
+                ts,
+            ))
+            .unwrap();
+    }
+
+    let shape_json = r#"{
+        "className": "Post",
+        "properties": {
+            "flag": {
+                "predicate": "we://flag",
+                "required": true,
+                "flag": true,
+                "initial": "we://post"
+            },
+            "title": { "predicate": "we://title", "resolveLanguage": "literal" },
+            "body": { "predicate": "we://body", "resolveLanguage": "literal" }
+        },
+        "relations": {}
+    }"#;
+
+    // title == "Alpha" OR body == "about dogs"  → posts 1 and 2, not 3.
+    let or_clause = super::types::WhereCondition::SubClauses(vec![
+        BTreeMap::from([(
+            "title".to_string(),
+            super::types::WhereCondition::String("Alpha".to_string()),
+        )]),
+        BTreeMap::from([(
+            "body".to_string(),
+            super::types::WhereCondition::String("about dogs".to_string()),
+        )]),
+    ]);
+
+    let query = ModelQueryInput {
+        where_clause: Some(BTreeMap::from([("OR".to_string(), or_clause)])),
+        order: Some(vec![(
+            "title".to_string(),
+            super::types::OrderDirection::DESC,
+        )]),
+        limit: Some(10),
+        ..Default::default()
+    };
+
+    let result = execute_model_query_from_json(&store, "Post", &query, shape_json)
+        .await
+        .unwrap();
+
+    let titles: Vec<&str> = result
+        .instances
+        .iter()
+        .map(|i| i["title"].as_str().unwrap())
+        .collect();
+
+    assert_eq!(
+        titles,
+        vec!["Beta", "Alpha"],
+        "the disjunction must match exactly posts 1 and 2, ordered by title DESC",
+    );
+}
+
+/// A negation filters in SPARQL.
+#[tokio::test]
+async fn test_not_where_filters_in_sparql() {
+    let store = SparqlStore::new(None).unwrap();
+
+    for (base, title, ts) in [
+        ("we://post/1", "keep", "1700000000000"),
+        ("we://post/2", "drop", "1700000000001"),
+    ] {
+        store
+            .add_link(&make_link(base, "we://flag", "we://post", ts))
+            .unwrap();
+        store
+            .add_link(&make_link(
+                base,
+                "we://title",
+                &format!("literal:string:{}", literal_percent_encode(title)),
+                ts,
+            ))
+            .unwrap();
+    }
+
+    let shape_json = r#"{
+        "className": "Post",
+        "properties": {
+            "flag": {
+                "predicate": "we://flag",
+                "required": true,
+                "flag": true,
+                "initial": "we://post"
+            },
+            "title": { "predicate": "we://title", "resolveLanguage": "literal" }
+        },
+        "relations": {}
+    }"#;
+
+    let query = ModelQueryInput {
+        where_clause: Some(BTreeMap::from([(
+            "NOT".to_string(),
+            super::types::WhereCondition::SubClause(BTreeMap::from([(
+                "title".to_string(),
+                super::types::WhereCondition::String("drop".to_string()),
+            )])),
+        )])),
+        limit: Some(10),
+        ..Default::default()
+    };
+
+    let result = execute_model_query_from_json(&store, "Post", &query, shape_json)
+        .await
+        .unwrap();
+
+    let titles: Vec<&str> = result
+        .instances
+        .iter()
+        .map(|i| i["title"].as_str().unwrap())
+        .collect();
+
+    assert_eq!(titles, vec!["keep"]);
+}
+
+/// Two conditions on one property, inside a combinator, must not collide.
+///
+/// Variable names are derived from the property name. That is safe while a where
+/// clause is a flat map — keys are unique — but a combinator lets the same
+/// property appear twice, and both leaves then emit `BIND(… AS ?_pw_title_v)`
+/// into the same group. SPARQL forbids binding a variable already in scope, so
+/// this did not return the wrong rows: the query failed to parse
+/// ("Query is not valid read-only SPARQL … expected [_]").
+#[tokio::test]
+async fn test_and_with_two_conditions_on_one_property() {
+    let store = SparqlStore::new(None).unwrap();
+    for (base, title) in [("ns://p/1", "alpha beta"), ("ns://p/2", "alpha only")] {
+        store
+            .add_link(&make_link(base, "ns://flag", "ns://post", "1"))
+            .unwrap();
+        store
+            .add_link(&make_link(
+                base,
+                "ns://title",
+                &format!("literal:string:{}", literal_percent_encode(title)),
+                "1",
+            ))
+            .unwrap();
+    }
+
+    let shape_json = r#"{"className":"Post","properties":{
+        "flag":{"predicate":"ns://flag","required":true,"flag":true,"initial":"ns://post"},
+        "title":{"predicate":"ns://title","resolveLanguage":"literal"}},"relations":{}}"#;
+
+    let contains = |v: &str| {
+        super::types::WhereCondition::Ops(super::types::WhereOps {
+            contains: Some(serde_json::Value::String(v.to_string())),
+            ..Default::default()
+        })
+    };
+
+    let query = ModelQueryInput {
+        where_clause: Some(BTreeMap::from([(
+            "AND".to_string(),
+            super::types::WhereCondition::SubClauses(vec![
+                BTreeMap::from([("title".to_string(), contains("alpha"))]),
+                BTreeMap::from([("title".to_string(), contains("beta"))]),
+            ]),
+        )])),
+        ..Default::default()
+    };
+
+    let result = execute_model_query_from_json(&store, "Post", &query, shape_json)
+        .await
+        .expect("the clause must compile to valid SPARQL");
+
+    let ids: Vec<&str> = result
+        .instances
+        .iter()
+        .map(|i| i["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        ids,
+        vec!["ns://p/1"],
+        "only the title containing both terms matches",
+    );
+}
+
+/// A `NOT` branch constraining a property the outer clause also constrains.
+///
+/// Not a bug that was observed — `FILTER NOT EXISTS` opens its own group, so this
+/// case survived the collision above and returns the right rows either way. Kept
+/// as a guard, because it is the shape most likely to break if the uniquifying
+/// ever regresses.
+#[tokio::test]
+async fn test_not_on_a_property_also_constrained_outside() {
+    let store = SparqlStore::new(None).unwrap();
+    for (base, title) in [("ns://p/1", "alpha beta"), ("ns://p/2", "alpha only")] {
+        store
+            .add_link(&make_link(base, "ns://flag", "ns://post", "1"))
+            .unwrap();
+        store
+            .add_link(&make_link(
+                base,
+                "ns://title",
+                &format!("literal:string:{}", literal_percent_encode(title)),
+                "1",
+            ))
+            .unwrap();
+    }
+
+    let shape_json = r#"{"className":"Post","properties":{
+        "flag":{"predicate":"ns://flag","required":true,"flag":true,"initial":"ns://post"},
+        "title":{"predicate":"ns://title","resolveLanguage":"literal"}},"relations":{}}"#;
+
+    let contains = |v: &str| {
+        super::types::WhereCondition::Ops(super::types::WhereOps {
+            contains: Some(serde_json::Value::String(v.to_string())),
+            ..Default::default()
+        })
+    };
+
+    // title contains "alpha" AND NOT title contains "beta"
+    let query = ModelQueryInput {
+        where_clause: Some(BTreeMap::from([
+            ("title".to_string(), contains("alpha")),
+            (
+                "NOT".to_string(),
+                super::types::WhereCondition::SubClause(BTreeMap::from([(
+                    "title".to_string(),
+                    contains("beta"),
+                )])),
+            ),
+        ])),
+        ..Default::default()
+    };
+
+    let result = execute_model_query_from_json(&store, "Post", &query, shape_json)
+        .await
+        .expect("the clause must compile to valid SPARQL");
+
+    let ids: Vec<&str> = result
+        .instances
+        .iter()
+        .map(|i| i["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids, vec!["ns://p/2"], "the one without \"beta\"");
+}

--- a/rust-executor/src/perspectives/model_query/sparql_builder.rs
+++ b/rust-executor/src/perspectives/model_query/sparql_builder.rs
@@ -15,6 +15,8 @@
 
 use serde_json::Value;
 
+use std::collections::BTreeMap;
+
 use super::types::{
     InstanceQueryPlan, ModelQueryInput, ModelShape, OrderDirection, Scope, SortKey,
     SparqlPagination, WhereCondition,
@@ -257,50 +259,26 @@ pub(super) fn build_count_sparql(shape: &ModelShape, query: &ModelQueryInput) ->
 
 /// Check whether **all** where-clause conditions can be pushed into SPARQL.
 ///
-/// Returns `true` when every condition targets either `id`/`base` (with
-/// simple string values), a collection relation (with string/array values),
-/// or a known scalar property.  When this returns `false`, post-hydration
-/// Rust-side filtering is required for the remaining conditions.
+/// Answered by *performing* the compilation and reporting whether it was
+/// complete, so this cannot drift from what [`build_query_patterns`] actually
+/// emits.
+///
+/// It used to be a second, hand-maintained judgement about which conditions the
+/// emitter could handle, and the two disagreed. A scalar property was declared
+/// pushable for any condition, while the emitter additionally required a
+/// non-empty, IRI-valid predicate — so a `@Property({ getter })` field, which
+/// carries no predicate, was reported pushable and then emitted nothing. The
+/// caller skips post-hydration filtering when this returns `true`, so the
+/// condition was applied in neither place and the query silently returned
+/// unfiltered rows (and `count()` an unfiltered count).
+///
+/// When this returns `false`, post-hydration Rust-side filtering is required for
+/// the remaining conditions, and SPARQL-level pagination must not be pushed.
 pub(super) fn all_where_pushable(query: &ModelQueryInput, shape: &ModelShape) -> bool {
-    let Some(ref wc) = query.where_clause else {
-        return true;
-    };
-    for (prop_name, condition) in wc {
-        // OR/AND/NOT are always evaluated Rust-side; SPARQL-level pagination
-        // cannot be applied when they are present.
-        if prop_name == "OR" || prop_name == "AND" || prop_name == "NOT" {
-            return false;
-        }
-
-        if prop_name == "base" || prop_name == "id" {
-            match condition {
-                WhereCondition::String(_) | WhereCondition::StringArray(_) => continue,
-                _ => return false,
-            }
-        }
-        if shape
-            .properties
-            .iter()
-            .any(|p| p.name == *prop_name && p.is_collection)
-        {
-            if matches!(
-                condition,
-                WhereCondition::String(_) | WhereCondition::StringArray(_)
-            ) {
-                continue;
-            }
-            return false;
-        }
-        if shape
-            .properties
-            .iter()
-            .any(|p| p.name == *prop_name && !p.is_collection)
-        {
-            continue;
-        }
-        return false;
+    match query.where_clause {
+        None => true,
+        Some(ref wc) => compile_where_clause(wc, shape).complete,
     }
-    true
 }
 
 /// Build the conformance and where-clause SPARQL pattern strings.
@@ -453,389 +431,11 @@ pub(super) fn build_query_patterns(
     }
 
     // WHERE clause filters that can be pushed to SPARQL.
-    let mut where_patterns = Vec::new();
-    if let Some(ref wc) = query.where_clause {
-        for (prop_name, condition) in wc {
-            // OR/AND/NOT are evaluated Rust-side after hydration; skip SPARQL emission.
-            if prop_name == "OR" || prop_name == "AND" || prop_name == "NOT" {
-                continue;
-            }
-
-            if prop_name == "base" || prop_name == "id" {
-                match condition {
-                    WhereCondition::String(val) => {
-                        if validate_iri(val).is_ok() {
-                            where_patterns.push(format!("    FILTER(?source = <{val}>)"));
-                        } else {
-                            where_patterns.push(format!(
-                                "    FILTER(STR(?source) = \"{}\")",
-                                escape_sparql_string(val)
-                            ));
-                        }
-                    }
-                    WhereCondition::StringArray(vals) => {
-                        let valid: Vec<&str> = vals
-                            .iter()
-                            .filter(|v| validate_iri(v).is_ok())
-                            .map(|v| v.as_str())
-                            .collect();
-                        if valid.len() == vals.len() {
-                            let iris = valid
-                                .iter()
-                                .map(|v| format!("<{v}>"))
-                                .collect::<Vec<_>>()
-                                .join(" ");
-                            where_patterns.push(format!("    VALUES ?source {{ {iris} }}"));
-                        } else {
-                            let ids = vals
-                                .iter()
-                                .map(|v| format!("\"{}\"", escape_sparql_string(v)))
-                                .collect::<Vec<_>>()
-                                .join(", ");
-                            where_patterns.push(format!("    FILTER(STR(?source) IN ({ids}))"));
-                        }
-                    }
-                    _ => {}
-                }
-                continue;
-            }
-
-            // Relation-based where
-            if let Some(prop) = shape
-                .properties
-                .iter()
-                .find(|p| &p.name == prop_name && p.is_collection)
-            {
-                let direction = prop.direction.as_deref().unwrap_or("forward");
-                match condition {
-                    WhereCondition::String(val) => {
-                        if validate_iri(val).is_ok() {
-                            if direction == "reverse" {
-                                where_patterns
-                                    .push(format!("    <{val}> <{}> ?source .", prop.predicate));
-                            } else {
-                                where_patterns
-                                    .push(format!("    ?source <{}> <{val}> .", prop.predicate));
-                            }
-                        } else {
-                            let safe_name = prop_name.replace(|c: char| !c.is_alphanumeric(), "_");
-                            let escaped = escape_sparql_string(val);
-                            if direction == "reverse" {
-                                where_patterns.push(format!(
-                                    "    ?_rv_{safe_name} <{}> ?source . FILTER(STR(?_rv_{safe_name}) = \"{escaped}\")",
-                                    prop.predicate
-                                ));
-                            } else {
-                                where_patterns.push(format!(
-                                    "    ?source <{}> ?_ft_{safe_name} . FILTER(STR(?_ft_{safe_name}) = \"{escaped}\")",
-                                    prop.predicate
-                                ));
-                            }
-                        }
-                    }
-                    WhereCondition::StringArray(vals) => {
-                        let safe_name = prop_name.replace(|c: char| !c.is_alphanumeric(), "_");
-                        let all_valid = vals.iter().all(|v| validate_iri(v).is_ok());
-                        if all_valid {
-                            let iris = vals
-                                .iter()
-                                .map(|v| format!("<{v}>"))
-                                .collect::<Vec<_>>()
-                                .join(" ");
-                            if direction == "reverse" {
-                                where_patterns.push(format!(
-                                    "    VALUES ?_rv_{safe_name} {{ {iris} }}\n    ?_rv_{safe_name} <{}> ?source .",
-                                    prop.predicate
-                                ));
-                            } else {
-                                where_patterns.push(format!(
-                                    "    VALUES ?_ft_{safe_name} {{ {iris} }}\n    ?source <{}> ?_ft_{safe_name} .",
-                                    prop.predicate
-                                ));
-                            }
-                        } else {
-                            let str_list = vals
-                                .iter()
-                                .map(|v| format!("\"{}\"", escape_sparql_string(v)))
-                                .collect::<Vec<_>>()
-                                .join(", ");
-                            if direction == "reverse" {
-                                where_patterns.push(format!(
-                                    "    ?_rv_{safe_name} <{}> ?source . FILTER(STR(?_rv_{safe_name}) IN ({str_list}))",
-                                    prop.predicate
-                                ));
-                            } else {
-                                where_patterns.push(format!(
-                                    "    ?source <{}> ?_ft_{safe_name} . FILTER(STR(?_ft_{safe_name}) IN ({str_list}))",
-                                    prop.predicate
-                                ));
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-                continue;
-            }
-
-            // Property-based where
-            if let Some(prop) = shape
-                .properties
-                .iter()
-                .find(|p| &p.name == prop_name && !p.is_collection && !p.predicate.is_empty())
-            {
-                if validate_iri(&prop.predicate).is_err() {
-                    continue;
-                }
-                let safe_name = prop_name.replace(|c: char| !c.is_alphanumeric(), "_");
-                let is_literal_prop = prop.is_deterministic_literal();
-                match condition {
-                    WhereCondition::String(val) => {
-                        if is_literal_prop {
-                            // Match the typed-literal storage form directly so
-                            // Oxigraph's POS index handles the lookup.  When
-                            // the value is itself a valid absolute IRI we keep
-                            // a UNION fallback so constructor-seeded raw URIs
-                            // on literal-resolveLanguage properties still
-                            // resolve.
-                            let escaped = escape_sparql_string(val);
-                            if looks_like_absolute_iri(val) {
-                                where_patterns.push(format!(
-                                    "    {{ ?source <{0}> \"{escaped}\"^^<{XSD_STRING}> . }} UNION {{ ?source <{0}> <{val}> . }}",
-                                    prop.predicate
-                                ));
-                            } else {
-                                where_patterns.push(format!(
-                                    "    ?source <{}> \"{escaped}\"^^<{XSD_STRING}> .",
-                                    prop.predicate
-                                ));
-                            }
-                        } else {
-                            // Expression-resolved storage (signed literal envelope
-                            // or custom resolveLanguage): the stored term is the
-                            // envelope/expression, never a NamedNode equal to
-                            // `val`. Unwrap with `fn/parse_literal` and compare on
-                            // the decoded value. (Emitting `<val>` here would also
-                            // be an invalid relative IRI for non-absolute values.)
-                            let var = format!("?_pw_{safe_name}");
-                            let escaped = escape_sparql_string(val);
-                            where_patterns
-                                .push(format!("    ?source <{}> {var} .", prop.predicate));
-                            where_patterns.push(format!(
-                                "    FILTER(<ad4m://fn/parse_literal>({var}) = \"{escaped}\")"
-                            ));
-                        }
-                    }
-                    WhereCondition::Number(n) => {
-                        if is_literal_prop {
-                            if let Some(typed) = typed_number_literal(*n) {
-                                where_patterns
-                                    .push(format!("    ?source <{}> {typed} .", prop.predicate));
-                            } else {
-                                where_patterns.push("    FILTER(false)".to_string());
-                            }
-                        } else {
-                            let var = format!("?_pw_{safe_name}");
-                            where_patterns
-                                .push(format!("    ?source <{}> {var} .", prop.predicate));
-                            where_patterns.push(format!(
-                                "    FILTER(<ad4m://fn/parse_literal>({var}) = \"{n}\")"
-                            ));
-                        }
-                    }
-                    WhereCondition::Bool(b) => {
-                        if is_literal_prop {
-                            where_patterns.push(format!(
-                                "    ?source <{}> \"{b}\"^^<{XSD_BOOLEAN}> .",
-                                prop.predicate
-                            ));
-                        } else {
-                            let var = format!("?_pw_{safe_name}");
-                            where_patterns
-                                .push(format!("    ?source <{}> {var} .", prop.predicate));
-                            where_patterns.push(format!(
-                                "    FILTER(<ad4m://fn/parse_literal>({var}) = \"{b}\")"
-                            ));
-                        }
-                    }
-                    WhereCondition::StringArray(vals) => {
-                        if is_literal_prop {
-                            let mut items: Vec<String> = Vec::with_capacity(vals.len() * 2);
-                            for v in vals {
-                                let escaped = escape_sparql_string(v);
-                                items.push(format!("\"{escaped}\"^^<{XSD_STRING}>"));
-                                if looks_like_absolute_iri(v) {
-                                    items.push(format!("<{v}>"));
-                                }
-                            }
-                            let iv_var = format!("?_iv_{safe_name}");
-                            where_patterns
-                                .push(format!("    VALUES {iv_var} {{ {} }}", items.join(" ")));
-                            where_patterns
-                                .push(format!("    ?source <{}> {iv_var} .", prop.predicate));
-                        } else {
-                            let values_list = vals
-                                .iter()
-                                .map(|v| format!("\"{}\"", escape_sparql_string(v)))
-                                .collect::<Vec<_>>()
-                                .join(", ");
-                            let var = format!("?_pw_{safe_name}");
-                            where_patterns
-                                .push(format!("    ?source <{}> {var} .", prop.predicate));
-                            where_patterns.push(format!(
-                                "    FILTER(<ad4m://fn/parse_literal>({var}) IN ({values_list}))"
-                            ));
-                        }
-                    }
-                    WhereCondition::NumberArray(vals) => {
-                        if is_literal_prop {
-                            let items: Vec<String> = vals
-                                .iter()
-                                .filter_map(|n| typed_number_literal(*n))
-                                .collect();
-                            if items.is_empty() {
-                                where_patterns.push("    FILTER(false)".to_string());
-                            } else {
-                                let iv_var = format!("?_iv_{safe_name}");
-                                where_patterns
-                                    .push(format!("    VALUES {iv_var} {{ {} }}", items.join(" ")));
-                                where_patterns
-                                    .push(format!("    ?source <{}> {iv_var} .", prop.predicate));
-                            }
-                        } else {
-                            let values_list = vals
-                                .iter()
-                                .map(|n| format!("\"{n}\""))
-                                .collect::<Vec<_>>()
-                                .join(", ");
-                            let var = format!("?_pw_{safe_name}");
-                            where_patterns
-                                .push(format!("    ?source <{}> {var} .", prop.predicate));
-                            where_patterns.push(format!(
-                                "    FILTER(<ad4m://fn/parse_literal>({var}) IN ({values_list}))"
-                            ));
-                        }
-                    }
-                    WhereCondition::Ops(ops) => {
-                        let var = format!("?_pw_{safe_name}");
-                        let val_var = format!("?_pw_{safe_name}_v");
-                        where_patterns.push(format!("    ?source <{}> {var} .", prop.predicate));
-                        // Compare on the lexical string rather than on a typed
-                        // literal term: Oxigraph treats a simple literal and an
-                        // `xsd:string` literal as distinct terms, so `?v != "x"^^xsd:string`
-                        // silently fails to match values stored either way.
-                        //
-                        // Deterministic literals expose their value via `STR()`
-                        // directly; envelope / custom-language values need
-                        // `parse_literal` first to reach the inner `data`.
-                        let val_src = if is_literal_prop {
-                            var.clone()
-                        } else {
-                            format!("<ad4m://fn/parse_literal>({var})")
-                        };
-                        where_patterns.push(format!("    BIND(STR({val_src}) AS {val_var})"));
-
-                        let mut filters = Vec::new();
-
-                        if let Some(ref not_val) = ops.not {
-                            match not_val {
-                                Value::String(s) => {
-                                    filters.push(format!(
-                                        "{val_var} != \"{}\"",
-                                        escape_sparql_string(s)
-                                    ));
-                                }
-                                Value::Number(n) => {
-                                    let n_f64 = n.as_f64().unwrap_or(0.0);
-                                    let n_str = if n_f64.fract() == 0.0 {
-                                        format!("{}", n_f64 as i64)
-                                    } else {
-                                        format!("{n_f64}")
-                                    };
-                                    filters.push(format!("{val_var} != \"{n_str}\""));
-                                }
-                                Value::Bool(b) => {
-                                    filters.push(format!("{val_var} != \"{b}\""));
-                                }
-                                Value::Array(arr) => {
-                                    let items: Vec<String> = arr
-                                        .iter()
-                                        .filter_map(|item| match item {
-                                            Value::String(s) => {
-                                                Some(format!("\"{}\"", escape_sparql_string(s)))
-                                            }
-                                            Value::Number(n) => {
-                                                let f = n.as_f64().unwrap_or(0.0);
-                                                let s = if f.fract() == 0.0 {
-                                                    format!("{}", f as i64)
-                                                } else {
-                                                    format!("{f}")
-                                                };
-                                                Some(format!("\"{s}\""))
-                                            }
-                                            _ => None,
-                                        })
-                                        .collect();
-                                    if !items.is_empty() {
-                                        filters.push(format!(
-                                            "{val_var} NOT IN ({})",
-                                            items.join(", ")
-                                        ));
-                                    }
-                                }
-                                _ => {}
-                            }
-                        }
-
-                        let has_numeric = ops.gt.is_some()
-                            || ops.gte.is_some()
-                            || ops.lt.is_some()
-                            || ops.lte.is_some()
-                            || ops.between.is_some();
-
-                        if has_numeric {
-                            let num_var = format!("?_pw_{safe_name}_num");
-                            where_patterns
-                                .push(format!("    BIND(<{XSD_DOUBLE}>({val_var}) AS {num_var})"));
-                            if let Some(gt) = ops.gt {
-                                filters.push(format!("{num_var} > {gt}"));
-                            }
-                            if let Some(gte) = ops.gte {
-                                filters.push(format!("{num_var} >= {gte}"));
-                            }
-                            if let Some(lt) = ops.lt {
-                                filters.push(format!("{num_var} < {lt}"));
-                            }
-                            if let Some(lte) = ops.lte {
-                                filters.push(format!("{num_var} <= {lte}"));
-                            }
-                            if let Some((lo, hi)) = ops.between {
-                                filters.push(format!("{num_var} >= {lo} && {num_var} <= {hi}"));
-                            }
-                        }
-
-                        if let Some(ref contains_val) = ops.contains {
-                            let needle = match contains_val {
-                                Value::String(s) => s.clone(),
-                                other => other.to_string(),
-                            };
-                            filters.push(format!(
-                                "CONTAINS(LCASE({val_var}), LCASE(\"{}\"))",
-                                escape_sparql_string(&needle)
-                            ));
-                        }
-
-                        if !filters.is_empty() {
-                            where_patterns.push(format!("    FILTER({})", filters.join(" && ")));
-                        }
-                    }
-                    // SubClauses/SubClause are OR/AND/NOT combinators evaluated
-                    // Rust-side; the outer loop skips them before reaching here.
-                    WhereCondition::SubClauses(_) | WhereCondition::SubClause(_) => {}
-                }
-                continue;
-            }
-        }
-    }
+    let where_patterns = query
+        .where_clause
+        .as_ref()
+        .map(|wc| compile_where_clause(wc, shape).patterns)
+        .unwrap_or_default();
 
     let conformance = conformance_patterns.join("\n");
     let where_extra = where_patterns.join("\n");
@@ -843,10 +443,567 @@ pub(super) fn build_query_patterns(
     (conformance, where_extra)
 }
 
+/// The outcome of compiling a where clause into SPARQL patterns.
+pub(super) struct CompiledWhere {
+    /// Patterns to splice into the query's WHERE block.
+    ///
+    /// Always sound to apply even when `complete` is false: every pattern is a
+    /// conjunctive constraint, so a partial set narrows the candidates without
+    /// ever excluding a row the full clause would have kept.
+    pub(super) patterns: Vec<String>,
+    /// Whether *every* condition in the clause reached `patterns`.
+    ///
+    /// When false the caller must still filter post-hydration, and must not push
+    /// pagination — a `LIMIT` over a partially-filtered set returns the wrong
+    /// rows, silently. This flag is the single source of that answer; deriving it
+    /// separately from the emission is what let the two disagree.
+    pub(super) complete: bool,
+}
+
+/// `None` when a condition produced no patterns at all.
+///
+/// Every unhandled match arm in [`compile_leaf_condition`] falls through to this,
+/// so "the emitter did not understand this condition" is reported rather than
+/// silently dropping the constraint.
+fn finish(out: Vec<String>) -> Option<Vec<String>> {
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+/// Does this pattern group bind `?source` on its own?
+///
+/// Only `UNION` branches need to care. SPARQL evaluates each branch
+/// independently and joins the result with the surrounding group afterwards, so
+/// a branch holding nothing but `FILTER(?source = <x>)` is evaluated with
+/// `?source` unbound — the filter errors, the branch yields nothing, and the
+/// disjunction quietly loses an arm. Inside the ordinary conjunction that is not
+/// a concern, because the instance query's own `?source ?predicate ?target`
+/// binds it.
+///
+/// Deliberately conservative: a false negative only costs pushdown for that
+/// query, while a false positive would produce wrong results.
+fn binds_source(patterns: &[String]) -> bool {
+    patterns.iter().any(|p| {
+        let t = p.trim();
+        t.starts_with("?source <")
+            || t.starts_with("{ ?source <")
+            || t.starts_with("VALUES ?source ")
+            || t.contains("> ?source .")
+    })
+}
+
+/// Compile a where clause into SPARQL patterns, reporting whether all of it fit.
+///
+/// Combinators compile as follows, and each is all-or-nothing for a reason:
+///
+/// - `AND` — a conjunction, so a partially compiled branch is still sound; the
+///   uncompiled parts fall to the post-hydration filter.
+/// - `OR` — a disjunction, so partial compilation is **not** sound: emitting only
+///   the arms that compiled would exclude rows the missing arm would have
+///   matched. Every branch must compile *and* bind `?source`, or the whole `OR`
+///   is left to post-hydration.
+/// - `NOT` — same reasoning as `OR`; a partial `FILTER NOT EXISTS` excludes rows
+///   it should keep. The branch need not bind `?source` itself, because
+///   `FILTER NOT EXISTS` is evaluated per solution with outer bindings visible.
+pub(super) fn compile_where_clause(
+    wc: &BTreeMap<String, WhereCondition>,
+    shape: &ModelShape,
+) -> CompiledWhere {
+    let mut seq = 0usize;
+    compile_where_clause_seq(wc, shape, &mut seq)
+}
+
+/// The recursive body, threading a counter that makes every generated variable
+/// name unique across the whole clause.
+///
+/// Variable names were derived from the property name alone. That is safe while a
+/// where clause is a flat map — its keys are unique — but a combinator lets the
+/// same property appear more than once, and two leaves on one property then emit
+/// `BIND(… AS ?_pw_title_v)` twice into the same group. SPARQL forbids binding a
+/// variable already in scope, so such a clause did not return the wrong rows: it
+/// failed to parse.
+///
+/// The counter advances once per leaf, so variables *within* a leaf still share a
+/// suffix and correlate as they must.
+fn compile_where_clause_seq(
+    wc: &BTreeMap<String, WhereCondition>,
+    shape: &ModelShape,
+    seq: &mut usize,
+) -> CompiledWhere {
+    let mut patterns = Vec::new();
+    let mut complete = true;
+
+    for (prop_name, condition) in wc {
+        match prop_name.as_str() {
+            "AND" => match condition {
+                WhereCondition::SubClauses(branches) => {
+                    for branch in branches {
+                        let compiled = compile_where_clause_seq(branch, shape, seq);
+                        patterns.extend(compiled.patterns);
+                        complete &= compiled.complete;
+                    }
+                }
+                _ => complete = false,
+            },
+            "OR" => match condition {
+                WhereCondition::SubClauses(branches) if !branches.is_empty() => {
+                    let mut arms = Vec::with_capacity(branches.len());
+                    let mut ok = true;
+                    for branch in branches {
+                        let compiled = compile_where_clause_seq(branch, shape, seq);
+                        if !compiled.complete || !binds_source(&compiled.patterns) {
+                            ok = false;
+                            break;
+                        }
+                        arms.push(format!("{{\n{}\n    }}", compiled.patterns.join("\n")));
+                    }
+                    if ok {
+                        patterns.push(format!("    {}", arms.join(" UNION ")));
+                    } else {
+                        complete = false;
+                    }
+                }
+                _ => complete = false,
+            },
+            "NOT" => match condition {
+                WhereCondition::SubClause(branch) => {
+                    let compiled = compile_where_clause_seq(branch, shape, seq);
+                    if compiled.complete && !compiled.patterns.is_empty() {
+                        patterns.push(format!(
+                            "    FILTER NOT EXISTS {{\n{}\n    }}",
+                            compiled.patterns.join("\n")
+                        ));
+                    } else {
+                        complete = false;
+                    }
+                }
+                _ => complete = false,
+            },
+            _ => match compile_leaf_condition(prop_name.as_str(), condition, shape, seq) {
+                Some(p) => patterns.extend(p),
+                None => complete = false,
+            },
+        }
+    }
+
+    CompiledWhere { patterns, complete }
+}
+
+/// Compile one `(property, condition)` pair into SPARQL patterns.
+///
+/// `None` means "not expressible here" — an unknown property, a getter-backed
+/// property with no link predicate, a predicate that is not a valid IRI, or a
+/// condition shape no arm handles. The caller turns that into
+/// `CompiledWhere::complete = false`, which is what routes the condition to the
+/// post-hydration filter instead of dropping it.
+fn compile_leaf_condition(
+    prop_name: &str,
+    condition: &WhereCondition,
+    shape: &ModelShape,
+    seq: &mut usize,
+) -> Option<Vec<String>> {
+    let mut out: Vec<String> = Vec::new();
+    // One id per leaf: variables inside a leaf share it, because they are meant
+    // to correlate. Variables across leaves never do.
+    let leaf_id = *seq;
+    *seq += 1;
+
+    if prop_name == "base" || prop_name == "id" {
+        match condition {
+            WhereCondition::String(val) => {
+                if validate_iri(val).is_ok() {
+                    // `VALUES` rather than `FILTER(?source = <val>)`:
+                    // it binds `?source` instead of merely testing it,
+                    // which is what lets an `id` condition stand alone
+                    // inside a `UNION` branch (see `binds_source`), and
+                    // it hands Oxigraph a single subject to seek to
+                    // rather than a predicate over every candidate.
+                    out.push(format!("    VALUES ?source {{ <{val}> }}"));
+                } else {
+                    out.push(format!(
+                        "    FILTER(STR(?source) = \"{}\")",
+                        escape_sparql_string(val)
+                    ));
+                }
+            }
+            WhereCondition::StringArray(vals) => {
+                let valid: Vec<&str> = vals
+                    .iter()
+                    .filter(|v| validate_iri(v).is_ok())
+                    .map(|v| v.as_str())
+                    .collect();
+                if valid.len() == vals.len() {
+                    let iris = valid
+                        .iter()
+                        .map(|v| format!("<{v}>"))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    out.push(format!("    VALUES ?source {{ {iris} }}"));
+                } else {
+                    let ids = vals
+                        .iter()
+                        .map(|v| format!("\"{}\"", escape_sparql_string(v)))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    out.push(format!("    FILTER(STR(?source) IN ({ids}))"));
+                }
+            }
+            _ => {}
+        }
+        return finish(out);
+    }
+
+    // Relation-based where
+    if let Some(prop) = shape
+        .properties
+        .iter()
+        .find(|p| &p.name == prop_name && p.is_collection)
+    {
+        let direction = prop.direction.as_deref().unwrap_or("forward");
+        match condition {
+            WhereCondition::String(val) => {
+                if validate_iri(val).is_ok() {
+                    if direction == "reverse" {
+                        out.push(format!("    <{val}> <{}> ?source .", prop.predicate));
+                    } else {
+                        out.push(format!("    ?source <{}> <{val}> .", prop.predicate));
+                    }
+                } else {
+                    let safe_name = format!(
+                        "{}_{leaf_id}",
+                        prop_name.replace(|c: char| !c.is_alphanumeric(), "_")
+                    );
+                    let escaped = escape_sparql_string(val);
+                    if direction == "reverse" {
+                        out.push(format!(
+                                    "    ?_rv_{safe_name} <{}> ?source . FILTER(STR(?_rv_{safe_name}) = \"{escaped}\")",
+                                    prop.predicate
+                                ));
+                    } else {
+                        out.push(format!(
+                                    "    ?source <{}> ?_ft_{safe_name} . FILTER(STR(?_ft_{safe_name}) = \"{escaped}\")",
+                                    prop.predicate
+                                ));
+                    }
+                }
+            }
+            WhereCondition::StringArray(vals) => {
+                let safe_name = format!(
+                    "{}_{leaf_id}",
+                    prop_name.replace(|c: char| !c.is_alphanumeric(), "_")
+                );
+                let all_valid = vals.iter().all(|v| validate_iri(v).is_ok());
+                if all_valid {
+                    let iris = vals
+                        .iter()
+                        .map(|v| format!("<{v}>"))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    if direction == "reverse" {
+                        out.push(format!(
+                                    "    VALUES ?_rv_{safe_name} {{ {iris} }}\n    ?_rv_{safe_name} <{}> ?source .",
+                                    prop.predicate
+                                ));
+                    } else {
+                        out.push(format!(
+                                    "    VALUES ?_ft_{safe_name} {{ {iris} }}\n    ?source <{}> ?_ft_{safe_name} .",
+                                    prop.predicate
+                                ));
+                    }
+                } else {
+                    let str_list = vals
+                        .iter()
+                        .map(|v| format!("\"{}\"", escape_sparql_string(v)))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    if direction == "reverse" {
+                        out.push(format!(
+                                    "    ?_rv_{safe_name} <{}> ?source . FILTER(STR(?_rv_{safe_name}) IN ({str_list}))",
+                                    prop.predicate
+                                ));
+                    } else {
+                        out.push(format!(
+                                    "    ?source <{}> ?_ft_{safe_name} . FILTER(STR(?_ft_{safe_name}) IN ({str_list}))",
+                                    prop.predicate
+                                ));
+                    }
+                }
+            }
+            _ => {}
+        }
+        return finish(out);
+    }
+
+    // Property-based where
+    if let Some(prop) = shape
+        .properties
+        .iter()
+        .find(|p| &p.name == prop_name && !p.is_collection && !p.predicate.is_empty())
+    {
+        if validate_iri(&prop.predicate).is_err() {
+            return None;
+        }
+        let safe_name = format!(
+            "{}_{leaf_id}",
+            prop_name.replace(|c: char| !c.is_alphanumeric(), "_")
+        );
+        let is_literal_prop = prop.is_deterministic_literal();
+        match condition {
+            WhereCondition::String(val) => {
+                if is_literal_prop {
+                    // Match the typed-literal storage form directly so
+                    // Oxigraph's POS index handles the lookup.  When
+                    // the value is itself a valid absolute IRI we keep
+                    // a UNION fallback so constructor-seeded raw URIs
+                    // on literal-resolveLanguage properties still
+                    // resolve.
+                    let escaped = escape_sparql_string(val);
+                    if looks_like_absolute_iri(val) {
+                        out.push(format!(
+                                    "    {{ ?source <{0}> \"{escaped}\"^^<{XSD_STRING}> . }} UNION {{ ?source <{0}> <{val}> . }}",
+                                    prop.predicate
+                                ));
+                    } else {
+                        out.push(format!(
+                            "    ?source <{}> \"{escaped}\"^^<{XSD_STRING}> .",
+                            prop.predicate
+                        ));
+                    }
+                } else {
+                    // Expression-resolved storage (signed literal envelope
+                    // or custom resolveLanguage): the stored term is the
+                    // envelope/expression, never a NamedNode equal to
+                    // `val`. Unwrap with `fn/parse_literal` and compare on
+                    // the decoded value. (Emitting `<val>` here would also
+                    // be an invalid relative IRI for non-absolute values.)
+                    let var = format!("?_pw_{safe_name}");
+                    let escaped = escape_sparql_string(val);
+                    out.push(format!("    ?source <{}> {var} .", prop.predicate));
+                    out.push(format!(
+                        "    FILTER(<ad4m://fn/parse_literal>({var}) = \"{escaped}\")"
+                    ));
+                }
+            }
+            WhereCondition::Number(n) => {
+                if is_literal_prop {
+                    if let Some(typed) = typed_number_literal(*n) {
+                        out.push(format!("    ?source <{}> {typed} .", prop.predicate));
+                    } else {
+                        out.push("    FILTER(false)".to_string());
+                    }
+                } else {
+                    let var = format!("?_pw_{safe_name}");
+                    out.push(format!("    ?source <{}> {var} .", prop.predicate));
+                    out.push(format!(
+                        "    FILTER(<ad4m://fn/parse_literal>({var}) = \"{n}\")"
+                    ));
+                }
+            }
+            WhereCondition::Bool(b) => {
+                if is_literal_prop {
+                    out.push(format!(
+                        "    ?source <{}> \"{b}\"^^<{XSD_BOOLEAN}> .",
+                        prop.predicate
+                    ));
+                } else {
+                    let var = format!("?_pw_{safe_name}");
+                    out.push(format!("    ?source <{}> {var} .", prop.predicate));
+                    out.push(format!(
+                        "    FILTER(<ad4m://fn/parse_literal>({var}) = \"{b}\")"
+                    ));
+                }
+            }
+            WhereCondition::StringArray(vals) => {
+                if is_literal_prop {
+                    let mut items: Vec<String> = Vec::with_capacity(vals.len() * 2);
+                    for v in vals {
+                        let escaped = escape_sparql_string(v);
+                        items.push(format!("\"{escaped}\"^^<{XSD_STRING}>"));
+                        if looks_like_absolute_iri(v) {
+                            items.push(format!("<{v}>"));
+                        }
+                    }
+                    let iv_var = format!("?_iv_{safe_name}");
+                    out.push(format!("    VALUES {iv_var} {{ {} }}", items.join(" ")));
+                    out.push(format!("    ?source <{}> {iv_var} .", prop.predicate));
+                } else {
+                    let values_list = vals
+                        .iter()
+                        .map(|v| format!("\"{}\"", escape_sparql_string(v)))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let var = format!("?_pw_{safe_name}");
+                    out.push(format!("    ?source <{}> {var} .", prop.predicate));
+                    out.push(format!(
+                        "    FILTER(<ad4m://fn/parse_literal>({var}) IN ({values_list}))"
+                    ));
+                }
+            }
+            WhereCondition::NumberArray(vals) => {
+                if is_literal_prop {
+                    let items: Vec<String> = vals
+                        .iter()
+                        .filter_map(|n| typed_number_literal(*n))
+                        .collect();
+                    if items.is_empty() {
+                        out.push("    FILTER(false)".to_string());
+                    } else {
+                        let iv_var = format!("?_iv_{safe_name}");
+                        out.push(format!("    VALUES {iv_var} {{ {} }}", items.join(" ")));
+                        out.push(format!("    ?source <{}> {iv_var} .", prop.predicate));
+                    }
+                } else {
+                    let values_list = vals
+                        .iter()
+                        .map(|n| format!("\"{n}\""))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let var = format!("?_pw_{safe_name}");
+                    out.push(format!("    ?source <{}> {var} .", prop.predicate));
+                    out.push(format!(
+                        "    FILTER(<ad4m://fn/parse_literal>({var}) IN ({values_list}))"
+                    ));
+                }
+            }
+            WhereCondition::Ops(ops) => {
+                let var = format!("?_pw_{safe_name}");
+                let val_var = format!("?_pw_{safe_name}_v");
+                out.push(format!("    ?source <{}> {var} .", prop.predicate));
+                // Compare on the lexical string rather than on a typed
+                // literal term: Oxigraph treats a simple literal and an
+                // `xsd:string` literal as distinct terms, so `?v != "x"^^xsd:string`
+                // silently fails to match values stored either way.
+                //
+                // Deterministic literals expose their value via `STR()`
+                // directly; envelope / custom-language values need
+                // `parse_literal` first to reach the inner `data`.
+                let val_src = if is_literal_prop {
+                    var.clone()
+                } else {
+                    format!("<ad4m://fn/parse_literal>({var})")
+                };
+                out.push(format!("    BIND(STR({val_src}) AS {val_var})"));
+
+                let mut filters = Vec::new();
+                // A requested operator that produces no filter must not leave the
+                // condition looking compiled. The triple pattern and BIND above are
+                // already in `out`, so `finish` would return `Some` and the caller
+                // would skip post-hydration filtering — silently dropping the
+                // constraint. Today both layers ignore the same shapes, so no rows
+                // differ; they agree by coincidence rather than by construction, and
+                // this PR's whole point is that pushability follows the emission.
+                let mut unhandled = false;
+
+                if let Some(ref not_val) = ops.not {
+                    match not_val {
+                        Value::String(s) => {
+                            filters.push(format!("{val_var} != \"{}\"", escape_sparql_string(s)));
+                        }
+                        Value::Number(n) => {
+                            let n_f64 = n.as_f64().unwrap_or(0.0);
+                            let n_str = if n_f64.fract() == 0.0 {
+                                format!("{}", n_f64 as i64)
+                            } else {
+                                format!("{n_f64}")
+                            };
+                            filters.push(format!("{val_var} != \"{n_str}\""));
+                        }
+                        Value::Bool(b) => {
+                            filters.push(format!("{val_var} != \"{b}\""));
+                        }
+                        Value::Array(arr) => {
+                            let items: Vec<String> = arr
+                                .iter()
+                                .filter_map(|item| match item {
+                                    Value::String(s) => {
+                                        Some(format!("\"{}\"", escape_sparql_string(s)))
+                                    }
+                                    Value::Number(n) => {
+                                        let f = n.as_f64().unwrap_or(0.0);
+                                        let s = if f.fract() == 0.0 {
+                                            format!("{}", f as i64)
+                                        } else {
+                                            format!("{f}")
+                                        };
+                                        Some(format!("\"{s}\""))
+                                    }
+                                    _ => None,
+                                })
+                                .collect();
+                            if items.is_empty() {
+                                // Either an empty array or one holding only shapes
+                                // this cannot render.
+                                unhandled = true;
+                            } else {
+                                filters.push(format!("{val_var} NOT IN ({})", items.join(", ")));
+                            }
+                        }
+                        _ => unhandled = true,
+                    }
+                }
+
+                let has_numeric = ops.gt.is_some()
+                    || ops.gte.is_some()
+                    || ops.lt.is_some()
+                    || ops.lte.is_some()
+                    || ops.between.is_some();
+
+                if has_numeric {
+                    let num_var = format!("?_pw_{safe_name}_num");
+                    out.push(format!("    BIND(<{XSD_DOUBLE}>({val_var}) AS {num_var})"));
+                    if let Some(gt) = ops.gt {
+                        filters.push(format!("{num_var} > {gt}"));
+                    }
+                    if let Some(gte) = ops.gte {
+                        filters.push(format!("{num_var} >= {gte}"));
+                    }
+                    if let Some(lt) = ops.lt {
+                        filters.push(format!("{num_var} < {lt}"));
+                    }
+                    if let Some(lte) = ops.lte {
+                        filters.push(format!("{num_var} <= {lte}"));
+                    }
+                    if let Some((lo, hi)) = ops.between {
+                        filters.push(format!("{num_var} >= {lo} && {num_var} <= {hi}"));
+                    }
+                }
+
+                if let Some(ref contains_val) = ops.contains {
+                    let needle = match contains_val {
+                        Value::String(s) => s.clone(),
+                        other => other.to_string(),
+                    };
+                    filters.push(format!(
+                        "CONTAINS(LCASE({val_var}), LCASE(\"{}\"))",
+                        escape_sparql_string(&needle)
+                    ));
+                }
+
+                // No filters at all means either an empty `{}` — no operator was
+                // requested, so this constrains nothing and should not narrow to
+                // "the property exists" — or every requested one was unrenderable.
+                if filters.is_empty() || unhandled {
+                    return None;
+                }
+                out.push(format!("    FILTER({})", filters.join(" && ")));
+            }
+            // SubClauses/SubClause are OR/AND/NOT combinators evaluated
+            // Rust-side; the outer loop skips them before reaching here.
+            WhereCondition::SubClauses(_) | WhereCondition::SubClause(_) => {}
+        }
+        return finish(out);
+    }
+
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::perspectives::model_query::test_helpers::{flag, prop, shape};
+    use crate::perspectives::model_query::test_helpers::{flag, prop, relation, shape};
 
     fn make_pg(sort_key: SortKey, direction: OrderDirection) -> SparqlPagination {
         SparqlPagination {
@@ -973,5 +1130,357 @@ mod tests {
             sparql.contains("DESC(?_rp_num)") && sparql.contains("DESC(?_rp_str)"),
             "ORDER BY should use DESC: {sparql}"
         );
+    }
+}
+
+#[cfg(test)]
+mod where_compiler_tests {
+    use super::*;
+    use crate::perspectives::model_query::test_helpers::{prop, relation, shape};
+
+    fn wc(pairs: Vec<(&str, WhereCondition)>) -> BTreeMap<String, WhereCondition> {
+        pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
+    }
+
+    fn branch(pairs: Vec<(&str, WhereCondition)>) -> BTreeMap<String, WhereCondition> {
+        wc(pairs)
+    }
+
+    fn test_shape() -> ModelShape {
+        shape(
+            "Post",
+            vec![
+                prop("title", "we://title"),
+                prop("body", "we://body"),
+                relation("signals", "we://signal"),
+            ],
+        )
+    }
+
+    /// A property defined by a getter carries no link predicate.
+    fn getter_shape() -> ModelShape {
+        let mut p = prop("computed", "");
+        p.getter = Some("SELECT ?target WHERE { <Base> ?p ?target }".to_string());
+        shape("Post", vec![prop("title", "we://title"), p])
+    }
+
+    // ---- the divergence this refactor closes -----------------------------
+
+    #[test]
+    fn test_getter_property_condition_is_not_pushable() {
+        // Regression: `all_where_pushable` reported *any* condition on a scalar
+        // property pushable, while the emitter additionally required a
+        // non-empty, IRI-valid predicate. A getter-backed property has neither,
+        // so the condition reached SPARQL from neither side and the caller —
+        // seeing "pushable" — skipped post-hydration filtering too. The query
+        // silently returned unfiltered rows.
+        let s = getter_shape();
+        let clause = wc(vec![(
+            "computed",
+            WhereCondition::String("anything".to_string()),
+        )]);
+
+        let compiled = compile_where_clause(&clause, &s);
+
+        assert!(compiled.patterns.is_empty(), "nothing can be emitted");
+        assert!(
+            !compiled.complete,
+            "so the clause must be reported incomplete, sending it to the \
+             post-hydration filter instead of being dropped",
+        );
+    }
+
+    #[test]
+    fn test_unknown_property_is_not_pushable() {
+        let s = test_shape();
+        let clause = wc(vec![("nope", WhereCondition::String("x".to_string()))]);
+        assert!(!compile_where_clause(&clause, &s).complete);
+    }
+
+    #[test]
+    fn test_pushability_is_derived_from_emission() {
+        // The property that makes the two impossible to desynchronise: a clause
+        // is complete exactly when compiling it produced patterns for every key.
+        let s = test_shape();
+        let clause = wc(vec![
+            ("title", WhereCondition::String("hello".to_string())),
+            ("nope", WhereCondition::String("x".to_string())),
+        ]);
+
+        let compiled = compile_where_clause(&clause, &s);
+
+        assert!(!compiled.patterns.is_empty(), "the known key still pushes");
+        assert!(!compiled.complete, "but the clause is not fully covered");
+    }
+
+    // ---- OR -> UNION -----------------------------------------------------
+
+    #[test]
+    fn test_or_compiles_to_union() {
+        let s = test_shape();
+        let clause = wc(vec![(
+            "OR",
+            WhereCondition::SubClauses(vec![
+                branch(vec![("title", WhereCondition::String("a".to_string()))]),
+                branch(vec![("body", WhereCondition::String("b".to_string()))]),
+            ]),
+        )]);
+
+        let compiled = compile_where_clause(&clause, &s);
+
+        assert!(compiled.complete);
+        let sparql = compiled.patterns.join("\n");
+        assert!(sparql.contains("UNION"), "expected a UNION: {sparql}");
+        assert!(sparql.contains("we://title"), "{sparql}");
+        assert!(sparql.contains("we://body"), "{sparql}");
+    }
+
+    #[test]
+    fn test_or_is_all_or_nothing() {
+        // Emitting only the arms that compiled would exclude rows the missing
+        // arm would have matched — unlike a conjunction, a partial disjunction
+        // is not a sound narrowing.
+        let s = test_shape();
+        let clause = wc(vec![(
+            "OR",
+            WhereCondition::SubClauses(vec![
+                branch(vec![("title", WhereCondition::String("a".to_string()))]),
+                branch(vec![("nope", WhereCondition::String("b".to_string()))]),
+            ]),
+        )]);
+
+        let compiled = compile_where_clause(&clause, &s);
+
+        assert!(
+            compiled.patterns.is_empty(),
+            "no half-disjunction is emitted"
+        );
+        assert!(!compiled.complete);
+    }
+
+    #[test]
+    fn test_or_over_id_binds_source() {
+        // `id` emits VALUES rather than a bare FILTER precisely so it can stand
+        // alone inside a UNION branch, where `?source` is otherwise unbound.
+        let s = test_shape();
+        let clause = wc(vec![(
+            "OR",
+            WhereCondition::SubClauses(vec![
+                branch(vec![(
+                    "id",
+                    WhereCondition::String("we://post/1".to_string()),
+                )]),
+                branch(vec![(
+                    "id",
+                    WhereCondition::String("we://post/2".to_string()),
+                )]),
+            ]),
+        )]);
+
+        let compiled = compile_where_clause(&clause, &s);
+
+        assert!(compiled.complete, "an id disjunction must push down");
+        let sparql = compiled.patterns.join("\n");
+        assert!(sparql.contains("VALUES ?source"), "{sparql}");
+        assert!(!sparql.contains("FILTER(?source ="), "{sparql}");
+    }
+
+    #[test]
+    fn test_or_refuses_a_branch_that_cannot_bind_source() {
+        // A non-IRI id compiles to `FILTER(STR(?source) = …)`, which tests
+        // `?source` without binding it. Sound in the main conjunction, useless
+        // in a UNION arm — so the disjunction falls back rather than silently
+        // losing that arm.
+        //
+        // Note `literal:string:x` does NOT exercise this: it parses as a valid
+        // absolute IRI (scheme `literal`) and so takes the VALUES branch. The
+        // value here has a space in it, which no IRI may.
+        let s = test_shape();
+        let clause = wc(vec![(
+            "OR",
+            WhereCondition::SubClauses(vec![
+                branch(vec![(
+                    "id",
+                    WhereCondition::String("not an iri".to_string()),
+                )]),
+                branch(vec![("title", WhereCondition::String("a".to_string()))]),
+            ]),
+        )]);
+
+        let compiled = compile_where_clause(&clause, &s);
+        assert!(!compiled.complete);
+        assert!(compiled.patterns.is_empty());
+    }
+
+    // ---- NOT -> FILTER NOT EXISTS ----------------------------------------
+
+    #[test]
+    fn test_not_compiles_to_filter_not_exists() {
+        let s = test_shape();
+        let clause = wc(vec![(
+            "NOT",
+            WhereCondition::SubClause(branch(vec![(
+                "title",
+                WhereCondition::String("draft".to_string()),
+            )])),
+        )]);
+
+        let compiled = compile_where_clause(&clause, &s);
+
+        assert!(compiled.complete);
+        let sparql = compiled.patterns.join("\n");
+        assert!(sparql.contains("FILTER NOT EXISTS"), "{sparql}");
+        assert!(sparql.contains("we://title"), "{sparql}");
+    }
+
+    #[test]
+    fn test_not_branch_need_not_bind_source() {
+        // FILTER NOT EXISTS is evaluated per solution with the outer bindings
+        // visible, so — unlike a UNION arm — its branch may test `?source`
+        // without binding it.
+        let s = test_shape();
+        let clause = wc(vec![(
+            "NOT",
+            WhereCondition::SubClause(branch(vec![(
+                "id",
+                WhereCondition::String("not an iri".to_string()),
+            )])),
+        )]);
+
+        assert!(compile_where_clause(&clause, &s).complete);
+    }
+
+    // ---- AND -------------------------------------------------------------
+
+    #[test]
+    fn test_and_is_conjunctive_and_may_be_partial() {
+        // A conjunction narrows, so pushing the arms that compiled is sound;
+        // the rest is caught post-hydration, which `complete: false` requests.
+        let s = test_shape();
+        let clause = wc(vec![(
+            "AND",
+            WhereCondition::SubClauses(vec![
+                branch(vec![("title", WhereCondition::String("a".to_string()))]),
+                branch(vec![("nope", WhereCondition::String("b".to_string()))]),
+            ]),
+        )]);
+
+        let compiled = compile_where_clause(&clause, &s);
+
+        assert!(!compiled.patterns.is_empty(), "the sound half still pushes");
+        assert!(!compiled.complete);
+    }
+
+    #[test]
+    fn test_nested_combinators_compile() {
+        let s = test_shape();
+        let inner = wc(vec![(
+            "OR",
+            WhereCondition::SubClauses(vec![
+                branch(vec![("title", WhereCondition::String("a".to_string()))]),
+                branch(vec![("title", WhereCondition::String("b".to_string()))]),
+            ]),
+        )]);
+        let clause = wc(vec![(
+            "AND",
+            WhereCondition::SubClauses(vec![
+                inner,
+                branch(vec![("body", WhereCondition::String("c".to_string()))]),
+            ]),
+        )]);
+
+        let compiled = compile_where_clause(&clause, &s);
+
+        assert!(compiled.complete);
+        let sparql = compiled.patterns.join("\n");
+        assert!(sparql.contains("UNION"), "{sparql}");
+        assert!(sparql.contains("we://body"), "{sparql}");
+    }
+}
+
+#[cfg(test)]
+mod ops_completeness_tests {
+    use super::*;
+    use crate::perspectives::model_query::test_helpers::{prop, shape};
+    use crate::perspectives::model_query::types::WhereOps;
+
+    fn wc(p: Vec<(&str, WhereCondition)>) -> BTreeMap<String, WhereCondition> {
+        p.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
+    }
+    fn s() -> ModelShape {
+        shape("Post", vec![prop("title", "ns://title")])
+    }
+    fn ops(o: WhereOps) -> WhereCondition {
+        WhereCondition::Ops(o)
+    }
+
+    #[test]
+    fn a_renderable_operator_pushes_down() {
+        let c = wc(vec![(
+            "title",
+            ops(WhereOps {
+                not: Some(Value::String("draft".into())),
+                ..Default::default()
+            }),
+        )]);
+        assert!(compile_where_clause(&c, &s()).complete);
+    }
+
+    #[test]
+    fn an_unrenderable_not_shape_is_not_complete() {
+        // An object is not a value this can compare against. The triple pattern and
+        // BIND are already emitted, so without the guard `finish` would report the
+        // clause compiled and the caller would skip the Rust filter entirely.
+        let c = wc(vec![(
+            "title",
+            ops(WhereOps {
+                not: Some(serde_json::json!({"a": 1})),
+                ..Default::default()
+            }),
+        )]);
+        let compiled = compile_where_clause(&c, &s());
+        assert!(!compiled.complete);
+        assert!(compiled.patterns.is_empty());
+    }
+
+    #[test]
+    fn an_empty_not_array_is_not_complete() {
+        let c = wc(vec![(
+            "title",
+            ops(WhereOps {
+                not: Some(Value::Array(vec![])),
+                ..Default::default()
+            }),
+        )]);
+        assert!(!compile_where_clause(&c, &s()).complete);
+    }
+
+    #[test]
+    fn one_bad_operator_spoils_an_otherwise_good_ops() {
+        // The `gt` renders fine, so filters is non-empty — the reason a bare
+        // `filters.is_empty()` check would not have caught this.
+        let c = wc(vec![(
+            "title",
+            ops(WhereOps {
+                not: Some(serde_json::json!({"a": 1})),
+                gt: Some(5.0),
+                ..Default::default()
+            }),
+        )]);
+        assert!(
+            !compile_where_clause(&c, &s()).complete,
+            "a dropped `not` must not be masked by a rendered `gt`",
+        );
+    }
+
+    #[test]
+    fn an_empty_ops_object_constrains_nothing() {
+        // `{}` requests no operator. Emitting the triple pattern alone would narrow
+        // to "the property exists", which is not what the Rust filter does for the
+        // same clause — it matches everything.
+        let c = wc(vec![("title", ops(WhereOps::default()))]);
+        let compiled = compile_where_clause(&c, &s());
+        assert!(!compiled.complete);
+        assert!(compiled.patterns.is_empty());
     }
 }


### PR DESCRIPTION
# Compile the where clause once; `OR` and `NOT` reach SPARQL

> [!IMPORTANT]
> **Branch** `refactor/where-clause-compiler` · **Base** `dev`.
> Independent. Nothing in the series is required before it.
>
> Part of an eight-PR series on the AD4M model layer — review wave 1 of 4. The full shape:

```
dev ─┬─ 1  relation-correctness ── 5  subjectClassOf ─┬─ 6  polymorphic-include
     │                                                └─ 7  ordering-module ── 8  ordering-integration
     ├─ 2  getter+target
     └─ 3  where-compiler ── 4  quantifiers
```

## Summary

The where clause had two independent implementations of the same semantics — a SPARQL emitter in
`build_query_patterns` and a Rust evaluator in `matches_where` — and a third function,
`all_where_pushable`, deciding which one ran. Nothing forced the three to agree, and they didn't.

This makes the compiler the single source of that answer: `compile_where_clause` returns the patterns
*and* whether every condition made it in, and `all_where_pushable` is that flag. The answer cannot
drift from the emission because it *is* the emission. With one compiler the combinators become
expressible, so `OR` and `NOT` come along — and they are the reason this was scoped as a feature
before the audit turned it into a bug fix.

## The bug this closes

`all_where_pushable` reported *any* condition on a scalar property pushable. The emitter additionally
required that property to carry a non-empty, IRI-valid predicate. A `@Property({ getter })` field has
neither — both shape loaders default a missing `sh://path` to the empty string.

So for `where: { someGetterProp: 'x' }`: the emitter skipped it, and the caller — told the clause was
fully pushable — skipped post-hydration filtering too, since `query.rs` only calls
`retain(matches_where)` when `all_where_pushable` is false. The condition was applied in neither
place. The query returned unfiltered rows and `count()` an unfiltered count, silently, with no error
anywhere.

That is not a missing feature. It is what two hand-maintained descriptions of one behaviour do to
each other over time, and it is why this PR grew from "add `OR`" into a refactor.

## Changes

**`rust-executor/src/perspectives/model_query/sparql_builder.rs`**

`compile_leaf_condition` holds the per-condition logic, moved across unchanged apart from its exits.
Where the loop used to `continue` past a condition it did not understand — silently, while the
pushability check said otherwise — it now returns `None`, surfacing as `complete: false` and routing
the condition to the Rust filter. Every previously-silent `_ => {}` arm is covered by the same rule:
no patterns emitted means not compiled.

`compile_where_clause` adds the combinators. `OR` → `UNION`, `NOT` → `FILTER NOT EXISTS`, `AND` →
conjunctive patterns. `AND` may compile *partially* — a conjunction narrows, so pushing the arms that
compiled is sound and the rest falls to the Rust filter. `OR` and `NOT` are all-or-nothing: a
half-emitted disjunction would exclude rows the missing arm would have matched, and a partial
`FILTER NOT EXISTS` excludes rows it should keep. Neither is a sound narrowing.

`binds_source` is the non-obvious part. SPARQL evaluates each `UNION` branch independently and joins
the result with the surrounding group afterwards, so a branch is **not** handed `?source` from
outside. A branch holding only `FILTER(?source = <x>)` therefore evaluates with `?source` unbound:
the filter errors, the branch yields nothing, and the disjunction quietly loses an arm. Branches must
bind `?source` themselves, and the check is deliberately conservative — a false negative costs
pushdown for one query, a false positive would return wrong rows. `FILTER NOT EXISTS` needs none of
this, being evaluated per solution with the outer bindings visible.

This is also why an `id` condition now emits `VALUES ?source { <val> }` rather than
`FILTER(?source = <val>)`. It binds instead of merely testing, which makes it usable in a branch, and
it hands Oxigraph a subject to seek to rather than a predicate to evaluate over every candidate.

**Every generated variable name is unique per leaf.**

Variable names were derived from the property name alone. That was safe while a where clause was a
flat map — its keys are unique — but combinators let the same property appear more than once, and
two leaves on one property then emit `BIND(… AS ?_pw_title_v)` twice into the same group.

SPARQL forbids binding a variable already in scope, so such a clause did not return the wrong rows:
**it failed to parse.** `where: { AND: [{ title: { contains: "a" } }, { title: { contains: "b" } }] }`
errored outright. So a counter is threaded through the recursion, advancing once per leaf and
appended to every generated name — variables *within* a leaf keep a shared suffix, because those are
meant to correlate.

`NOT` was checked for the same problem and does not have it: `FILTER NOT EXISTS` opens its own group,
so a branch constraining a property the outer clause also constrains returns the right rows either
way. There is a test pinning that, labelled as a guard rather than as a fixed bug.

**An operator that cannot be rendered un-completes its whole condition.**

The `Ops` branch is the one place patterns reach `out` *before* the operators are examined — the
triple pattern and its `BIND` are emitted so the filters have a variable to compare against. So a
`not` holding a shape SPARQL cannot compare (an object, or an empty array) used to leave those
patterns behind, `finish` saw a non-empty `out`, and the condition was reported compiled with the
operator silently absent.

No rows differ today: `matches_ops` happens to ignore exactly the same shapes, so the two layers
agree — but by coincidence, not by construction, which is the thing this PR exists to stop relying
on. The branch now tracks whether every requested operator produced a filter and declines the whole
condition otherwise. A bare `{}` declines too: it requests nothing, so pushing the triple pattern
alone would narrow to "the property exists" where the Rust filter matches everything.

**`rust-executor/src/perspectives/model_query/integration_tests.rs`** — end-to-end tests that the
combinators now filter in SPARQL and keep their ordering and limit. Previously a `where` with an `OR`
hydrated every instance of the class and sorted in Rust, because `all_where_pushable` returned false
on sight of a combinator and that also disabled the pagination pushdown.

## Known follow-ups

- **Downstream, once this lands:** WE's AD4M query adapter marks any query using an explicit
  combinator as degraded, on the grounds that AD4M drops its sort — and routes around it. That
  becomes untrue, so the workaround can go. Worth noting it currently *under*-reports: it knows the
  sort is lost, not
  that the query also became a full scan.
- `matches_where` still exists and still duplicates operator semantics for the non-pushable
  remainder. The direction of travel is compile-more/post-filter-less, ending with post-hydration
  reserved for what genuinely leaves the store (language resolution, expression unwrapping). Each
  subsequent operator should shrink that surface rather than grow it.

## Test plan

> Counts are for this branch **against its own base**, so they include only this PR's tests —
> not its predecessors'. Re-measured after the stack was split from one linear chain into the
> tree above.

- [x] `cargo test -p ad4m-executor --lib perspectives::model_query` — 234 passing (214 → 234)
- [x] 11 unit tests on the compiler: the getter-property divergence, pushability derived from
      emission, `OR` → `UNION`, `OR` all-or-nothing, `id` binding via `VALUES`, a branch that cannot
      bind `?source` declining, `NOT` → `FILTER NOT EXISTS`, `NOT` not needing to bind, partial `AND`,
      nested combinators
- [x] 2 end-to-end tests against a real store: `OR` returning exactly the right rows with
      `ORDER BY … DESC` + `LIMIT` honoured, and `NOT` filtering correctly
- [x] 2 end-to-end tests for the variable-collision fix below. **Verified the `AND` one fails
      without it**, with the exact parse error: `Query is not valid read-only SPARQL … error at
      15:2: expected [_]`
- [x] 5 unit tests on the `Ops` completeness guard: a renderable operator still pushes, an
      unrenderable `not` shape declines, an empty `not` array declines, an empty `{}` declines, and
      a good `gt` beside a bad `not` still declines — **all five verified to fail without the
      guard**, the last being the one a bare "emitted nothing" check would have missed
- [x] The refactor verified behaviour-preserving before the combinators were added — full suite green
      on the pure extraction
- [x] `cargo fmt -p ad4m-executor`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering for complex, combined, and negated conditions, including ID and base-property filters.
  * Fixed query behavior for OR conditions, ordering, and pagination.
  * Prevented conflicts in generated queries and avoided incomplete results for unsupported or invalid conditions.
  * Fixed self-referential relation queries so included targets resolve to fully hydrated instances.

* **Tests**
  * Added comprehensive coverage for advanced filtering, relation traversal, query generation, ordering, pagination, and expected results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->