### PR TITLE
Feature: A getter relation can name its target class

### DIFF
--- a/core/src/model/decorators.ts
+++ b/core/src/model/decorators.ts
@@ -815,7 +815,7 @@ export interface RelationOptions {
      */
     through?: string;
     /** The target model class (use a thunk to avoid circular-dependency issues). Optional for untyped string relations.
-     *  Cannot be combined with `getter`. */
+     *  Combines with `getter`, where it names the class the traversal's values hydrate into. */
     target?: () => Ad4mModelLike;
     /**
      * Custom getter to resolve the relation values. Use this for custom graph traversals.
@@ -863,7 +863,8 @@ export interface RelationOptions {
      * auto-derived from the target shape (flags + required properties).
      * Providing `where` overrides this auto-derivation.
      *
-     * Mutually exclusive with `getter` and `filter: false`.
+     * Mutually exclusive with `filter: false`. Combines with `getter`, where it
+     * is applied as a post-getter filter against the target class.
      *
      * @example
      * ```typescript
@@ -942,7 +943,16 @@ function resolveRelationArgs(
         ? { ...(second || {}), target: first }
         : first;
 
-    // getter is mutually exclusive with through, target, and where
+    // `where` and `filter: false` contradict each other on every relation,
+    // getter-backed ones included — checked before the getter path returns.
+    if (opts.where && opts.filter === false) {
+        throw new Error(
+            'Relation decorator: `where` and `filter: false` are contradictory. ' +
+            '`where` adds filtering constraints; `filter: false` disables filtering.'
+        );
+    }
+
+    // getter is mutually exclusive with through
     if (opts.getter) {
         if (opts.through) {
             throw new Error(
@@ -989,16 +999,6 @@ function resolveRelationArgs(
     // Default predicate when not provided
     if (!opts.through) {
         opts.through = 'ad4m://has_child';
-    }
-
-    // where validation
-    if (opts.where) {
-        if (opts.filter === false) {
-            throw new Error(
-                'Relation decorator: `where` and `filter: false` are contradictory. ' +
-                '`where` adds filtering constraints; `filter: false` disables filtering.'
-            );
-        }
     }
 
     return opts;

--- a/core/src/model/decorators.ts
+++ b/core/src/model/decorators.ts
@@ -813,8 +813,27 @@ export interface RelationOptions {
      * The expression can reference 'Base' which will be replaced with the instance's base expression.
      * Example: "SELECT ?target WHERE { ?target <flux://has_reply> <Base> . }"
      *
-     * Mutually exclusive with `through` and `target`. When `getter` is provided the
-     * relation is read-only (no adder/remover actions are generated).
+     * Mutually exclusive with `through` — a getter replaces link-based resolution,
+     * so there is no predicate to add to or remove from. When `getter` is provided
+     * the relation is read-only (no adder/remover actions are generated).
+     *
+     * **Combines with `target`**, which names the class the traversal's values
+     * hydrate into — without it `include` has no shape to resolve and the relation
+     * can only return bare URIs. Also combines with `where`, applied as a
+     * post-getter filter against the target class.
+     *
+     * @example Traversing a reified edge — a connection stored as a record rather
+     * than a predicate, so no `through` can express it:
+     * ```typescript
+     * @HasMany({
+     *   getter: `SELECT ?target WHERE {
+     *     ?citation <paper://cites_from> <Base> .
+     *     ?citation <paper://cites_to> ?target .
+     *   }`,
+     *   target: () => Paper,
+     * })
+     * cited: Paper[] = [];
+     * ```
      */
     getter?: string;
     /** Whether the link is stored locally (not shared on the network) */
@@ -904,19 +923,38 @@ function resolveRelationArgs(
                 '(with optional `target`) for standard link-based relations.'
             );
         }
-        if (opts.target) {
-            throw new Error(
-                'Relation decorator: `getter` and `target` are mutually exclusive. ' +
-                '`target` auto-generates a conformance getter from the model shape; ' +
-                'providing both is contradictory.'
-            );
-        }
-        if (opts.where) {
-            throw new Error(
-                'Relation decorator: `where` and `getter` are mutually exclusive. ' +
-                'Use `where` for DSL-based filtering, or `getter` for raw getter expression.'
-            );
-        }
+        // `target` and `where` are NOT mutually exclusive with `getter`.
+        //
+        // `target` does two separable jobs: it auto-derives a conformance
+        // getter, and it names the class the relation's values hydrate into.
+        // Only the first conflicts with an explicit getter, and `buildSHACL`
+        // already resolves that on its own — an explicit getter wins the getter
+        // slot, while `sh:class` / `ad4m:targetClassName` are emitted from
+        // `target` independently.
+        //
+        // Refusing the pair cost the one thing a custom getter is for. A getter
+        // expresses a traversal the link-shaped DSL cannot — most usefully
+        // through a reified edge, where the connection is a record rather than
+        // a predicate:
+        //
+        //     @HasMany({
+        //       getter: "SELECT ?target WHERE { \
+        //                  ?citation <paper://cites_from> <Base> . \
+        //                  ?citation <paper://cites_to> ?target . }",
+        //       target: () => Paper,
+        //     })
+        //     cited: Paper[] = [];
+        //
+        // Without `target` the relation has no target class, so `include` on it
+        // resolves a shape named "" and fails — leaving a traversal that can
+        // only ever return bare URIs. With it, the values hydrate like any other
+        // relation, because getters are evaluated before include resolution.
+        //
+        // `where` is the same story: the executor applies post-getter where
+        // filters specifically to getter-backed relations
+        // (`apply_where_filter_to_relation`), and emitting `wherePredicates`
+        // needs `target` to resolve the target's metadata — so the runtime is
+        // built for all three together and only this check said otherwise.
         return opts;
     }
 

--- a/core/src/model/relation-filtering.test.ts
+++ b/core/src/model/relation-filtering.test.ts
@@ -617,6 +617,21 @@ describe("where clause validation", () => {
       }
     }).toThrow(/where.*filter.*contradictory/i);
   });
+
+  it("should throw if both where and filter:false are provided on a getter relation", () => {
+    expect(() => {
+      @Model({ name: "InvalidGetterWhereFilterFalse" })
+      class _Invalid extends Ad4mModel {
+        @HasMany({
+          getter: "SELECT ?target WHERE { ?target ?p <Base> . }",
+          target: () => FlaggedTarget,
+          where: { status: "active" },
+          filter: false,
+        })
+        items: string[] = [];
+      }
+    }).toThrow(/where.*filter.*contradictory/i);
+  });
 });
 
 describe("where clause compilation", () => {

--- a/core/src/model/relation-filtering.test.ts
+++ b/core/src/model/relation-filtering.test.ts
@@ -394,17 +394,44 @@ describe("Ad4mModel.getModelMetadata() relation filtering fields", () => {
 // ============================================================================
 
 describe("Relation decorator validation", () => {
-  it("should throw if both getter and target are provided", () => {
-    expect(() => {
-      @Model({ name: "InvalidGetterTarget" })
-      class _Invalid extends Ad4mModel {
-        @HasMany({
-          getter: "SELECT ?target WHERE { ?target ?p ?source . }",
-          target: () => FlaggedTarget,
-        })
-        items: string[] = [];
-      }
-    }).toThrow(/getter.*target.*mutually exclusive/i);
+  it("accepts getter together with target, and keeps the getter verbatim", () => {
+    // `target` does two separable jobs — derive a conformance getter, and name
+    // the class values hydrate into. Only the first conflicts with an explicit
+    // getter, so the pair is legal and the explicit getter wins.
+    @Model({ name: "GetterWithTarget" })
+    class GetterWithTarget extends Ad4mModel {
+      @HasMany({
+        getter: "SELECT ?target WHERE { ?rel <we://src> <Base> . ?rel <we://tgt> ?target . }",
+        target: () => FlaggedTarget,
+      })
+      items: string[] = [];
+    }
+
+    const { shape } = (GetterWithTarget as any).generateSHACL();
+    const rel = shape.properties.find((p: any) => p.name === "items");
+
+    expect(rel.getter).toBe(
+      "SELECT ?target WHERE { ?rel <we://src> <Base> . ?rel <we://tgt> ?target . }"
+    );
+  });
+
+  it("emits sh:class for a getter relation, so include has a shape to resolve", () => {
+    // Without a target class the executor resolves a shape named "" and the
+    // include fails — which is what made a custom traversal able to return only
+    // bare URIs.
+    @Model({ name: "GetterWithTargetClass" })
+    class GetterWithTargetClass extends Ad4mModel {
+      @HasMany({
+        getter: "SELECT ?target WHERE { ?target ?p <Base> . }",
+        target: () => FlaggedTarget,
+      })
+      items: string[] = [];
+    }
+
+    const { shape } = (GetterWithTargetClass as any).generateSHACL();
+    const rel = shape.properties.find((p: any) => p.name === "items");
+
+    expect(rel.targetClassName).toBe("FlaggedTarget");
   });
 
   it("should throw if both getter and through are provided", () => {
@@ -556,17 +583,25 @@ describe("sh:class target shape reference", () => {
 // ============================================================================
 
 describe("where clause validation", () => {
-  it("should throw if both where and getter are provided", () => {
-    expect(() => {
-      @Model({ name: "InvalidWhereGetter" })
-      class _Invalid extends Ad4mModel {
-        @HasMany({
-          where: { status: "active" },
-          getter: "SELECT ?target WHERE { ?target ?p ?source . }",
-        })
-        items: string[] = [];
-      }
-    }).toThrow(/where.*getter.*mutually exclusive/i);
+  it("accepts where alongside a getter, as a post-getter filter", () => {
+    // The executor applies where filters specifically to getter-backed
+    // relations (`apply_where_filter_to_relation`), so the runtime was built
+    // for this pairing; only the decorator refused it.
+    @Model({ name: "WhereWithGetter" })
+    class WhereWithGetter extends Ad4mModel {
+      @HasMany({
+        where: { status: "active" },
+        getter: "SELECT ?target WHERE { ?target ?p <Base> . }",
+        target: () => FlaggedTarget,
+      })
+      items: string[] = [];
+    }
+
+    const { shape } = (WhereWithGetter as any).generateSHACL();
+    const rel = shape.properties.find((p: any) => p.name === "items");
+
+    expect(rel.whereFilter).toEqual({ status: "active" });
+    expect(rel.getter).toBe("SELECT ?target WHERE { ?target ?p <Base> . }");
   });
 
   it("should throw if both where and filter:false are provided", () => {

--- a/rust-executor/src/perspectives/model_query/integration_tests.rs
+++ b/rust-executor/src/perspectives/model_query/integration_tests.rs
@@ -5383,3 +5383,116 @@ async fn test_duplicate_literal_property_values_keep_instances_distinct() {
         "base2's body must be unaffected by base1's independent update"
     );
 }
+
+/// A getter relation that names a target class hydrates through `include`.
+///
+/// This is the traversal a link-shaped relation cannot express: the connection
+/// between two nodes is itself a record (a reified edge), so there is no single
+/// predicate for `through` to name. A getter walks the two hops; `targetClassName`
+/// is what lets the result become typed instances rather than bare URIs.
+///
+/// The two were mutually exclusive in the TypeScript decorator until this change,
+/// even though every layer beneath — SHACL emission, shape parsing, getter
+/// evaluation, include resolution — already supported the pair.
+#[tokio::test]
+async fn test_getter_relation_with_target_class_hydrates_via_include() {
+    let store = SparqlStore::new(None).unwrap();
+
+    let node_a = "we://node/a";
+    let node_b = "we://node/b";
+    let edge = "we://rel/1";
+
+    // Two nodes of the same class.
+    for (base, text, ts) in [
+        (node_a, "Node A", "1700000000000"),
+        (node_b, "Node B", "1700000000002"),
+    ] {
+        store
+            .add_link(&make_link(base, "we://flag", "we://text_block", ts))
+            .unwrap();
+        store
+            .add_link(&make_link(
+                base,
+                "we://text",
+                &format!("literal:string:{}", literal_percent_encode(text)),
+                ts,
+            ))
+            .unwrap();
+    }
+
+    // The edge: a record whose two to-one relations name the ends it joins.
+    store
+        .add_link(&make_link(
+            edge,
+            "we://relationship_source",
+            node_a,
+            "1700000000004",
+        ))
+        .unwrap();
+    store
+        .add_link(&make_link(
+            edge,
+            "we://relationship_target",
+            node_b,
+            "1700000000005",
+        ))
+        .unwrap();
+
+    // `related` is defined by a two-hop traversal through the edge record, and
+    // names its own class so the values can be hydrated. Self-referential —
+    // a node relates to other nodes — which also exercises the target shape
+    // resolving to the shape currently being queried.
+    let shape_json = r#"{
+        "className": "TextBlock",
+        "properties": {
+            "flag": {
+                "predicate": "we://flag",
+                "required": true,
+                "flag": true,
+                "initial": "we://text_block"
+            },
+            "text": { "predicate": "we://text", "resolveLanguage": "literal" }
+        },
+        "relations": {
+            "related": {
+                "kind": "hasMany",
+                "getter": "SELECT ?target WHERE { ?rel <we://relationship_source> <Base> . ?rel <we://relationship_target> ?target . }",
+                "targetClassName": "TextBlock"
+            }
+        }
+    }"#;
+
+    let query = ModelQueryInput {
+        where_clause: Some(BTreeMap::from([(
+            "id".to_string(),
+            super::types::WhereCondition::String(node_a.to_string()),
+        )])),
+        include: Some(HashMap::from([(
+            "related".to_string(),
+            super::types::IncludeValue::Bool(true),
+        )])),
+        ..Default::default()
+    };
+
+    let result = execute_model_query_from_json(&store, "TextBlock", &query, shape_json)
+        .await
+        .unwrap();
+
+    assert_eq!(result.instances.len(), 1, "expected node A");
+    let related = result.instances[0]["related"]
+        .as_array()
+        .expect("related must hydrate as an array");
+
+    assert_eq!(related.len(), 1, "A is joined to exactly one node");
+    assert_eq!(
+        related[0]["id"].as_str().unwrap(),
+        node_b,
+        "the traversal must land on the far end of the edge",
+    );
+    assert_eq!(
+        related[0]["text"].as_str().unwrap(),
+        "Node B",
+        "and it must be a hydrated instance, not a bare URI — which is what \
+         naming the target class buys",
+    );
+}


### PR DESCRIPTION
# A getter relation can name its target class

> [!IMPORTANT]
> **Branch** `feat/getter-relation-target-class` · **Base** `dev`.
> Independent. Nothing in the series is required before it.
>
> Part of an eight-PR series on the AD4M model layer — review wave 2 of 4. The full shape:

```
dev ─┬─ 1  relation-correctness ── 5  subjectClassOf ─┬─ 6  polymorphic-include
     │                                                └─ 7  ordering-module ── 8  ordering-integration
     ├─ 2  getter+target
     └─ 3  where-compiler ── 4  quantifiers
```

## Summary

`resolveRelationArgs` refused `getter` alongside `target`, and alongside `where`. Every layer
beneath already supported both pairings — SHACL emission, shape parsing, getter evaluation, include
resolution — and only the decorator said no. This deletes the two guards.

The pairing matters because a custom getter exists to express a traversal the link-shaped DSL
cannot, and the case WE is walking into is a **reified edge**: a connection stored as a record rather
than a predicate, so that it can carry a label, comments and signals. There is no single
predicate for `through` to name, because the edge is two hops. Without `target` such a relation has
no target class, `include` resolves a shape named `""` and the query errors — so a traversal could
only ever hand back bare URIs, and the caller had to re-fetch each one to learn anything about it.

## Changes

**`core/src/model/decorators.ts`** — removes the `getter`/`target` and `getter`/`where` throws, and
documents why the pairing is coherent.

`target` does two separable jobs: derive a conformance filter, and name the class the relation's
values hydrate into. Only the first competes with an explicit getter — and `buildSHACL` already
resolves that competition on its own. Its getter slot is a priority chain (`relMeta.getter` first,
auto-derived conformance second), while `sh:class` and `ad4m:targetClassName` are emitted from
`relMeta.target` in a separate branch that never consulted the getter. The generator was written for
this; the guard upstream meant it could not be reached.

`where` is the same story from the other end: the executor applies post-getter where filters
*specifically* to getter-backed relations (`apply_where_filter_to_relation`, called over
`getter_props`), and emitting `wherePredicates` needs `relMeta.target` to resolve the target's
metadata. The runtime is built for getter + target + where together.

`getter` and `through` stay mutually exclusive. That one is real — a getter replaces link-based
resolution, so there is no predicate to add to or remove from, and the relation is read-only.

**`core/src/model/relation-filtering.test.ts`** — the two tests that pinned the old behaviour now
pin the new: the explicit getter survives verbatim, `targetClassName` is emitted beside it, and a
`where` on a getter relation reaches `whereFilter`.

**`rust-executor/src/perspectives/model_query/integration_tests.rs`** — a round-trip test building
the shape this is for: two nodes joined by an edge record, asserting the far end arrives **hydrated**
(`text == "Node B"`) rather than as a URI. Self-referential (a node relates to nodes), which also
covers the target shape resolving to the shape being queried.

## Known follow-ups

- This is a **model-declaration** escape hatch: a getter is fixed per class, so "edges of kind X"
  still needs the query layer. The relation-quantifier PR later in this stack covers that.
- Nothing here changes `getter` + `through`, which remains refused. If a relation ever wants to be
  *read* by traversal and *written* by predicate, that is a separate design question.

## What this unblocks in WE

A `WeNode` can declare a `related` relation defined by a two-hop SPARQL traversal through
`Relationship`, and `include` it — getting typed instances rather than URIs, in one query. Not
adopted here; WE is untouched until the stack merges.

## Test plan

> Counts are for this branch **against its own base**, so they include only this PR's tests —
> not its predecessors'. Re-measured after the stack was split from one linear chain into the
> tree above.

- [x] `cargo test -p ad4m-executor --lib perspectives::model_query` — 215 passing, 1 new
- [x] New round-trip test asserts the traversal's far end is a hydrated instance, not a URI
- [x] `jest src/model` in `core` — 247 passing
- [x] Confirmed the order the executor relies on: getters are evaluated at `query.rs:383`, includes
      resolve at `:395`, so a getter relation's URIs are populated before includes hydrate them
- [x] `tsc --noEmit` clean
- [x] `cargo fmt -p ad4m-executor`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Getter-backed relations can now specify a target model and apply filtering after retrieval.
  * Related records can be hydrated as typed model instances when traversing configured relations.

* **Bug Fixes**
  * Preserved custom getter behavior with target-model metadata and post-retrieval filters.
  * Continued to prevent incompatible combinations with through-relations.
  * Invalid filtering combinations are now consistently rejected for getter-backed relations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->