### PR TITLE
feat(ad4m-ldk): extract WebSocket interfaces into ALDK

### DIFF
--- a/ad4m-ldk/js/src/index.ts
+++ b/ad4m-ldk/js/src/index.ts
@@ -30,3 +30,4 @@ export * from "./types.js";
 export * from "./errors.js";
 export * from "./imports.js";
 export * from "./defineLanguage.js";
+export * from "./websocket.js";

--- a/ad4m-ldk/js/src/websocket-globals.d.ts
+++ b/ad4m-ldk/js/src/websocket-globals.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Minimal ambient declarations for WebSocket globals available in the
+ * executor's Deno language sandbox. The executor runs a full
+ * deno_runtime MainWorker (not a bare deno_core isolate), so
+ * deno_web/deno_net/deno_websocket are all present at runtime.
+ *
+ * Only the subset used by DenoWebSocketFactory appears here —
+ * adding "DOM" to lib would pull in thousands of unused types.
+ */
+
+declare class WebSocket {
+    constructor(url: string | URL);
+    send(data: string | ArrayBuffer | Blob | ArrayBufferView): void;
+    close(code?: number, reason?: string): void;
+    addEventListener(type: "open", listener: (event: Event) => void): void;
+    addEventListener(type: "message", listener: (event: MessageEvent) => void): void;
+    addEventListener(type: "close", listener: (event: CloseEvent) => void): void;
+    addEventListener(type: "error", listener: (event: Event) => void): void;
+}
+
+declare class Event {
+    readonly type: string;
+}
+
+declare class MessageEvent extends Event {
+    readonly data: unknown;
+}
+
+declare class CloseEvent extends Event {
+    readonly code: number;
+    readonly reason: string;
+}
+
+declare class Blob {}

--- a/ad4m-ldk/js/src/websocket-globals.d.ts
+++ b/ad4m-ldk/js/src/websocket-globals.d.ts
@@ -10,6 +10,8 @@
 
 declare class WebSocket {
     constructor(url: string | URL);
+    /** 0 = CONNECTING, 1 = OPEN, 2 = CLOSING, 3 = CLOSED. */
+    readonly readyState: number;
     send(data: string | ArrayBuffer | Blob | ArrayBufferView): void;
     close(code?: number, reason?: string): void;
     addEventListener(type: "open", listener: (event: Event) => void): void;

--- a/ad4m-ldk/js/src/websocket.ts
+++ b/ad4m-ldk/js/src/websocket.ts
@@ -1,0 +1,62 @@
+/**
+ * WebSocket adapter interfaces and Deno implementation.
+ *
+ * Provides a platform-agnostic WebSocket abstraction so link languages
+ * can open WebSocket connections without directly depending on the Deno
+ * or browser WebSocket global. The DenoWebSocketFactory wraps the native
+ * WebSocket global available in the executor's language sandbox.
+ */
+
+/** A single open (or opening) WebSocket-like connection. */
+export interface WSConnection {
+    send(data: string): void;
+    close(code?: number, reason?: string): void;
+    onOpen(cb: () => void): void;
+    onMessage(cb: (data: string) => void): void;
+    onClose(cb: (code: number, reason: string) => void): void;
+    onError(cb: (err: unknown) => void): void;
+}
+
+/** Factory for creating WebSocket connections. */
+export interface WebSocketFactory {
+    connect(url: string): WSConnection;
+}
+
+/**
+ * Wraps the native WebSocket global available in the executor's Deno
+ * language sandbox. The executor runs a full deno_runtime MainWorker
+ * (not a bare deno_core isolate), so deno_web/deno_net/deno_websocket
+ * are all present.
+ */
+export class DenoWebSocketFactory implements WebSocketFactory {
+    connect(url: string): WSConnection {
+        const ws = new WebSocket(url);
+
+        return {
+            send(data: string): void {
+                ws.send(data);
+            },
+            close(code?: number, reason?: string): void {
+                try {
+                    ws.close(code, reason);
+                } catch {
+                    // Already closed/closing
+                }
+            },
+            onOpen(cb: () => void): void {
+                ws.addEventListener("open", () => cb());
+            },
+            onMessage(cb: (data: string) => void): void {
+                ws.addEventListener("message", (event: MessageEvent) => {
+                    cb(typeof event.data === "string" ? event.data : String(event.data));
+                });
+            },
+            onClose(cb: (code: number, reason: string) => void): void {
+                ws.addEventListener("close", (event: CloseEvent) => cb(event.code, event.reason));
+            },
+            onError(cb: (err: unknown) => void): void {
+                ws.addEventListener("error", (event: Event) => cb(event));
+            },
+        };
+    }
+}

--- a/ad4m-ldk/js/src/websocket.ts
+++ b/ad4m-ldk/js/src/websocket.ts
@@ -41,10 +41,14 @@ function isBinaryPayload(data: unknown): boolean {
  */
 class DenoWSConnection implements WSConnection {
     private readonly ws: WebSocket;
-    private errorCallback?: (err: unknown) => void;
+    private readonly errorCallbacks: Array<(err: unknown) => void> = [];
 
     constructor(url: string) {
         this.ws = new WebSocket(url);
+    }
+
+    private emitError(err: unknown): void {
+        for (const cb of this.errorCallbacks) cb(err);
     }
 
     send(data: string): void {
@@ -59,7 +63,7 @@ class DenoWSConnection implements WSConnection {
             this.ws.close(code, reason);
         } catch (err) {
             // Forward unexpected close failures instead of dropping them silently.
-            this.errorCallback?.(err);
+            this.emitError(err);
         }
     }
 
@@ -77,7 +81,7 @@ class DenoWSConnection implements WSConnection {
             if (isBinaryPayload(data)) {
                 // No binary path in this interface (link languages are text/JSON only) —
                 // report it instead of silently mangling the payload via String(data).
-                this.errorCallback?.(new Error("DenoWebSocketFactory: received a binary WebSocket frame, which is not supported"));
+                this.emitError(new Error("DenoWebSocketFactory: received a binary WebSocket frame, which is not supported"));
                 return;
             }
             cb(String(data));
@@ -89,7 +93,7 @@ class DenoWSConnection implements WSConnection {
     }
 
     onError(cb: (err: unknown) => void): void {
-        this.errorCallback = cb;
+        this.errorCallbacks.push(cb);
         this.ws.addEventListener("error", (event: Event) => cb(event));
     }
 }

--- a/ad4m-ldk/js/src/websocket.ts
+++ b/ad4m-ldk/js/src/websocket.ts
@@ -22,41 +22,80 @@ export interface WebSocketFactory {
     connect(url: string): WSConnection;
 }
 
+const READY_STATE_CLOSING = 2;
+const READY_STATE_CLOSED = 3;
+
+function isBinaryPayload(data: unknown): boolean {
+    return (
+        (typeof ArrayBuffer !== "undefined" && data instanceof ArrayBuffer) ||
+        (typeof Blob !== "undefined" && data instanceof Blob) ||
+        ArrayBuffer.isView(data)
+    );
+}
+
 /**
  * Wraps the native WebSocket global available in the executor's Deno
  * language sandbox. The executor runs a full deno_runtime MainWorker
  * (not a bare deno_core isolate), so deno_web/deno_net/deno_websocket
  * are all present.
  */
+class DenoWSConnection implements WSConnection {
+    private readonly ws: WebSocket;
+    private errorCallback?: (err: unknown) => void;
+
+    constructor(url: string) {
+        this.ws = new WebSocket(url);
+    }
+
+    send(data: string): void {
+        this.ws.send(data);
+    }
+
+    close(code?: number, reason?: string): void {
+        if (this.ws.readyState === READY_STATE_CLOSING || this.ws.readyState === READY_STATE_CLOSED) {
+            return;
+        }
+        try {
+            this.ws.close(code, reason);
+        } catch (err) {
+            // Forward unexpected close failures instead of dropping them silently.
+            this.errorCallback?.(err);
+        }
+    }
+
+    onOpen(cb: () => void): void {
+        this.ws.addEventListener("open", () => cb());
+    }
+
+    onMessage(cb: (data: string) => void): void {
+        this.ws.addEventListener("message", (event: MessageEvent) => {
+            const data = event.data;
+            if (typeof data === "string") {
+                cb(data);
+                return;
+            }
+            if (isBinaryPayload(data)) {
+                // No binary path in this interface (link languages are text/JSON only) —
+                // report it instead of silently mangling the payload via String(data).
+                this.errorCallback?.(new Error("DenoWebSocketFactory: received a binary WebSocket frame, which is not supported"));
+                return;
+            }
+            cb(String(data));
+        });
+    }
+
+    onClose(cb: (code: number, reason: string) => void): void {
+        this.ws.addEventListener("close", (event: CloseEvent) => cb(event.code, event.reason));
+    }
+
+    onError(cb: (err: unknown) => void): void {
+        this.errorCallback = cb;
+        this.ws.addEventListener("error", (event: Event) => cb(event));
+    }
+}
+
 export class DenoWebSocketFactory implements WebSocketFactory {
     connect(url: string): WSConnection {
-        const ws = new WebSocket(url);
-
-        return {
-            send(data: string): void {
-                ws.send(data);
-            },
-            close(code?: number, reason?: string): void {
-                try {
-                    ws.close(code, reason);
-                } catch {
-                    // Already closed/closing
-                }
-            },
-            onOpen(cb: () => void): void {
-                ws.addEventListener("open", () => cb());
-            },
-            onMessage(cb: (data: string) => void): void {
-                ws.addEventListener("message", (event: MessageEvent) => {
-                    cb(typeof event.data === "string" ? event.data : String(event.data));
-                });
-            },
-            onClose(cb: (code: number, reason: string) => void): void {
-                ws.addEventListener("close", (event: CloseEvent) => cb(event.code, event.reason));
-            },
-            onError(cb: (err: unknown) => void): void {
-                ws.addEventListener("error", (event: Event) => cb(event));
-            },
-        };
+        return new DenoWSConnection(url);
     }
 }

--- a/ad4m-ldk/js/tests/websocket.test.ts
+++ b/ad4m-ldk/js/tests/websocket.test.ts
@@ -9,6 +9,7 @@ class MockWebSocket {
     closed = false;
     closeCode?: number;
     closeReason?: string;
+    readyState = 1; // OPEN
 
     constructor(url: string) {
         this.url = url;
@@ -110,12 +111,26 @@ describe("websocket: DenoWebSocketFactory", () => {
         assert.equal(lastMock?.closeReason, "done");
     });
 
-    it("close() swallows errors from already-closed sockets", () => {
+    it("close() is a no-op when the socket is already CLOSING or CLOSED", () => {
         const factory = new DenoWebSocketFactory();
         const conn = factory.connect("ws://localhost:3456/ws");
         const mock = lastMock!;
-        mock.close = () => { throw new Error("already closed"); };
+        mock.close = () => { throw new Error("should not be called"); };
+        mock.readyState = 3; // CLOSED
         assert.doesNotThrow(() => conn.close());
+        assert.equal(mock.closed, false);
+    });
+
+    it("close() forwards unexpected close errors to onError instead of dropping them", () => {
+        const factory = new DenoWebSocketFactory();
+        const conn = factory.connect("ws://localhost:3456/ws");
+        const mock = lastMock!;
+        const thrown = new Error("write after end");
+        mock.close = () => { throw thrown; };
+        let received: unknown = null;
+        conn.onError((err) => { received = err; });
+        assert.doesNotThrow(() => conn.close());
+        assert.equal(received, thrown);
     });
 
     it("onOpen fires when the WebSocket open event dispatches", () => {
@@ -136,13 +151,26 @@ describe("websocket: DenoWebSocketFactory", () => {
         assert.deepEqual(received, ["text payload"]);
     });
 
-    it("onMessage stringifies non-string data", () => {
+    it("onMessage stringifies non-string, non-binary data", () => {
         const factory = new DenoWebSocketFactory();
         const conn = factory.connect("ws://localhost:3456/ws");
         const received: string[] = [];
         conn.onMessage((data) => received.push(data));
         lastMock!.emit("message", { data: 42 });
         assert.deepEqual(received, ["42"]);
+    });
+
+    it("onMessage forwards binary frames to onError instead of mangling them", () => {
+        const factory = new DenoWebSocketFactory();
+        const conn = factory.connect("ws://localhost:3456/ws");
+        const received: string[] = [];
+        let error: unknown = null;
+        conn.onMessage((data) => received.push(data));
+        conn.onError((err) => { error = err; });
+        lastMock!.emit("message", { data: new ArrayBuffer(4) });
+        assert.deepEqual(received, []);
+        assert.ok(error instanceof Error);
+        assert.match((error as Error).message, /binary/i);
     });
 
     it("onClose passes code and reason", () => {

--- a/ad4m-ldk/js/tests/websocket.test.ts
+++ b/ad4m-ldk/js/tests/websocket.test.ts
@@ -194,6 +194,27 @@ describe("websocket: DenoWebSocketFactory", () => {
         assert.equal(received, errEvent);
     });
 
+    it("onError notifies every registered callback, not just the last one", () => {
+        const factory = new DenoWebSocketFactory();
+        const conn = factory.connect("ws://localhost:3456/ws");
+        const mock = lastMock!;
+        const firstReceived: unknown[] = [];
+        const secondReceived: unknown[] = [];
+        conn.onError((err) => firstReceived.push(err));
+        conn.onError((err) => secondReceived.push(err));
+
+        const errEvent = { type: "error" };
+        mock.emit("error", errEvent);
+        assert.deepEqual(firstReceived, [errEvent]);
+        assert.deepEqual(secondReceived, [errEvent]);
+
+        const closeErr = new Error("boom");
+        mock.close = () => { throw closeErr; };
+        conn.close();
+        assert.deepEqual(firstReceived, [errEvent, closeErr]);
+        assert.deepEqual(secondReceived, [errEvent, closeErr]);
+    });
+
     it("implements WebSocketFactory interface", () => {
         const factory: WebSocketFactory = new DenoWebSocketFactory();
         assert.equal(typeof factory.connect, "function");

--- a/ad4m-ldk/js/tests/websocket.test.ts
+++ b/ad4m-ldk/js/tests/websocket.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { DenoWebSocketFactory, type WSConnection, type WebSocketFactory } from "../src/websocket.js";
+
+class MockWebSocket {
+    url: string;
+    listeners: Record<string, Array<(e: any) => void>> = {};
+    sentMessages: string[] = [];
+    closed = false;
+    closeCode?: number;
+    closeReason?: string;
+
+    constructor(url: string) {
+        this.url = url;
+    }
+
+    send(data: string): void {
+        this.sentMessages.push(data);
+    }
+
+    close(code?: number, reason?: string): void {
+        this.closed = true;
+        this.closeCode = code;
+        this.closeReason = reason;
+    }
+
+    addEventListener(type: string, listener: (e: any) => void): void {
+        (this.listeners[type] ??= []).push(listener);
+    }
+
+    emit(type: string, event: any): void {
+        for (const cb of this.listeners[type] ?? []) cb(event);
+    }
+}
+
+let originalWebSocket: any;
+let lastMock: MockWebSocket | undefined;
+
+beforeEach(() => {
+    originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = class extends MockWebSocket {
+        constructor(url: string) {
+            super(url);
+            lastMock = this;
+        }
+    };
+});
+
+afterEach(() => {
+    (globalThis as any).WebSocket = originalWebSocket;
+    lastMock = undefined;
+});
+
+describe("websocket: interfaces", () => {
+    it("WSConnection shape matches the contract", () => {
+        const conn: WSConnection = {
+            send(_d: string) {},
+            close(_c?: number, _r?: string) {},
+            onOpen(_cb) {},
+            onMessage(_cb) {},
+            onClose(_cb) {},
+            onError(_cb) {},
+        };
+        assert.equal(typeof conn.send, "function");
+        assert.equal(typeof conn.close, "function");
+        assert.equal(typeof conn.onOpen, "function");
+        assert.equal(typeof conn.onMessage, "function");
+        assert.equal(typeof conn.onClose, "function");
+        assert.equal(typeof conn.onError, "function");
+    });
+
+    it("WebSocketFactory shape matches the contract", () => {
+        const factory: WebSocketFactory = {
+            connect(_url: string): WSConnection {
+                return {
+                    send() {},
+                    close() {},
+                    onOpen() {},
+                    onMessage() {},
+                    onClose() {},
+                    onError() {},
+                };
+            },
+        };
+        assert.equal(typeof factory.connect, "function");
+    });
+});
+
+describe("websocket: DenoWebSocketFactory", () => {
+    it("connect() creates a WebSocket with the given URL", () => {
+        const factory = new DenoWebSocketFactory();
+        factory.connect("ws://localhost:3456/ws");
+        assert.equal(lastMock?.url, "ws://localhost:3456/ws");
+    });
+
+    it("send() forwards data through the WebSocket", () => {
+        const factory = new DenoWebSocketFactory();
+        const conn = factory.connect("ws://localhost:3456/ws");
+        conn.send("hello");
+        conn.send("world");
+        assert.deepEqual(lastMock?.sentMessages, ["hello", "world"]);
+    });
+
+    it("close() calls WebSocket.close with code and reason", () => {
+        const factory = new DenoWebSocketFactory();
+        const conn = factory.connect("ws://localhost:3456/ws");
+        conn.close(1000, "done");
+        assert.equal(lastMock?.closed, true);
+        assert.equal(lastMock?.closeCode, 1000);
+        assert.equal(lastMock?.closeReason, "done");
+    });
+
+    it("close() swallows errors from already-closed sockets", () => {
+        const factory = new DenoWebSocketFactory();
+        const conn = factory.connect("ws://localhost:3456/ws");
+        const mock = lastMock!;
+        mock.close = () => { throw new Error("already closed"); };
+        assert.doesNotThrow(() => conn.close());
+    });
+
+    it("onOpen fires when the WebSocket open event dispatches", () => {
+        const factory = new DenoWebSocketFactory();
+        const conn = factory.connect("ws://localhost:3456/ws");
+        let fired = false;
+        conn.onOpen(() => { fired = true; });
+        lastMock!.emit("open", {});
+        assert.equal(fired, true);
+    });
+
+    it("onMessage passes string data to the callback", () => {
+        const factory = new DenoWebSocketFactory();
+        const conn = factory.connect("ws://localhost:3456/ws");
+        const received: string[] = [];
+        conn.onMessage((data) => received.push(data));
+        lastMock!.emit("message", { data: "text payload" });
+        assert.deepEqual(received, ["text payload"]);
+    });
+
+    it("onMessage stringifies non-string data", () => {
+        const factory = new DenoWebSocketFactory();
+        const conn = factory.connect("ws://localhost:3456/ws");
+        const received: string[] = [];
+        conn.onMessage((data) => received.push(data));
+        lastMock!.emit("message", { data: 42 });
+        assert.deepEqual(received, ["42"]);
+    });
+
+    it("onClose passes code and reason", () => {
+        const factory = new DenoWebSocketFactory();
+        const conn = factory.connect("ws://localhost:3456/ws");
+        let closeCode = 0;
+        let closeReason = "";
+        conn.onClose((code, reason) => { closeCode = code; closeReason = reason; });
+        lastMock!.emit("close", { code: 1001, reason: "going away" });
+        assert.equal(closeCode, 1001);
+        assert.equal(closeReason, "going away");
+    });
+
+    it("onError forwards the event to the callback", () => {
+        const factory = new DenoWebSocketFactory();
+        const conn = factory.connect("ws://localhost:3456/ws");
+        let received: unknown = null;
+        conn.onError((err) => { received = err; });
+        const errEvent = { type: "error" };
+        lastMock!.emit("error", errEvent);
+        assert.equal(received, errEvent);
+    });
+
+    it("implements WebSocketFactory interface", () => {
+        const factory: WebSocketFactory = new DenoWebSocketFactory();
+        assert.equal(typeof factory.connect, "function");
+    });
+});


### PR DESCRIPTION
## Summary

- Extracts `WSConnection`, `WebSocketFactory` interfaces and `DenoWebSocketFactory` class into `@coasys/ad4m-ldk` (`ad4m-ldk/js/src/websocket.ts`)
- Adds minimal ambient type declarations (`websocket-globals.d.ts`) for the WebSocket globals the executor's Deno sandbox provides — avoids pulling full DOM lib into the ALDK tsconfig
- Adds 12 tests covering interface contracts and adapter behaviour via mock WebSocket global
- Exports from the ALDK barrel (`ad4m-ldk/js/src/index.ts`)

## Context

The server-link-language ([#930](https://github.com/coasys/ad4m/pull/930)) defines its own WebSocket abstraction layer. These interfaces and the Deno implementation belong in the LDK so every link language can reuse them without duplicating adapter code.

Once this lands, #930 replaces its local `WSConnection`/`WebSocketFactory`/`DenoWebSocketFactory` definitions with imports from `@coasys/ad4m-ldk`.

## Test plan

- [x] `tsc --noEmit` passes (ambient types resolve WebSocket/MessageEvent/CloseEvent/Event)
- [x] 12 new websocket tests pass (interface contracts + DenoWebSocketFactory mock)
- [x] 7 existing defineLanguage tests still pass
- [ ] CI `build-and-test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a platform-agnostic WebSocket interface for connecting, sending messages, closing connections, and handling events.
  * Added Deno WebSocket support, including connection lifecycle and message handling.

* **Tests**
  * Added coverage for WebSocket connections, event handling, closing behavior, errors, and binary messages.

* **Developer Experience**
  * Added TypeScript declarations for WebSocket-related runtime globals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->