### PR TITLE
Feature: Auto processor class set

### DIFF
--- a/core/src/perspectives/PerspectiveClient.ts
+++ b/core/src/perspectives/PerspectiveClient.ts
@@ -359,6 +359,13 @@ export class PerspectiveClient {
         )
     }
 
+    /** Delete an auto-processor's config. `false` when there was none to delete. */
+    async removeAutoProcessor(uuid: string, processorId: string): Promise<boolean> {
+        return this.#apiClient.call<boolean>(
+            'perspective.removeAutoProcessor', { uuid, processorId },
+        )
+    }
+
     /** Pending interpretation overlays (LLM suggestions awaiting human accept/reject). */
     async interpretationOverlays(uuid: string): Promise<InterpretationOverlayInfo[]> {
         return this.#apiClient.call<InterpretationOverlayInfo[]>(

--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -642,6 +642,25 @@ export class PerspectiveProxy {
     }
 
     /**
+     * Stop an auto-processor by deleting its config.
+     *
+     * The registration is data — the watch loop reads the processor set back out of the
+     * perspective's graph on every tick — so deleting the config is what stops it, and there is
+     * nothing else to unregister. The config is `Shared`, so this stops the processor for the
+     * neighbourhood rather than only for this peer.
+     *
+     * Resolves `true` when there was a processor to remove and `false` when there was not; a
+     * processor another peer has already removed is not an error.
+     *
+     * The processor's `InterpretationRun` nodes stay: they are the record of what it did and the
+     * processed-turn cursor, so a processor later registered under the same id resumes where this
+     * one left off rather than re-reading every turn.
+     */
+    async removeAutoProcessor(processorId: string): Promise<boolean> {
+        return await this.#client.removeAutoProcessor(this.#handle.uuid, processorId)
+    }
+
+    /**
      * Pending interpretation overlays on this perspective — LLM suggestions the
      * §4 divergence gate staged rather than applied, awaiting human accept/reject.
      */

--- a/rust-executor/src/api/perspectives_ws.rs
+++ b/rust-executor/src/api/perspectives_ws.rs
@@ -1595,6 +1595,19 @@ async fn emit_one_shot_abandoned(uuid: &str, observation_id: &str, did: &str, re
 /// `AutoProcessorConfig` into the shared graph; the executor watch loop reads it
 /// back and starts running interpretation automatically over new source items,
 /// emitting step signals on the events WebSocket (`auto-processor-event`).
+///
+/// **Registering is not idempotent in its class list.** Scalars overwrite through their
+/// `setSingleTarget` setters, but `interpretationClasses` is a collection written with the shape's
+/// `addLink` setter, so a second registration under the same `processorId` *unions* its classes
+/// with what is already stored rather than replacing them. Registering `[A]` and then `[B]` leaves
+/// a processor materializing both.
+///
+/// This endpoint is therefore for **creating** a processor. To change what an existing one
+/// extracts, edit its `AutoProcessorConfig` through the model API, where a collection can be set to
+/// exactly the values given; to stop it, use `perspective.removeAutoProcessor`. A client that
+/// re-registers on reconnect should check whether the config already exists first — the config is
+/// shared graph state that outlives any one agent's session, so "ensure it exists" is the shape
+/// that wants, not "register it again".
 async fn add_auto_processor_handler(
     params: Value,
     ctx: Arc<RequestContext>,
@@ -1618,6 +1631,14 @@ async fn add_auto_processor_handler(
     // back at the boundary instead. Ranges mirror
     // `AutoProcessorConfig::config_from_instance` (rust-executor/src/
     // perspectives/auto_processor/config.rs).
+    //
+    // `scalar_string` treats an empty scalar as absent, so `config_from_instance` rejects a config
+    // whose `processorId` is `""` — it writes, reports success, and never loads. It is also the
+    // identity: the node URI, the claim's batch nodes and the processed-turn cursor are all derived
+    // from it, so an empty one is not a processor that runs badly but a processor with no name.
+    if body.processor_id.is_empty() {
+        return Err(WsRpcError::bad_request("`processorId` must be non-empty"));
+    }
     if body.interpretation_classes.is_empty() {
         return Err(WsRpcError::bad_request(
             "`interpretationClasses` must be non-empty",
@@ -1672,6 +1693,46 @@ async fn add_auto_processor_handler(
     .map_err(|e| WsRpcError::internal(e.to_string()))?;
 
     Ok(serde_json::to_value(body.processor_id)?)
+}
+
+/// `perspective.removeAutoProcessor` — delete a processor's config instance, which is what stops
+/// its watch: the loop reads the processor set back out of the perspective's graph on every tick.
+///
+/// Answers `true` when there was a processor to remove and `false` when there was not, rather than
+/// erroring on the second case — a caller tidying up after a processor a peer has already removed
+/// has done the right thing, and a teardown path is the worst place to raise an avoidable failure.
+///
+/// Deliberately validates less than its `add` counterpart, which rejects an empty `processorId`.
+/// Strictness belongs on the way in: registration decides what may exist, and removal is how
+/// anything already there is recovered from. A config written before that validation existed — or
+/// by any writer that is not this handler — must stay removable, and refusing the id here would
+/// leave junk on the graph with no API able to take it away. The id is used verbatim to derive one
+/// node URI, so an empty one addresses exactly the node an empty-id write produced and nothing else.
+///
+/// Takes the same `update` capability as registering one. Deleting a processor is not a read: it
+/// changes what the neighbourhood extracts, for everyone.
+async fn remove_auto_processor_handler(
+    params: Value,
+    ctx: Arc<RequestContext>,
+) -> Result<Value, WsRpcError> {
+    use crate::api::types::RemoveAutoProcessorRequest;
+    use crate::perspectives::auto_processor::config::remove_processor;
+
+    let body: RemoveAutoProcessorRequest = serde_json::from_value(params.clone())
+        .map_err(|e| WsRpcError::bad_request(format!("Invalid params: {}", e)))?;
+    check_capability(
+        &ctx.capabilities,
+        &perspective_update_capability(vec![body.uuid.clone()]),
+    )
+    .map_err(|e| WsRpcError::forbidden(e))?;
+
+    let mut perspective = get_perspective_with_access(&body.uuid, &ctx).await?;
+    let agent_context = AgentContext::from_auth_token(ctx.auth_token.clone());
+    let removed = remove_processor(&mut perspective, &body.processor_id, &agent_context)
+        .await
+        .map_err(|e| WsRpcError::internal(e.to_string()))?;
+
+    Ok(Value::Bool(removed))
 }
 
 /// `perspective.acceptInterpretation` — materialize the overlay's staged
@@ -1798,6 +1859,10 @@ pub fn register_ws_handlers(map: &mut HandlerMap) {
         run_interpretation_with_harness_handler,
     );
     map.register("perspective.addAutoProcessor", add_auto_processor_handler);
+    map.register(
+        "perspective.removeAutoProcessor",
+        remove_auto_processor_handler,
+    );
     map.register(
         "perspective.acceptInterpretation",
         accept_interpretation_handler,

--- a/rust-executor/src/api/types.rs
+++ b/rust-executor/src/api/types.rs
@@ -729,6 +729,23 @@ pub struct AddAutoProcessorRequest {
     pub emit_debug_events: Option<bool>,
 }
 
+/// Stop a neighbourhood auto-processor by deleting its config instance.
+///
+/// The counterpart to [`AddAutoProcessorRequest`]. A processor's registration is a subject instance
+/// in the shared graph, which the watch loop re-reads on every tick, so removing that instance is
+/// what stops it — and stops it for the neighbourhood, since the config is `Shared` state rather
+/// than one peer's local record of it.
+///
+/// Server-side deserialization only, matching [`AddAutoProcessorRequest`]: the TypeScript client
+/// passes `uuid` separately and names only the processor.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoveAutoProcessorRequest {
+    pub uuid: String,
+    /// The `processorId` the processor was registered under.
+    pub processor_id: String,
+}
+
 /// `perspective.acceptInterpretation` / `perspective.rejectInterpretation` —
 /// resolve an LLM interpretation overlay's suggestion(s) on a base. `property`
 /// scopes to one predicate; omit it to accept/reject the whole base.

--- a/rust-executor/src/perspectives/auto_processor/config.rs
+++ b/rust-executor/src/perspectives/auto_processor/config.rs
@@ -30,7 +30,7 @@
 use crate::agent::AgentContext;
 use crate::perspectives::model_query::types::Scope;
 use crate::perspectives::perspective_instance::{PerspectiveInstance, SubjectClassOption};
-use crate::types::{Link, LinkStatus};
+use crate::types::{Link, LinkExpression, LinkQuery, LinkStatus};
 
 use super::scalar_string;
 use crate::perspectives::hardwired_class::{ensure_subject_class, subject_class_registered};
@@ -367,6 +367,73 @@ pub async fn write_processor(
     }
 
     Ok(())
+}
+
+/// Stop a processor by deleting its config instance. Returns whether there was one to delete.
+///
+/// The registration *is* data: [`load_processors`] reads the processor set out of the perspective's
+/// own graph on every watch tick, so deleting the instance is what stops the watch, and there is
+/// nothing else to unregister. Without this the only way to stop a processor was for a client to
+/// work out the node URI and delete the links itself — reaching around a subject class whose whole
+/// purpose is that a processor can be administered through the ordinary model API.
+///
+/// Idempotent, and it reports which case it was rather than treating one as a failure: a caller
+/// tidying up after a processor another peer has already removed is doing the right thing.
+///
+/// The processor's `InterpretationRun` nodes are deliberately left behind. They are both the record
+/// of what it did and the processed-turn cursor keyed on this node (see [`super::cursor`]), so
+/// deleting them would make a processor later registered under the same id re-interpret every turn
+/// the first one had already read.
+///
+/// One batch, so the instance goes away in a single commit. A partial removal would leave a node
+/// that no longer conforms to the class — invisible to [`load_processors`] and therefore stopped,
+/// but stopped by accident rather than by the write, and still carrying whichever links happened to
+/// survive.
+pub async fn remove_processor(
+    perspective: &mut PerspectiveInstance,
+    processor_id: &str,
+    context: &AgentContext,
+) -> anyhow::Result<bool> {
+    let node = processor_node(processor_id);
+    let links = perspective
+        .get_links(&LinkQuery {
+            source: Some(node.clone()),
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!("remove_processor(`{processor_id}`): get_links failed: {e:#}")
+        })?;
+
+    // Nothing here. Not an error: a processor that was never written and one another peer removed
+    // first are the same state, and neither is a failure of this call.
+    if links.is_empty() {
+        return Ok(false);
+    }
+
+    let batch_id = perspective.create_batch().await;
+    let removal = perspective
+        .remove_links(
+            links.into_iter().map(LinkExpression::from).collect(),
+            Some(batch_id.clone()),
+        )
+        .await;
+
+    if let Err(e) = removal {
+        let _ = perspective.discard_batch(&batch_id).await;
+        return Err(anyhow::anyhow!(
+            "remove_processor(`{processor_id}`): remove_links failed: {e:#}"
+        ));
+    }
+
+    if let Err(e) = perspective.commit_batch(batch_id.clone(), context).await {
+        let _ = perspective.discard_batch(&batch_id).await;
+        return Err(anyhow::anyhow!(
+            "remove_processor(`{processor_id}`): commit_batch failed: {e:#}"
+        ));
+    }
+
+    Ok(true)
 }
 
 fn class_option() -> SubjectClassOption {
@@ -954,6 +1021,134 @@ mod tests {
         assert_eq!(
             loaded[0].interpretation_classes,
             vec!["ns://Question".to_string(), "ns://Task".to_string()]
+        );
+    }
+
+    /// Removing a processor takes it out of the loaded set — which is what stops its watch,
+    /// since the loop reads the set back out of the graph on every tick. Its neighbours are left
+    /// alone: one processor going away must not disturb another on the same perspective.
+    #[tokio::test]
+    async fn remove_processor_deletes_only_that_processor() {
+        let (mut p, _shapes, ctx) = setup_perspective_no_llm(&[]).await;
+        for id in ["keep-me", "remove-me"] {
+            write_processor(&mut p, &sample_config(id), Some(false), &ctx)
+                .await
+                .expect("write");
+        }
+
+        let removed = remove_processor(&mut p, "remove-me", &ctx)
+            .await
+            .expect("remove");
+        assert!(removed, "there was a processor to remove");
+
+        let ids: Vec<String> = load_processors(&p)
+            .await
+            .expect("load")
+            .into_iter()
+            .map(|c| c.processor_id)
+            .collect();
+        assert_eq!(ids, vec!["keep-me"]);
+
+        let leftovers = p
+            .get_links(&LinkQuery {
+                source: Some(processor_node("remove-me")),
+                ..Default::default()
+            })
+            .await
+            .expect("get_links");
+        assert!(
+            leftovers.is_empty(),
+            "the config node must carry no links, found {leftovers:?}"
+        );
+    }
+
+    /// Removing a processor that is not there answers `false` rather than erroring. A caller
+    /// tidying up after a processor a peer already removed has done the right thing, and a
+    /// teardown path is the worst place to raise an avoidable failure.
+    #[tokio::test]
+    async fn remove_processor_is_idempotent() {
+        let (mut p, _shapes, ctx) = setup_perspective_no_llm(&[]).await;
+        write_processor(&mut p, &sample_config("once"), Some(false), &ctx)
+            .await
+            .expect("write");
+
+        assert!(remove_processor(&mut p, "once", &ctx).await.expect("first"));
+        assert!(!remove_processor(&mut p, "once", &ctx)
+            .await
+            .expect("second"));
+        assert!(
+            !remove_processor(&mut p, "never-existed", &ctx)
+                .await
+                .expect("unknown id"),
+            "an unknown processor id is not an error"
+        );
+    }
+
+    /// Removal really clears the node, so a processor registered again under the same id starts
+    /// from the new config rather than inheriting the old one's classes.
+    ///
+    /// Worth pinning precisely because `write_processor` *appends* to the class collection: the
+    /// only reason a re-registration does not accumulate the previous list is that removal left
+    /// nothing behind. A removal that missed a link would show up here and nowhere else.
+    #[tokio::test]
+    async fn a_removed_processor_can_be_registered_again() {
+        let (mut p, _shapes, ctx) = setup_perspective_no_llm(&[]).await;
+        let mut cfg = sample_config("recycled");
+        cfg.interpretation_classes = vec!["ns://Task".into()];
+        write_processor(&mut p, &cfg, Some(false), &ctx)
+            .await
+            .expect("write first");
+        remove_processor(&mut p, "recycled", &ctx)
+            .await
+            .expect("remove");
+
+        cfg.interpretation_classes = vec!["ns://Belief".into()];
+        write_processor(&mut p, &cfg, Some(false), &ctx)
+            .await
+            .expect("write again");
+
+        let loaded = load_processors(&p).await.expect("load");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(
+            loaded[0].interpretation_classes,
+            vec!["ns://Belief".to_string()],
+            "a re-registered processor must not inherit the removed one's classes"
+        );
+    }
+
+    /// A processor written with an empty id is unloadable — `scalar_string` reads an empty scalar
+    /// as absent, so `config_from_instance` rejects it — and must still be removable.
+    ///
+    /// `perspective.addAutoProcessor` refuses an empty `processorId` precisely because of the
+    /// first half, but that is a validation on the way *in*: a config written before it existed,
+    /// or by a writer that is not that handler, is exactly the junk removal has to be able to
+    /// clear. Refusing the id on the way out would strand it with nothing able to take it away.
+    #[tokio::test]
+    async fn an_unloadable_empty_id_processor_is_still_removable() {
+        let (mut p, _shapes, ctx) = setup_perspective_no_llm(&[]).await;
+        write_processor(&mut p, &sample_config(""), Some(false), &ctx)
+            .await
+            .expect("write");
+
+        assert!(
+            load_processors(&p).await.expect("load").is_empty(),
+            "an empty processor_id is read as absent, so the config must not load"
+        );
+
+        assert!(
+            remove_processor(&mut p, "", &ctx).await.expect("remove"),
+            "the config's links are there to remove even though it never loaded"
+        );
+        let leftovers = p
+            .get_links(&LinkQuery {
+                source: Some(processor_node("")),
+                ..Default::default()
+            })
+            .await
+            .expect("get_links");
+        assert!(
+            leftovers.is_empty(),
+            "nothing must be left behind, found {leftovers:?}"
         );
     }
 


### PR DESCRIPTION
# A processor can be removed

_Based on `dev`. Five files, +304/−1 — purely additive apart from one import line._

## Summary

`perspective.addAutoProcessor` had no counterpart. A processor's registration is a subject
instance in the shared graph that the watch loop re-reads on every tick, so deleting that instance
is what stops it — but with no API for it, the only way to stop a processor was for a client to
derive the node URI and delete its links by hand. That reaches around the very subject class that
exists, per its own module doc, "so app UIs can list, inspect and edit processors through the
ordinary model API instead of reverse-engineering a private link shape."

This adds the removal side of that, plus one validation gap it exposed.

## How this PR changed shape

It originally also made `interpretationClasses` a set, so a processor's extraction targets could
be narrowed rather than only widened. That is dropped, on review feedback from Nico, and the
reasoning is worth recording because it is not obvious:

- `interpretationClasses` is a collection, and the Rust subject-write path writes **one value per
  property** — `resolve_property_value` collapses an array into a single `literal:json:` IRI. The
  established way to write a collection from Rust is one `update_subject` call per member against
  an `addLink` setter, which is exactly what `InterpretationRun.sources` does.
- The model layer *does* have a set-the-whole-collection operation, `Action::CollectionSetter`, but
  it builds its links from `execute_commands`'s `parameters` — and `create_subject`/`update_subject`
  both pass `vec![]`. So from Rust it would remove every link and add none. Nothing in the Rust
  codebase constructs one; the only occurrence of the symbol is the match arm itself.
- It is reachable from `executeAction`, which is the **TypeScript ORM's** path. `AutoProcessorConfig`
  is a real `@Model` whose `interpretationClasses` is a `@HasMany`, and `Ad4mModel` generates its
  actions from decorator metadata rather than from the installed SDNA — so a client can set the
  whole list today, with no executor change.

So set semantics belong client-side, and the Rust-side implementation this PR carried was a
hand-rolled reimplementation of a primitive that already exists one layer down. Removing it leaves
the part that genuinely needs to be in the executor.

## Changes

### `rust-executor/src/perspectives/auto_processor/config.rs`

`remove_processor` — deletes a processor's config instance in one batch, and reports whether there
was one to delete.

Two decisions worth reviewing explicitly:

- It answers `false` rather than erroring when there is no such processor. A caller tidying up
  after a peer that removed it first has done the right thing, and a teardown path is a poor place
  to raise an avoidable failure.
- The processor's `InterpretationRun` nodes are deliberately left behind. They are both the record
  of what it did and the processed-turn cursor keyed on the processor node, so deleting them would
  make a processor later registered under the same id re-interpret every turn the first one had
  already read.

One batch rather than loose removals: a partial removal would leave a node that no longer conforms
to the class — invisible to `load_processors` and therefore stopped, but stopped by accident rather
than by the write.

### `rust-executor/src/api/perspectives_ws.rs`, `rust-executor/src/api/types.rs`

`perspective.removeAutoProcessor` and its `RemoveAutoProcessorRequest`. Takes the same `update`
capability as registering one: deleting a processor is not a read, it changes what the
neighbourhood extracts for every member.

`addAutoProcessor` now rejects an empty `processorId`. `scalar_string` reads an empty scalar as
absent, so `config_from_instance` rejects such a config: it writes, reports success, and never
loads — the exact "caller sees success but the processor never runs" failure the handler's
validation block already existed to prevent, with `processorId` the one field missing from it.

Removal deliberately does *not* validate the id. Strictness belongs on the way in; removal is how
anything already on the graph is recovered from, and a config written before that validation
existed (or by a writer that is not this handler) has to stay removable. The id derives one node
URI verbatim, so an empty one addresses exactly the node an empty-id write produced and nothing
else.

The handler's docs now also state what registration does to a collection, since this PR makes it
load bearing: `interpretationClasses` is written with the shape's `addLink` setter, so registering
twice under one id **unions** the class lists rather than replacing them. The endpoint is for
creating a processor; changing what an existing one extracts is an edit to its `AutoProcessorConfig`
through the model API. A client that re-registers on reconnect should check whether the config
exists first — it is shared graph state that outlives any one agent's session, so "ensure it
exists" is the right shape, not "register it again".

### `core/src/perspectives/PerspectiveClient.ts`, `core/src/perspectives/PerspectiveProxy.ts`

`removeAutoProcessor(processorId)` on both, mirroring the `addAutoProcessor` pair. The proxy's
docstring carries the two behaviours a caller has to know: `false` means "there was none", and the
run/cursor nodes survive so a re-registered processor resumes rather than restarts.

## Test plan

- [x] `cargo test -p ad4m-executor --lib auto_processor::config` — 21 passed, 0 failed. Four new:
      `remove_processor_deletes_only_that_processor`, `remove_processor_is_idempotent`,
      `a_removed_processor_can_be_registered_again`,
      `an_unloadable_empty_id_processor_is_still_removable`.
- [x] `cargo test -p ad4m-executor --lib -- auto_processor --skip interpretation_e2e` — 89 passed, 0 failed.
- [x] `cargo fmt --all`; `cargo clippy -p ad4m-executor --lib --tests` clean on the changed files
      (the `redundant closure` warnings in `perspectives_ws.rs` are the file's existing idiom,
      present from line 141 of untouched code; the new handler matches its neighbours).
- [x] `pnpm run build` in `core/`.

`a_removed_processor_can_be_registered_again` is the one worth keeping an eye on: because
`write_processor` appends to the class collection, the only reason a re-registration does not
accumulate the previous list is that removal left nothing behind. A removal that missed a link
would show up there and nowhere else.

**Not run:** the `interpretation_e2e` and `interpretation_harness_e2e` suites, which need a local
Ollama serving `gemma3:12b` — not available in the environment this was written in, and they fail
at `AIService::prompt … model 'gemma3:12b' not found` before reaching any changed code. Nothing
here touches a pass's execution.

## Follow-ups

- **Consumers should treat `addAutoProcessor` as create-only** and edit the class list through the
  model API. WE re-registers on its resume and adopt paths, so it needs the check-first behaviour
  described above; without it, a stale config left by a failed teardown would union its old class
  list with the new one.
- **`perspective.autoProcessors` (list)** would complete the CRUD triangle and is cheap, but it
  needs a decision about what shape it returns and nothing here depends on it.
- **Rust-side collection writes** remain one-value-per-call. Teaching `create_subject`/
  `update_subject` to pass an array on a collection property through as `parameters` would make
  `CollectionSetter` reachable from Rust and let `InterpretationRun.sources` drop its N+1 loop.
  Deliberately not here: it changes shared machinery with an externally visible effect on
  `createSubject`/MCP, and it edits the same match arm #927 is already rewriting.
- **#892 is stranded.** `fix(interpretation): decode literal-encoded overlay kind on read` is still
  open against `feature/generic-extraction-ws-ts`, a base already merged into `dev`, and the change
  is absent from dev's `overlay/accept.rs`. It is on the overlay path accept/reject uses.
- **#901 looks already merged** — its head commit (`68fe6c608`) is in `dev`, but the PR is still
  open against the same stale base.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to remove configured perspective auto-processors.
  * Removal reports whether a processor configuration was deleted and is safe to repeat.
  * Added validation for missing processor IDs when registering auto-processors.
  * Existing processor registrations now combine interpretation classes.

* **Behavior**
  * Removing a processor deletes its configuration while preserving processing history.
  * Access and update permissions are enforced for processor removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->