### PR TITLE
chore: Clean-up warnings and wire missing billing paths for OpenAI compat. interface

### DIFF
--- a/rust-executor/src/ai_service/mod.rs
+++ b/rust-executor/src/ai_service/mod.rs
@@ -1375,6 +1375,11 @@ impl AIService {
     /// Streaming variant of [`Self::prompt_messages`].  Returns a token
     /// stream + a oneshot for the final [`PromptResult`] (carries the
     /// full text + token counts for the closing SSE event).
+    ///
+    /// Billing happens when the stream completes: the worker's final
+    /// result is billed (on success only, matching
+    /// [`Self::prompt_messages`]) in a forwarder task before it reaches
+    /// the caller's `done_rx`.
     pub async fn prompt_messages_stream(
         &self,
         model_id: String,
@@ -1403,6 +1408,10 @@ impl AIService {
         spawn_rx.await??;
 
         let (token_tx, token_rx) = mpsc::unbounded_channel::<String>();
+        // worker -> forwarder -> caller: the billing hook runs between the
+        // worker's final result and the caller's done_rx, so stream:true
+        // requests are charged like the non-stream path (success only).
+        let (worker_done_tx, worker_done_rx) = oneshot::channel::<Result<PromptResult>>();
         let (done_tx, done_rx) = oneshot::channel::<Result<PromptResult>>();
         {
             let llm_channel = self.llm_channel.lock().await;
@@ -1414,9 +1423,21 @@ impl AIService {
                 prompt: final_prompt,
                 constraint,
                 token_sender: token_tx,
-                done_sender: done_tx,
+                done_sender: worker_done_tx,
             }))?;
         }
+
+        let billing_model_id = resolved.clone();
+        tokio::spawn(async move {
+            // The worker always sends Ok/Err; the Err arm only covers a
+            // dropped sender (worker panic).
+            let result = match worker_done_rx.await {
+                Ok(inner) => inner,
+                Err(_) => Err(anyhow!("LLM stream ended without a final result")),
+            };
+            Self::bill_and_forward_stream_result(auth_token, &billing_model_id, result, done_tx)
+                .await;
+        });
 
         // Schedule a Remove for after the prompt completes — best-effort
         // background cleanup so the caller doesn't have to await it.
@@ -1494,6 +1515,30 @@ impl AIService {
             completion_tokens,
             model_id,
         })
+    }
+
+    /// Bill a completed stream result (on success only, matching
+    /// [`Self::prompt_messages`]) and relay it to the caller's oneshot.
+    ///
+    /// Runs inside the forwarder spawned by
+    /// [`Self::prompt_messages_stream`]; exposed as an associated function
+    /// so the streaming billing behaviour is unit-testable without a live
+    /// LLM channel.
+    pub(crate) async fn bill_and_forward_stream_result(
+        auth_token: Option<String>,
+        model_id: &str,
+        result: Result<PromptResult>,
+        done_tx: oneshot::Sender<Result<PromptResult>>,
+    ) {
+        if let Ok(pr) = &result {
+            Self::bill_prompt_if_authed(
+                auth_token.as_deref(),
+                model_id,
+                pr.prompt_tokens,
+                pr.completion_tokens,
+            );
+        }
+        let _ = done_tx.send(result);
     }
 
     /// Shared post-compute billing hook for prompt paths.

--- a/rust-executor/src/api/openai_compat/billing_amounts.rs
+++ b/rust-executor/src/api/openai_compat/billing_amounts.rs
@@ -1,15 +1,13 @@
 //! Pure functions that compute the credit amount billed by each `/v1`
-//! endpoint. Extracted from the handlers so the formulas are:
+//! endpoint that bills at the handler level. Extracted from the handlers so
+//! the formulas are:
 //!   - easy to read in one place (single source of truth per endpoint),
-//!   - unit-testable without spinning up a runtime or mocking `bill_compute`,
-//!   - trivial to swap in real Kalosm/BPE token counts once available.
+//!   - unit-testable without spinning up a runtime or mocking `bill_compute`.
 //!
 //! Handlers MUST route their amount calculation through these helpers and
 //! pass the result to `bill_compute` — do NOT inline a different formula.
 //!
 //! Operation labels used with `bill_compute`:
-//!   - `"ai_prompt"` → chat/completions oneshot + streaming + legacy completions
-//!   - `"ai_embedding"` → embeddings
 //!   - `"ai_tts"` → speech
 //!   - `"ai_transcription"` → NOT billed at the handler level. Transcription
 //!     is billed exactly once in the worker (`ai_service/mod.rs::open_transcription_stream`).
@@ -18,36 +16,9 @@
 //!     call in `audio::transcriptions`, the `no_bill_compute_in_transcriptions_handler`
 //!     test will fail — that's the guard.
 //!
-//! Streaming caveat: `stream_prompt` returns a flat `1.0` today because
-//! Kalosm doesn't hand back token counts on the streaming path. TODO to
-//! plumb real counts when the backend exposes them.
-
-/// Per-request minimum charge so a genuinely tiny prompt still records
-/// activity in the compute log. `bill_compute` clamps this again in
-/// aggregate, but keeping the floor at the call site makes the invariant
-/// visible in the formula.
-pub(super) const MIN_PROMPT_BILL: f64 = 0.001;
-
-/// Non-streaming chat / legacy completions: proportional to
-/// `(prompt_tokens + completion_tokens) / 1000.0`, floored at
-/// `MIN_PROMPT_BILL` so tiny requests still bill something.
-pub(super) fn chat_or_completion_amount(prompt_tokens: usize, completion_tokens: usize) -> f64 {
-    let total = (prompt_tokens + completion_tokens) as f64;
-    (total / 1000.0).max(MIN_PROMPT_BILL)
-}
-
-/// Streaming chat: flat `1.0` for now. Kalosm's streaming path doesn't
-/// yield per-token counts; when it does, switch to
-/// `chat_or_completion_amount(prompt_tokens, streamed_completion_tokens)`.
-pub(super) fn stream_prompt_amount() -> f64 {
-    1.0
-}
-
-/// Embeddings: one credit per returned embedding vector, minimum one.
-/// A single call with N inputs bills N credits so batching stays fair.
-pub(super) fn embedding_amount(vector_count: usize) -> f64 {
-    vector_count.max(1) as f64
-}
+//! Chat/completions (streaming and non-streaming) and embeddings are billed
+//! by `AIService` via host_rates (`crate::billing::bill_ai_operation`), not
+//! here.
 
 /// TTS speech: characters synthesised / 1000, floored at 1.0 so any
 /// synthesis bills at least one credit. Aligns with OpenAI's own

--- a/rust-executor/src/api/openai_compat/chat.rs
+++ b/rust-executor/src/api/openai_compat/chat.rs
@@ -267,7 +267,6 @@ async fn chat_stream(
     // receiver.  This avoids pulling in `async-stream` for the sole
     // sake of one `yield`-style generator.
     let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel::<Result<Event, Infallible>>();
-    let auth_clone = auth.clone();
 
     // Initial role event.
     let role_chunk = ChatCompletionChunk {

--- a/rust-executor/src/api/openai_compat/embeddings.rs
+++ b/rust-executor/src/api/openai_compat/embeddings.rs
@@ -63,14 +63,6 @@ pub async fn embeddings(
         });
     }
 
-    if let Some(email) = crate::agent::capabilities::user_email_from_token(auth.auth_token.clone())
-    {
-        // Billing now happens inside AIService::embed via bill_ai_operation
-        // (host_rates-based, shared with WS-RPC ai.embed). Handler used to
-        // double-bill here; that path is gone.
-        let _ = data.len(); // silence unused-var if data was only used for billing
-    }
-
     Ok(Json(EmbeddingResponse {
         object: "list",
         data,

--- a/rust-executor/src/api/openai_compat/tests.rs
+++ b/rust-executor/src/api/openai_compat/tests.rs
@@ -617,7 +617,7 @@ fn init_test_db() {
         // If a prior init attempt panicked, the mutex may be poisoned.
         // Recover by taking the poisoned inner value.
         let arc = crate::db::Ad4mDb::global_instance();
-        let mut guard = match arc.lock() {
+        let guard = match arc.lock() {
             Ok(g) => g,
             Err(poisoned) => poisoned.into_inner(),
         };

--- a/rust-executor/src/api/openai_compat/tests.rs
+++ b/rust-executor/src/api/openai_compat/tests.rs
@@ -1,8 +1,5 @@
 use super::audio::{audio_decode, decode_pcm_wav};
-use super::billing_amounts::{
-    chat_or_completion_amount, embedding_amount, speech_amount, stream_prompt_amount,
-    MIN_PROMPT_BILL,
-};
+use super::billing_amounts::speech_amount;
 use super::errors::OpenAIError;
 use super::realtime::pcm16_to_f32;
 use super::types::*;
@@ -428,61 +425,11 @@ fn estimate_token_count_counts_unicode_scalars_not_bytes() {
 // Billing: per-endpoint amount formulas
 // ---------------------------------------------------------------------------
 //
-// Every /v1 endpoint that debits credits routes its amount through
-// `billing_amounts` — the handlers no longer inline formulas. Tests below
-// pin the exact formula per endpoint so a silent change to billing math
-// is caught before it hits production.
+// Handler-level formulas in `billing_amounts` are pinned here so a silent
+// change to billing math is caught before it hits production.
+// (Chat — streaming and non-streaming — and embeddings are billed by
+// `AIService` via host_rates; see `stream_completion_bills_once_on_success`.)
 // ---------------------------------------------------------------------------
-
-#[test]
-fn chat_amount_zero_tokens_floors_to_minimum() {
-    // An "empty" prompt still bills a floor amount so the request shows
-    // up in the compute log at all (invariant: MIN_PROMPT_BILL).
-    assert!((chat_or_completion_amount(0, 0) - MIN_PROMPT_BILL).abs() < f64::EPSILON);
-}
-
-#[test]
-fn chat_amount_proportional_above_floor() {
-    // Below the 1000-token bucket → still floored.
-    let a = chat_or_completion_amount(100, 100);
-    assert!(a >= MIN_PROMPT_BILL);
-    assert!(a > 0.199 && a < 0.201, "200 tokens → 0.2 credits, got {a}");
-
-    // Exactly at the bucket boundary.
-    assert!((chat_or_completion_amount(500, 500) - 1.0).abs() < 1e-12);
-
-    // Above the bucket → scales linearly.
-    assert!((chat_or_completion_amount(1500, 2500) - 4.0).abs() < 1e-12);
-}
-
-#[test]
-fn chat_amount_scaling_is_linear() {
-    // 10× the tokens → 10× the amount (once above the floor).
-    let ten_k = chat_or_completion_amount(5_000, 5_000);
-    let hundred_k = chat_or_completion_amount(50_000, 50_000);
-    assert!((hundred_k - 10.0 * ten_k).abs() < 1e-9);
-}
-
-#[test]
-fn stream_prompt_amount_is_flat_one() {
-    // Streaming path bills a flat 1.0 today because Kalosm's stream API
-    // doesn't yield per-token counts. Locked in so any switch to
-    // proportional streaming billing is a deliberate, tested change.
-    assert!((stream_prompt_amount() - 1.0).abs() < f64::EPSILON);
-}
-
-#[test]
-fn embedding_amount_per_vector() {
-    // Batch of N inputs bills N credits — fair scaling for callers who
-    // batch to reduce round-trips.
-    assert!(
-        (embedding_amount(0) - 1.0).abs() < f64::EPSILON,
-        "min-one floor"
-    );
-    assert!((embedding_amount(1) - 1.0).abs() < f64::EPSILON);
-    assert!((embedding_amount(5) - 5.0).abs() < f64::EPSILON);
-    assert!((embedding_amount(100) - 100.0).abs() < f64::EPSILON);
-}
 
 #[test]
 fn speech_amount_per_thousand_chars() {
@@ -1018,6 +965,155 @@ async fn chat_completions_stream_does_not_bill_at_setup() {
     assert!(
         calls.is_empty(),
         "streaming chat setup should defer billing to end-of-stream; got calls: {calls:?}"
+    );
+    test_seam::reset();
+}
+
+// ---------------------------------------------------------------------------
+// Streaming billing forwarder: the missing charge is the whole point of
+// this section. On success the stream must bill exactly once (same shape
+// as the non-stream path: ai_prompt, prompt+completion tokens, host-rate
+// priced); on error it must not bill at all. The forwarder is exercised
+// directly (no live LLM channel needed in unit tests).
+// ---------------------------------------------------------------------------
+
+use crate::ai_service::{AIService, PromptResult};
+
+/// Ensure the global wallet has a "main" keypair (decode_jwt signs and
+/// verifies with it) and return a user JWT whose `sub` is `email`.
+fn user_jwt_token(email: &str) -> String {
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    let wallet = crate::wallet::Wallet::instance();
+    let mut w = wallet.lock().unwrap();
+    let w = w.as_mut().unwrap();
+    if w.get_secret_key(&"main".to_string()).is_none() {
+        w.generate_keypair("main".to_string());
+    }
+    let secret = w.get_secret_key(&"main".to_string()).unwrap();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    encode(
+        &Header::default(),
+        &serde_json::json!({
+            "iss": "ad4m-test",
+            "sub": email,
+            "aud": "ad4m-test",
+            "exp": now + 3600,
+            "iat": now,
+            "nonce": "test-nonce",
+            "capabilities": { "appName": "test", "appDesc": "test" },
+        }),
+        &EncodingKey::from_secret(secret.as_slice()),
+    )
+    .unwrap()
+}
+
+fn sample_prompt_result() -> PromptResult {
+    PromptResult {
+        text: "hello world".to_string(),
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        model_id: "gpt-4".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn stream_completion_bills_once_on_success() {
+    init_test_db();
+    test_seam::reset();
+    test_seam::force_result(test_seam::ForcedResult::Success);
+
+    // bill_prompt_if_authed needs: multi-user mode on + a user JWT, and
+    // bill_ai_operation needs a priced model. Save/restore both because
+    // the global in-memory DB is shared across the test binary.
+    let prev_multi_user =
+        crate::db::Ad4mDb::with_global_instance(|db| db.get_multi_user_enabled().unwrap_or(false));
+    let prev_rates =
+        crate::db::Ad4mDb::with_global_instance(|db| db.get_host_rates().unwrap_or_default());
+    crate::db::Ad4mDb::with_global_instance(|db| db.set_multi_user_enabled(true).unwrap());
+    crate::db::Ad4mDb::with_global_instance(|db| {
+        db.set_host_rates(&[("gpt-4".to_string(), 0.5)]).unwrap()
+    });
+
+    let token = user_jwt_token("billing-user@ex.test");
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    AIService::bill_and_forward_stream_result(Some(token), "gpt-4", Ok(sample_prompt_result()), tx)
+        .await;
+    let forwarded = rx.await.unwrap().unwrap();
+    assert_eq!(forwarded.text, "hello world");
+    assert_eq!(forwarded.prompt_tokens, 10);
+    assert_eq!(forwarded.completion_tokens, 5);
+
+    let calls = test_seam::calls();
+    assert_eq!(
+        calls.len(),
+        1,
+        "stream completion must bill exactly once; got calls: {calls:?}"
+    );
+    assert_eq!(calls[0].email, "billing-user@ex.test");
+    assert!(
+        (calls[0].amount - 7.5).abs() < f64::EPSILON,
+        "15 tokens @ 0.5"
+    );
+    assert_eq!(calls[0].operation, "ai_prompt");
+    assert_eq!(
+        calls[0].summary.as_deref(),
+        Some("15 tokens (model: gpt-4)")
+    );
+
+    crate::db::Ad4mDb::with_global_instance(|db| {
+        db.set_multi_user_enabled(prev_multi_user).unwrap()
+    });
+    crate::db::Ad4mDb::with_global_instance(|db| db.set_host_rates(&prev_rates).unwrap());
+    test_seam::reset();
+}
+
+#[tokio::test]
+async fn stream_error_does_not_bill() {
+    init_test_db();
+    test_seam::reset();
+    test_seam::force_result(test_seam::ForcedResult::Success);
+
+    // A valid user token is passed on purpose: the skip must come from
+    // the Err gate, not from token absence (matches prompt_messages, which
+    // bills only after a successful prompt).
+    let result: Result<PromptResult, anyhow::Error> = Err(anyhow::anyhow!("inference failed"));
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    AIService::bill_and_forward_stream_result(
+        Some(user_jwt_token("billing-user@ex.test")),
+        "gpt-4",
+        result,
+        tx,
+    )
+    .await;
+    let err = rx.await.unwrap().unwrap_err();
+    assert_eq!(err.to_string(), "inference failed");
+
+    assert!(
+        test_seam::calls().is_empty(),
+        "failed streams must not bill; got calls: {:?}",
+        test_seam::calls()
+    );
+    test_seam::reset();
+}
+
+#[tokio::test]
+async fn stream_without_token_does_not_bill() {
+    init_test_db();
+    test_seam::reset();
+    test_seam::force_result(test_seam::ForcedResult::Success);
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    AIService::bill_and_forward_stream_result(None, "gpt-4", Ok(sample_prompt_result()), tx).await;
+    let forwarded = rx.await.unwrap().unwrap();
+    assert_eq!(forwarded.text, "hello world");
+
+    assert!(
+        test_seam::calls().is_empty(),
+        "unauthenticated streams must not bill; got calls: {:?}",
+        test_seam::calls()
     );
     test_seam::reset();
 }

--- a/rust-executor/src/api/openai_compat/tests.rs
+++ b/rust-executor/src/api/openai_compat/tests.rs
@@ -981,6 +981,11 @@ use crate::ai_service::{AIService, PromptResult};
 
 /// Ensure the global wallet has a "main" keypair (decode_jwt signs and
 /// verifies with it) and return a user JWT whose `sub` is `email`.
+///
+/// Mints against the *current* global "main" key. Safe under the project's
+/// single-threaded test convention (`--test-threads=1`, see package.json);
+/// a parallel test rotating the key via `test_utils::setup_wallet()`
+/// between mint and decode would break verification.
 fn user_jwt_token(email: &str) -> String {
     use jsonwebtoken::{encode, EncodingKey, Header};
     let wallet = crate::wallet::Wallet::instance();
@@ -1019,23 +1024,51 @@ fn sample_prompt_result() -> PromptResult {
     }
 }
 
+/// Restores multi-user mode + host rates on drop, so a panicking
+/// assertion can't leak settings into the rest of the test binary (the
+/// global in-memory DB is shared across all tests).
+struct DbSettingsGuard {
+    prev_multi_user: bool,
+    prev_rates: Vec<(String, f64)>,
+}
+
+impl DbSettingsGuard {
+    fn set(multi_user: bool, rates: &[(String, f64)]) -> Self {
+        let prev_multi_user = crate::db::Ad4mDb::with_global_instance(|db| {
+            db.get_multi_user_enabled().unwrap_or(false)
+        });
+        let prev_rates =
+            crate::db::Ad4mDb::with_global_instance(|db| db.get_host_rates().unwrap_or_default());
+        let _ = crate::db::Ad4mDb::with_global_instance(|db| {
+            db.set_multi_user_enabled(multi_user)?;
+            db.set_host_rates(rates)
+        });
+        Self {
+            prev_multi_user,
+            prev_rates,
+        }
+    }
+}
+
+impl Drop for DbSettingsGuard {
+    fn drop(&mut self) {
+        let _ = crate::db::Ad4mDb::with_global_instance(|db| {
+            db.set_multi_user_enabled(self.prev_multi_user)?;
+            db.set_host_rates(&self.prev_rates)
+        });
+    }
+}
+
 #[tokio::test]
 async fn stream_completion_bills_once_on_success() {
     init_test_db();
     test_seam::reset();
     test_seam::force_result(test_seam::ForcedResult::Success);
 
-    // bill_prompt_if_authed needs: multi-user mode on + a user JWT, and
-    // bill_ai_operation needs a priced model. Save/restore both because
-    // the global in-memory DB is shared across the test binary.
-    let prev_multi_user =
-        crate::db::Ad4mDb::with_global_instance(|db| db.get_multi_user_enabled().unwrap_or(false));
-    let prev_rates =
-        crate::db::Ad4mDb::with_global_instance(|db| db.get_host_rates().unwrap_or_default());
-    crate::db::Ad4mDb::with_global_instance(|db| db.set_multi_user_enabled(true).unwrap());
-    crate::db::Ad4mDb::with_global_instance(|db| {
-        db.set_host_rates(&[("gpt-4".to_string(), 0.5)]).unwrap()
-    });
+    // bill_prompt_if_authed needs multi-user mode on + a user JWT, and
+    // bill_ai_operation needs a priced model. The guard restores both even
+    // if an assertion below panics.
+    let _guard = DbSettingsGuard::set(true, &[("gpt-4".to_string(), 0.5)]);
 
     let token = user_jwt_token("billing-user@ex.test");
     let (tx, rx) = tokio::sync::oneshot::channel();
@@ -1063,10 +1096,6 @@ async fn stream_completion_bills_once_on_success() {
         Some("15 tokens (model: gpt-4)")
     );
 
-    crate::db::Ad4mDb::with_global_instance(|db| {
-        db.set_multi_user_enabled(prev_multi_user).unwrap()
-    });
-    crate::db::Ad4mDb::with_global_instance(|db| db.set_host_rates(&prev_rates).unwrap());
     test_seam::reset();
 }
 
@@ -1075,6 +1104,12 @@ async fn stream_error_does_not_bill() {
     init_test_db();
     test_seam::reset();
     test_seam::force_result(test_seam::ForcedResult::Success);
+
+    // Multi-user mode + a priced model are enabled on purpose: the only
+    // thing that must stop billing here is the Err gate. Without this, the
+    // skip would come from the missing user email and the test would pass
+    // even if error streams did bill.
+    let _guard = DbSettingsGuard::set(true, &[("gpt-4".to_string(), 0.5)]);
 
     // A valid user token is passed on purpose: the skip must come from
     // the Err gate, not from token absence (matches prompt_messages, which

--- a/rust-executor/src/holochain_service/mod.rs
+++ b/rust-executor/src/holochain_service/mod.rs
@@ -13,8 +13,8 @@ use holochain::conductor::paths::DataRootPath;
 use holochain::conductor::{ConductorBuilder, ConductorHandle};
 use holochain::prelude::hash_type::Agent;
 use holochain::prelude::{
-    AppManifest, DnaHash, ExternIO, HoloHash, InstallAppPayload, Kitsune2NetworkMetricsRequest,
-    Signal, Signature, Timestamp, ZomeCallParams, ZomeCallResponse,
+    AppManifest, ExternIO, HoloHash, InstallAppPayload, Kitsune2NetworkMetricsRequest, Signal,
+    Signature, Timestamp, ZomeCallParams, ZomeCallResponse,
 };
 use holochain::test_utils::itertools::Either;
 

--- a/rust-executor/src/js_core/mod.rs
+++ b/rust-executor/src/js_core/mod.rs
@@ -1,6 +1,6 @@
 use ::futures::Future;
 use deno_core::anyhow::anyhow;
-use deno_core::error::{AnyError, CoreError};
+use deno_core::error::AnyError;
 use deno_core::{resolve_url_or_path, v8, PollEventLoopOptions};
 use deno_fs::RealFs;
 use deno_resolver::npm::DenoInNpmPackageChecker;

--- a/rust-executor/src/js_core/string_module_loader.rs
+++ b/rust-executor/src/js_core/string_module_loader.rs
@@ -1,5 +1,3 @@
-use deno_core::error::CoreError;
-use deno_core::error::JsError;
 use deno_core::error::ModuleLoaderError;
 use deno_core::ModuleLoadResponse;
 use deno_core::ModuleLoader;
@@ -7,7 +5,6 @@ use deno_core::ModuleSource;
 use deno_core::ModuleSourceCode;
 use deno_core::ModuleSpecifier;
 use deno_core::ModuleType;
-use deno_core::RequestedModuleType;
 use deno_core::ResolutionKind;
 use deno_core::SourceCodeCacheInfo;
 use deno_error::JsErrorClass;

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -187,10 +187,10 @@ async fn holochain_signal_receiver() {
                     // languages that want direct-signal support can wire it
                     // in later via a dedicated handler.
                     //
-                    // Matched explicitly rather than falling through the
-                    // wildcard so any *future* Signal variant surfaces as a
-                    // real unhandled-variant log line instead of being silently
-                    // rebranded as an AppDirect. (Data's PR #907 review MED-4.)
+                    // Matched explicitly so any *future* Signal variant
+                    // surfaces as an unhandled-variant compile error instead
+                    // of being silently rebranded as an AppDirect.
+                    // (Data's PR #907 review MED-4.)
                     Signal::AppDirect { .. } => {
                         log::debug!(
                             "Received Signal::AppDirect (HC 0.7 direct peer signal; \

--- a/rust-executor/src/lib.rs
+++ b/rust-executor/src/lib.rs
@@ -197,9 +197,6 @@ async fn holochain_signal_receiver() {
                              not routed to per-language handlers)"
                         );
                     }
-                    _ => {
-                        log::debug!("Received unhandled Holochain signal variant: {:?}", signal);
-                    }
                 }
             } else {
                 // stream_receiver.recv() returned None — channel closed.
@@ -221,7 +218,7 @@ pub async fn run(mut config: Ad4mConfig) -> JoinHandle<()> {
     unsafe {
         let mut action: sigaction = std::mem::zeroed();
         action.sa_flags = SA_ONSTACK;
-        action.sa_sigaction = handle_sigurg as sighandler_t;
+        action.sa_sigaction = handle_sigurg as *const () as sighandler_t;
         sigemptyset(&mut action.sa_mask);
 
         if libc::sigaction(SIGURG, &action, ptr::null_mut()) != 0 {

--- a/rust-executor/src/perspectives/interpretation/overlay/mod.rs
+++ b/rust-executor/src/perspectives/interpretation/overlay/mod.rs
@@ -44,9 +44,7 @@ mod classes;
 mod gate;
 mod write;
 
-pub(crate) use accept::{
-    accept_interpretation, list_overlays, overlay_of, reject_interpretation, OverlayView,
-};
+pub(crate) use accept::{accept_interpretation, list_overlays, reject_interpretation};
 pub use classes::InterpretationRunCursor;
 pub(crate) use classes::{
     ensure_interpretation_overlay_classes, mint_interpretation_run, InterpretationRunMeta,

--- a/rust-executor/src/perspectives/model_query/sparql_builder.rs
+++ b/rust-executor/src/perspectives/model_query/sparql_builder.rs
@@ -1003,7 +1003,7 @@ fn compile_leaf_condition(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::perspectives::model_query::test_helpers::{flag, prop, relation, shape};
+    use crate::perspectives::model_query::test_helpers::{flag, prop, shape};
 
     fn make_pg(sort_key: SortKey, direction: OrderDirection) -> SparqlPagination {
         SparqlPagination {


### PR DESCRIPTION
Some warnings were simple fixes, some revealed that the OpenAI compat. interface did not exercise billing in all paths. Both fixed.

### Qwen3.8:

# Fix missing billing on streaming chat + clean up warnings and dead billing code
Two related cleanups on top of the host_rates billing unification (be2f390bc, 45827c0b4):

1. Bill streaming chat completions (the actual bug)
POST /v1/chat/completions with stream: true was pre-checked for credits but never billed — the auth token arrived at the stream path as an unused _auth_token. It now bills exactly once, on success, through the same bill_ai_operation / host_rates path as oneshot and WS-RPC:
AIService::prompt_messages_stream relays the worker’s final Result<PromptResult> through a forwarder; new bill_and_forward_stream_result bills via bill_prompt_if_authed only when the stream completed successfully, then forwards the result to the caller (worker panic still delivers an error, bills nothing).

2. Remove orphaned handler-level billing formulas
MIN_PROMPT_BILL, chat_or_completion_amount, stream_prompt_amount, embedding_amount lost their only production callers when billing moved into AIService — their pinning tests asserted formulas production no longer used (e.g. streaming at a flat 1.0 credit). Removed them plus the 5 stale tests; speech_amount (TTS, still used by audio.rs) is kept.

3. Warning cleanup (15 lib + 2 test warnings)
Unused imports (DnaHash, CoreError, RequestedModuleType, …), a dead match arm, and a sighandler_t cast.

## Tests
3 new tests in api/openai_compat: stream_completion_bills_once_on_success (exactly one debit, amount = tokens × host rate, correct op label/summary), stream_error_does_not_bill, stream_without_token_does_not_bill
cargo check --lib --tests: 0 warnings
cargo test --lib api::openai_compat: 91 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Billing**
  * Successful streaming AI responses are now billed consistently with non-streaming requests.
  * Failed or unauthenticated streams are not billed.

* **Bug Fixes**
  * Improved handling when streaming results cannot be forwarded to the caller.
  * Removed obsolete endpoint-level billing logic while preserving quota checks and response behavior.

* **Maintenance**
  * Cleaned up unused code and imports.
  * Tightened signal handling so unexpected signal variants are detected during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->