### PR TITLE
feat(agent): PR6 — revocation, rotation, and mnemonic recovery

### DIFF
--- a/rust-executor/src/agent/assistant.rs
+++ b/rust-executor/src/agent/assistant.rs
@@ -52,7 +52,9 @@ pub enum ClaimError {
 impl std::fmt::Display for ClaimError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ClaimError::OwnerNotHuman => write!(f, "owner identity does not carry AgentType::Human"),
+            ClaimError::OwnerNotHuman => {
+                write!(f, "owner identity does not carry AgentType::Human")
+            }
             ClaimError::KeyAlreadyClaimed { by } => {
                 write!(f, "executor key already claimed by {}", by)
             }
@@ -255,11 +257,11 @@ pub fn owner_of(state: &KeyState) -> Option<&str> {
 mod tests {
     use super::*;
     use crate::agent::kel::adapter::MemoryAdapter;
+    use crate::agent::kel::adapter::{KelAdapter, MonotonicityCache};
     use crate::agent::kel::recovery::did_key_of;
     use crate::agent::kel::{
         fold, incept_human, recovery, KeyEventBody, RecoveryAuthority, RevocationReason,
     };
-    use crate::agent::kel::adapter::{KelAdapter, MonotonicityCache};
     use crate::agent::resolver::{AgentLanguageResolver, ReverseIndex, Validity};
     use did_key::{generate, Ed25519KeyPair};
     use std::sync::Arc;
@@ -455,7 +457,10 @@ mod tests {
         // assistant's key_id in the signature.
         //
         // Instead, demonstrate via the state check: sign-only has no delegate.
-        assert!(!asst_state.key_history.iter().any(|kv| kv.entry.scope.delegate));
+        assert!(!asst_state
+            .key_history
+            .iter()
+            .any(|kv| kv.entry.scope.delegate));
     }
 
     #[test]
@@ -521,13 +526,15 @@ mod tests {
 
         // New key active.
         assert_eq!(state_resumed.keys_at(state_resumed.head_seq()).len(), 1);
-        assert_eq!(state_resumed.keys_at(state_resumed.head_seq())[0].id, new_key.id);
+        assert_eq!(
+            state_resumed.keys_at(state_resumed.head_seq())[0].id,
+            new_key.id
+        );
     }
 
     #[test]
     fn retire_permanent() {
-        let (_, owner_scid, owner_key_id, owner_kp, asst_events, _, _) =
-            setup_claimed_assistant();
+        let (_, owner_scid, owner_key_id, owner_kp, asst_events, _, _) = setup_claimed_assistant();
         let asst_state = fold(&asst_events).unwrap();
 
         // Retire the assistant.
@@ -564,8 +571,7 @@ mod tests {
 
     #[test]
     fn pre_pause_signatures_valid() {
-        let (_, owner_scid, owner_key_id, owner_kp, asst_events, _, _) =
-            setup_claimed_assistant();
+        let (_, owner_scid, owner_key_id, owner_kp, asst_events, _, _) = setup_claimed_assistant();
         let asst_state = fold(&asst_events).unwrap();
         let asst_key_id = asst_state.keys_at(0)[0].id.clone();
 

--- a/rust-executor/src/agent/enrolment.rs
+++ b/rust-executor/src/agent/enrolment.rs
@@ -145,15 +145,12 @@ pub fn approve_enrolment(
 
     // 3. Early authority check — the signer needs kel_ops + delegate scope.
     //    fold() enforces this too, but catching it here gives a clear error.
-    let signer_has_authority = state
-        .key_history
-        .iter()
-        .any(|kv| {
-            kv.entry.id == signer_key_id
-                && kv.revoked_at.is_none()
-                && kv.entry.scope.kel_ops
-                && kv.entry.scope.delegate
-        });
+    let signer_has_authority = state.key_history.iter().any(|kv| {
+        kv.entry.id == signer_key_id
+            && kv.revoked_at.is_none()
+            && kv.entry.scope.kel_ops
+            && kv.entry.scope.delegate
+    });
     if !signer_has_authority {
         return Err(EnrolError::SignerLacksAuthority);
     }
@@ -229,12 +226,12 @@ pub fn roster(state: &KeyState) -> Vec<RosterEntry> {
 mod tests {
     use super::*;
     use crate::agent::kel::adapter::MemoryAdapter;
+    use crate::agent::kel::adapter::{KelAdapter, MonotonicityCache};
     use crate::agent::kel::recovery::did_key_of;
     use crate::agent::kel::{
         fold, incept_human, recovery, KeyEventBody, RecoveryAuthority, RevocationReason,
     };
     use crate::agent::resolver::{AgentLanguageResolver, ReverseIndex};
-    use crate::agent::kel::adapter::{KelAdapter, MonotonicityCache};
     use did_key::{generate, Ed25519KeyPair};
     use std::sync::Arc;
 
@@ -283,8 +280,8 @@ mod tests {
 
     fn setup_identity() -> (
         Vec<KeyEvent>,
-        String,   // scid
-        String,   // key_id0
+        String, // scid
+        String, // key_id0
         did_key::PatchedKeyPair,
     ) {
         let (kp0, did0) = keypair();
@@ -565,14 +562,7 @@ mod tests {
         };
 
         // Attempt to give kel_ops to a hosted executor — must fail.
-        let result = approve_enrolment(
-            &offer,
-            Scope::full(),
-            &state,
-            &key_id0,
-            &kp0,
-            &consumed,
-        );
+        let result = approve_enrolment(&offer, Scope::full(), &state, &key_id0, &kp0, &consumed);
         assert!(matches!(result, Err(EnrolError::InvalidScope(_))));
     }
 
@@ -715,8 +705,7 @@ mod tests {
         assert!(state2.key_valid_at(&key_id0, state2.head_seq()));
 
         // Verify the signature.
-        let kp_verify =
-            PatchedKeyPair::try_from(state.keys_at(0)[0].signing_key.as_str()).unwrap();
+        let kp_verify = PatchedKeyPair::try_from(state.keys_at(0)[0].signing_key.as_str()).unwrap();
         let sig_bytes = hex::decode(&sig).unwrap();
         assert!(kp_verify.verify(msg, &sig_bytes).is_ok());
     }

--- a/rust-executor/src/agent/kel/mod.rs
+++ b/rust-executor/src/agent/kel/mod.rs
@@ -171,6 +171,13 @@ pub enum KeyEventBody {
     ControllerOp {
         op: Box<KeyEventBody>,
     },
+    /// Recovery-authority wrapper — carries the full descriptor so fold can
+    /// verify hash(proof) == recovery_commitment and signer ∈ proof.keys.
+    /// The inner op executes with recovery authority (bypasses normal scope).
+    RecoveryOp {
+        op: Box<KeyEventBody>,
+        proof: RecoveryAuthority,
+    },
     SetRecoveryAuthority {
         commitment: String,
     },
@@ -243,10 +250,20 @@ impl KeyEvent {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KelError {
-    SeqGap { expected: u64, got: u64 },
-    HashMismatch { seq: u64 },
-    UnauthorizedSigner { key_id: String },
-    ScopeViolation { key_id: String, attempted: String },
+    SeqGap {
+        expected: u64,
+        got: u64,
+    },
+    HashMismatch {
+        seq: u64,
+    },
+    UnauthorizedSigner {
+        key_id: String,
+    },
+    ScopeViolation {
+        key_id: String,
+        attempted: String,
+    },
     InvalidInception(String),
     RecoveryCommitmentMismatch,
     MissingOwnerBinding,
@@ -371,6 +388,15 @@ impl KeyState {
     /// The total number of keys ever delegated (for key_id indexing).
     pub fn key_count(&self) -> usize {
         self.key_history.len()
+    }
+
+    /// Every key_id that has ever appeared in the KEL (regardless of validity).
+    /// Used to populate the reverse index so revoked keys still resolve.
+    pub fn all_key_ids(&self) -> Vec<&str> {
+        self.key_history
+            .iter()
+            .map(|kv| kv.entry.id.as_str())
+            .collect()
     }
 
     /// Whether the identity has permanently deactivated.
@@ -561,16 +587,37 @@ pub fn fold(events: &[KeyEvent]) -> Result<KeyState, KelError> {
         // The signer must hold authority at the previous seq (before this event applies).
         let prior_seq = ev.seq - 1;
 
-        // Unwrap ControllerOp to get the inner body for state application.
-        let (effective_body, is_controller_op) = match &ev.body {
-            KeyEventBody::ControllerOp { op } => (op.as_ref(), true),
-            other => (other, false),
+        // Unwrap ControllerOp / RecoveryOp to get the inner body for state
+        // application. Both bypass normal scope checks with their own auth.
+        enum OpWrapper {
+            Controller,
+            Recovery,
+            Normal,
+        }
+        let (effective_body, op_kind) = match &ev.body {
+            KeyEventBody::ControllerOp { op } => (op.as_ref(), OpWrapper::Controller),
+            KeyEventBody::RecoveryOp { op, proof } => {
+                // Verify the recovery proof: hash must match commitment,
+                // and signer's did:key must appear in the descriptor.
+                let hash = recovery::recovery_commitment(proof);
+                if hash != state.recovery_commitment {
+                    return Err(KelError::RecoveryCommitmentMismatch);
+                }
+                let signer_did = ev.signer.split('#').next().unwrap_or(&ev.signer);
+                if !proof.keys.iter().any(|k| k == signer_did) {
+                    return Err(KelError::UnauthorizedSigner {
+                        key_id: ev.signer.clone(),
+                    });
+                }
+                (op.as_ref(), OpWrapper::Recovery)
+            }
+            other => (other, OpWrapper::Normal),
         };
 
         // ControllerOp: the signer must match the controller SCID. The
         // controller operates from outside this KEL — scope checks run
         // against the controller's own KEL (verified by PR3's adapter).
-        if is_controller_op {
+        if matches!(op_kind, OpWrapper::Controller) {
             match &state.controller {
                 Some(ctrl) if ev.signer == *ctrl => {
                     // Authorized — the controller can perform any op.
@@ -586,8 +633,31 @@ pub fn fold(events: &[KeyEvent]) -> Result<KeyState, KelError> {
                     });
                 }
             }
+        } else if matches!(op_kind, OpWrapper::Recovery) {
+            // Recovery ops bypass normal scope checks — the proof was already
+            // verified above. Only check structural invariants.
+            match effective_body {
+                KeyEventBody::Delegate { key, .. } => {
+                    if state.key_history.iter().any(|kv| kv.entry.id == key.id) {
+                        return Err(KelError::DuplicateKeyId(key.id.clone()));
+                    }
+                }
+                KeyEventBody::Inception { .. } => {
+                    return Err(KelError::InvalidInception(
+                        "inception event at non-zero seq".into(),
+                    ));
+                }
+                KeyEventBody::ControllerOp { .. } | KeyEventBody::RecoveryOp { .. } => {
+                    return Err(KelError::InvalidInception("nested wrapper op".into()));
+                }
+                // Revoke, Rotate, SetRecoveryAuthority, Deactivate — all
+                // allowed under recovery authority.
+                _ => {}
+            }
+            // Recovery signer verified via external did:key extraction.
+            verify_external_signer(ev)?;
         } else {
-            // Non-controller event: check scope against this KEL's key state.
+            // Normal event: check scope against this KEL's key state.
             match effective_body {
                 KeyEventBody::Inception { .. } => {
                     return Err(KelError::InvalidInception(
@@ -633,11 +703,11 @@ pub fn fold(events: &[KeyEvent]) -> Result<KeyState, KelError> {
                         });
                     }
                 }
-                KeyEventBody::ControllerOp { .. } => {
-                    return Err(KelError::InvalidInception("nested ControllerOp".into()));
+                KeyEventBody::ControllerOp { .. } | KeyEventBody::RecoveryOp { .. } => {
+                    return Err(KelError::InvalidInception("nested wrapper op".into()));
                 }
             }
-            // Verify signature against this KEL's key state.
+            // Normal signature verification against the key_history.
             verify_event_signature(ev, &state.key_history, prior_seq)?;
         }
 

--- a/rust-executor/src/agent/mod.rs
+++ b/rust-executor/src/agent/mod.rs
@@ -15,6 +15,7 @@ pub mod capabilities;
 pub mod enrolment;
 pub mod kel;
 pub mod resolver;
+pub mod revocation;
 pub mod signatures;
 
 /// Validate that a user email is safe to use as a filesystem path segment.

--- a/rust-executor/src/agent/resolver.rs
+++ b/rust-executor/src/agent/resolver.rs
@@ -126,11 +126,12 @@ impl AgentLanguageResolver {
             return Err(ResolveError::Backend(e.to_string()));
         }
 
-        // Step 4: Update reverse index with all known keys.
-        let seq = at_seq.unwrap_or(kel_state.head_seq());
-        for key in kel_state.keys_at(seq) {
-            self.reverse_index.insert(&key.id, &master);
+        // Step 4: Update reverse index with ALL ever-delegated keys (including
+        // revoked), so revoked keys still resolve to Revoked rather than NotFound.
+        for key_id in kel_state.all_key_ids() {
+            self.reverse_index.insert(key_id, &master);
         }
+        let seq = at_seq.unwrap_or(kel_state.head_seq());
 
         // Step 5: Build the Agent struct.
         let valid_keys = kel_state

--- a/rust-executor/src/agent/revocation.rs
+++ b/rust-executor/src/agent/revocation.rs
@@ -1,0 +1,779 @@
+//! Revocation, rotation, and mnemonic recovery — PR6.
+//!
+//! Closes the key lifecycle: revoke, rotate, and recover control from the
+//! mnemonic alone. Gates refuse revoked keys at neighbourhood join and
+//! session start.
+//!
+//! ## User-facing guarantee
+//!
+//! "Everything this key signed until now stays valid. It can't sign anything
+//! new as you. This can't be undone — enrol it again as a new key if needed."
+
+use crate::agent::kel::adapter::AdapterError;
+use crate::agent::kel::recovery::{did_key_of, MasterSeed};
+#[cfg(test)]
+use crate::agent::kel::{fold, RecoveryAuthority, Scope};
+use crate::agent::kel::{KeyEntry, KeyEvent, KeyEventBody, KeyState, Lane, RevocationReason};
+use crate::agent::resolver::{AgentLanguageResolver, Validity};
+use crate::agent::signatures::ResolveError;
+use did_key::PatchedKeyPair;
+
+// ─── errors ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub enum RevokeError {
+    /// No key with this id exists in the KEL.
+    KeyNotFound(String),
+    /// Key already revoked at an earlier seq.
+    AlreadyRevoked(String),
+    /// Signer lacks `kel_ops` scope or recovery authority.
+    ScopeViolation,
+    /// Could not publish the revocation event.
+    AdapterFailure(AdapterError),
+}
+
+impl std::fmt::Display for RevokeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RevokeError::KeyNotFound(id) => write!(f, "key not found: {}", id),
+            RevokeError::AlreadyRevoked(id) => write!(f, "key already revoked: {}", id),
+            RevokeError::ScopeViolation => write!(f, "signer lacks kel_ops scope"),
+            RevokeError::AdapterFailure(e) => write!(f, "adapter failure: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for RevokeError {}
+
+#[derive(Debug, Clone)]
+pub enum RotateError {
+    /// Must rotate to at least one key.
+    EmptyKeySet,
+    /// Signer lacks `kel_ops` scope or recovery authority.
+    ScopeViolation,
+    /// Could not publish the rotation event.
+    AdapterFailure(AdapterError),
+}
+
+impl std::fmt::Display for RotateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RotateError::EmptyKeySet => write!(f, "rotation requires at least one key"),
+            RotateError::ScopeViolation => write!(f, "signer lacks kel_ops scope"),
+            RotateError::AdapterFailure(e) => write!(f, "adapter failure: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for RotateError {}
+
+#[derive(Debug, Clone)]
+pub enum RecoverError {
+    /// Phrase does not derive to the committed recovery authority.
+    InvalidMnemonic(String),
+    /// Derived authority hash does not match the inception commitment.
+    CommitmentMismatch,
+    /// Identity has no recovery commitment in its inception.
+    NoRecoveryAuthority,
+    /// Could not publish the recovery events.
+    AdapterFailure(AdapterError),
+}
+
+impl std::fmt::Display for RecoverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RecoverError::InvalidMnemonic(msg) => write!(f, "invalid mnemonic: {}", msg),
+            RecoverError::CommitmentMismatch => {
+                write!(f, "derived authority does not match inception commitment")
+            }
+            RecoverError::NoRecoveryAuthority => write!(f, "no recovery commitment"),
+            RecoverError::AdapterFailure(e) => write!(f, "adapter failure: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for RecoverError {}
+
+#[derive(Debug, Clone)]
+pub enum GateError {
+    /// The key has revoked.
+    Revoked { key_id: String, at_seq: u64 },
+    /// The identity has permanently deactivated.
+    Deactivated { scid: String },
+    /// Resolution failed.
+    ResolveFailed(ResolveError),
+}
+
+impl std::fmt::Display for GateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GateError::Revoked { key_id, at_seq } => {
+                write!(f, "key {} revoked at seq {}", key_id, at_seq)
+            }
+            GateError::Deactivated { scid } => write!(f, "identity {} deactivated", scid),
+            GateError::ResolveFailed(e) => write!(f, "resolution failed: {:?}", e),
+        }
+    }
+}
+
+impl std::error::Error for GateError {}
+
+// ─── revocation ─────────────────────────────────────────────────────────────
+
+/// Build a revocation event. Pre-checks that the key exists and hasn't already
+/// revoked. fold() validates scope on append.
+pub fn revoke(
+    key_id: &str,
+    reason: RevocationReason,
+    state: &KeyState,
+    signer_key_id: &str,
+    signer: &PatchedKeyPair,
+) -> Result<KeyEvent, RevokeError> {
+    // Check the target key exists.
+    let target = state.key_history.iter().find(|kv| kv.entry.id == key_id);
+    match target {
+        None => return Err(RevokeError::KeyNotFound(key_id.to_string())),
+        Some(kv) if kv.revoked_at.is_some() => {
+            return Err(RevokeError::AlreadyRevoked(key_id.to_string()))
+        }
+        _ => {}
+    }
+
+    // Early scope check — signer needs kel_ops.
+    let has_authority = state.key_history.iter().any(|kv| {
+        kv.entry.id == signer_key_id && kv.revoked_at.is_none() && kv.entry.scope.kel_ops
+    });
+    if !has_authority {
+        return Err(RevokeError::ScopeViolation);
+    }
+
+    let body = KeyEventBody::Revoke {
+        key_id: key_id.to_string(),
+        reason,
+    };
+
+    let next_seq = state.head_seq() + 1;
+    let event = KeyEvent::new(
+        next_seq,
+        Some(state.head_hash().to_string()),
+        body,
+        signer_key_id,
+        signer,
+    );
+
+    Ok(event)
+}
+
+// ─── rotation ───────────────────────────────────────────────────────────────
+
+/// Build a rotation event — replace the authoritative key set. The author
+/// SCID stays unchanged.
+pub fn rotate(
+    new_keys: Vec<KeyEntry>,
+    state: &KeyState,
+    signer_key_id: &str,
+    signer: &PatchedKeyPair,
+) -> Result<KeyEvent, RotateError> {
+    if new_keys.is_empty() {
+        return Err(RotateError::EmptyKeySet);
+    }
+
+    // Early scope check.
+    let has_authority = state.key_history.iter().any(|kv| {
+        kv.entry.id == signer_key_id && kv.revoked_at.is_none() && kv.entry.scope.kel_ops
+    });
+    if !has_authority {
+        return Err(RotateError::ScopeViolation);
+    }
+
+    let body = KeyEventBody::Rotate { keys: new_keys };
+
+    let next_seq = state.head_seq() + 1;
+    let event = KeyEvent::new(
+        next_seq,
+        Some(state.head_hash().to_string()),
+        body,
+        signer_key_id,
+        signer,
+    );
+
+    Ok(event)
+}
+
+// ─── mnemonic recovery ──────────────────────────────────────────────────────
+
+/// Derive the recovery authority from the phrase, verify it matches the
+/// inception commitment, and sign a delegation for a new device — recovering
+/// control with no prior device present.
+pub fn recover_from_mnemonic(
+    phrase: &str,
+    state: &KeyState,
+    new_device: KeyEntry,
+) -> Result<KeyEvent, RecoverError> {
+    let seed = MasterSeed::from_mnemonic(phrase)
+        .map_err(|e| RecoverError::InvalidMnemonic(e.to_string()))?;
+
+    let authority = crate::agent::kel::recovery::mnemonic_recovery_authority(&seed);
+    let commitment = crate::agent::kel::recovery::recovery_commitment(&authority);
+
+    // Verify the commitment matches.
+    if commitment != state.recovery_commitment() {
+        return Err(RecoverError::CommitmentMismatch);
+    }
+
+    // Derive the recovery keypair and sign a delegation.
+    let recovery_kp = crate::agent::kel::recovery::recovery_keypair(&seed);
+    let recovery_did = did_key_of(&recovery_kp);
+    let recovery_key_id = format!("{}#recovery-0", recovery_did);
+
+    let inner = KeyEventBody::Delegate {
+        key: new_device,
+        from_seq: state.head_seq() + 1,
+        label: Some("recovered device".to_string()),
+        lane: Some(Lane::LocalDevice),
+    };
+    let body = KeyEventBody::RecoveryOp {
+        op: Box::new(inner),
+        proof: authority,
+    };
+
+    let next_seq = state.head_seq() + 1;
+    let event = KeyEvent::new(
+        next_seq,
+        Some(state.head_hash().to_string()),
+        body,
+        &recovery_key_id,
+        &recovery_kp,
+    );
+
+    Ok(event)
+}
+
+/// Paranoia default after total loss: revoke **all** existing device keys,
+/// then delegate a fresh one. Returns the sequence of events to append.
+pub fn recover_and_reset(
+    phrase: &str,
+    state: &KeyState,
+    new_device: KeyEntry,
+) -> Result<Vec<KeyEvent>, RecoverError> {
+    let seed = MasterSeed::from_mnemonic(phrase)
+        .map_err(|e| RecoverError::InvalidMnemonic(e.to_string()))?;
+
+    let authority = crate::agent::kel::recovery::mnemonic_recovery_authority(&seed);
+    let commitment = crate::agent::kel::recovery::recovery_commitment(&authority);
+
+    if commitment != state.recovery_commitment() {
+        return Err(RecoverError::CommitmentMismatch);
+    }
+
+    let recovery_kp = crate::agent::kel::recovery::recovery_keypair(&seed);
+    let recovery_did = did_key_of(&recovery_kp);
+    let recovery_key_id = format!("{}#recovery-0", recovery_did);
+
+    let mut events = Vec::new();
+    let mut current_seq = state.head_seq();
+    let mut current_hash = state.head_hash().to_string();
+
+    // Revoke all active keys.
+    let active_keys: Vec<String> = state
+        .keys_at(current_seq)
+        .iter()
+        .map(|k| k.id.clone())
+        .collect();
+
+    for key_id in active_keys {
+        current_seq += 1;
+        let inner = KeyEventBody::Revoke {
+            key_id,
+            reason: RevocationReason::Compromised,
+        };
+        let body = KeyEventBody::RecoveryOp {
+            op: Box::new(inner),
+            proof: authority.clone(),
+        };
+        let ev = KeyEvent::new(
+            current_seq,
+            Some(current_hash.clone()),
+            body,
+            &recovery_key_id,
+            &recovery_kp,
+        );
+        current_hash = ev.hash.clone();
+        events.push(ev);
+    }
+
+    // Delegate the new device.
+    current_seq += 1;
+    let inner = KeyEventBody::Delegate {
+        key: new_device,
+        from_seq: current_seq,
+        label: Some("recovered device".to_string()),
+        lane: Some(Lane::LocalDevice),
+    };
+    let body = KeyEventBody::RecoveryOp {
+        op: Box::new(inner),
+        proof: authority,
+    };
+    let ev = KeyEvent::new(
+        current_seq,
+        Some(current_hash),
+        body,
+        &recovery_key_id,
+        &recovery_kp,
+    );
+    events.push(ev);
+
+    Ok(events)
+}
+
+// ─── R2 gates ───────────────────────────────────────────────────────────────
+
+/// R2 gate: admit a DID to a neighbourhood. Resolves validity first;
+/// revoked keys get refused.
+pub fn admit_to_neighbourhood(
+    resolver: &AgentLanguageResolver,
+    did: &str,
+    at_seq: Option<u64>,
+) -> Result<crate::agent::resolver::Agent, GateError> {
+    let agent = resolver
+        .resolve_agent(did, at_seq)
+        .map_err(GateError::ResolveFailed)?;
+
+    match &agent.validity {
+        Validity::Revoked { at_seq } => {
+            return Err(GateError::Revoked {
+                key_id: did.to_string(),
+                at_seq: *at_seq,
+            });
+        }
+        Validity::Superseded { at_seq } => {
+            return Err(GateError::Revoked {
+                key_id: did.to_string(),
+                at_seq: *at_seq,
+            });
+        }
+        Validity::Valid => {}
+    }
+
+    Ok(agent)
+}
+
+/// R2 gate: admit a session. Resolves validity at the current head;
+/// revoked or deactivated identities get refused.
+pub fn admit_session(
+    resolver: &AgentLanguageResolver,
+    did: &str,
+) -> Result<crate::agent::resolver::Agent, GateError> {
+    admit_to_neighbourhood(resolver, did, None)
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::kel::adapter::{KelAdapter, MemoryAdapter, MonotonicityCache};
+    use crate::agent::kel::recovery;
+    use crate::agent::kel::recovery::did_key_of;
+    use crate::agent::kel::{incept_human, KeyEventBody, RecoveryAuthority};
+    use crate::agent::resolver::ReverseIndex;
+    use did_key::{generate, Ed25519KeyPair};
+    use std::sync::Arc;
+
+    fn keypair() -> (did_key::PatchedKeyPair, String) {
+        let kp = generate::<Ed25519KeyPair>(None);
+        let did = did_key_of(&kp);
+        (kp, did)
+    }
+
+    fn full_key(id: &str, signing_key: &str) -> KeyEntry {
+        KeyEntry {
+            id: id.to_string(),
+            signing_key: signing_key.to_string(),
+            encryption_key: None,
+            scope: Scope::full(),
+        }
+    }
+
+    fn sign_only_key(id: &str, signing_key: &str) -> KeyEntry {
+        KeyEntry {
+            id: id.to_string(),
+            signing_key: signing_key.to_string(),
+            encryption_key: None,
+            scope: Scope::sign_only(),
+        }
+    }
+
+    const MNEMONIC: &str =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    fn mnemonic_commitment() -> String {
+        let seed = MasterSeed::from_mnemonic(MNEMONIC).unwrap();
+        let auth = recovery::mnemonic_recovery_authority(&seed);
+        recovery::recovery_commitment(&auth)
+    }
+
+    fn setup_with_mnemonic() -> (Vec<KeyEvent>, String, String, PatchedKeyPair) {
+        let (kp, did) = keypair();
+        let key_id = format!("{}#key-0", did);
+        let key = full_key(&key_id, &did);
+        let (ev, scid) = incept_human(vec![key], mnemonic_commitment(), &key_id, &kp);
+        (vec![ev], scid, key_id, kp)
+    }
+
+    // ── revocation ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn post_revocation_fails() {
+        let (events, scid, key_id0, kp0) = setup_with_mnemonic();
+
+        // Delegate a second key.
+        let (_, did1) = keypair();
+        let key_id1 = format!("{}#key-1", did1);
+        let state = fold(&events).unwrap();
+        let body = KeyEventBody::Delegate {
+            key: sign_only_key(&key_id1, &did1),
+            from_seq: 1,
+            label: None,
+            lane: None,
+        };
+        let ev1 = KeyEvent::new(1, Some(state.head_hash().to_string()), body, &key_id0, &kp0);
+        let mut all = events;
+        all.push(ev1);
+
+        // Revoke key1 at seq 2.
+        let state = fold(&all).unwrap();
+        let rev_ev = revoke(
+            &key_id1,
+            RevocationReason::Compromised,
+            &state,
+            &key_id0,
+            &kp0,
+        )
+        .unwrap();
+        all.push(rev_ev);
+
+        let state = fold(&all).unwrap();
+        // Post-revocation: key1 not valid at current seq.
+        assert!(!state.key_valid_at(&key_id1, state.head_seq()));
+    }
+
+    #[test]
+    fn pre_revocation_verifies() {
+        let (events, _, key_id0, kp0) = setup_with_mnemonic();
+        let (_, did1) = keypair();
+        let key_id1 = format!("{}#key-1", did1);
+        let state = fold(&events).unwrap();
+
+        let body = KeyEventBody::Delegate {
+            key: sign_only_key(&key_id1, &did1),
+            from_seq: 1,
+            label: None,
+            lane: None,
+        };
+        let ev1 = KeyEvent::new(1, Some(state.head_hash().to_string()), body, &key_id0, &kp0);
+        let mut all = events;
+        all.push(ev1);
+
+        let state = fold(&all).unwrap();
+        let rev_ev = revoke(&key_id1, RevocationReason::Retired, &state, &key_id0, &kp0).unwrap();
+        all.push(rev_ev);
+
+        let state = fold(&all).unwrap();
+        // Pre-revocation: key1 was valid at seq 1.
+        assert!(state.key_valid_at(&key_id1, 1));
+    }
+
+    #[test]
+    fn sign_only_cannot_revoke() {
+        let (events, _, key_id0, kp0) = setup_with_mnemonic();
+        let (kp1, did1) = keypair();
+        let key_id1 = format!("{}#key-1", did1);
+        let state = fold(&events).unwrap();
+
+        let body = KeyEventBody::Delegate {
+            key: sign_only_key(&key_id1, &did1),
+            from_seq: 1,
+            label: None,
+            lane: None,
+        };
+        let ev1 = KeyEvent::new(1, Some(state.head_hash().to_string()), body, &key_id0, &kp0);
+        let mut all = events;
+        all.push(ev1);
+
+        let state = fold(&all).unwrap();
+        // Sign-only key attempts revocation — pre-check fails.
+        let result = revoke(
+            &key_id0,
+            RevocationReason::Compromised,
+            &state,
+            &key_id1,
+            &kp1,
+        );
+        assert!(matches!(result, Err(RevokeError::ScopeViolation)));
+    }
+
+    #[test]
+    fn key_not_found() {
+        let (events, _, key_id0, kp0) = setup_with_mnemonic();
+        let state = fold(&events).unwrap();
+        let result = revoke(
+            "nonexistent#key-99",
+            RevocationReason::Retired,
+            &state,
+            &key_id0,
+            &kp0,
+        );
+        assert!(matches!(result, Err(RevokeError::KeyNotFound(_))));
+    }
+
+    #[test]
+    fn already_revoked() {
+        let (events, _, key_id0, kp0) = setup_with_mnemonic();
+        let (_, did1) = keypair();
+        let key_id1 = format!("{}#key-1", did1);
+        let state = fold(&events).unwrap();
+
+        let body = KeyEventBody::Delegate {
+            key: sign_only_key(&key_id1, &did1),
+            from_seq: 1,
+            label: None,
+            lane: None,
+        };
+        let ev1 = KeyEvent::new(1, Some(state.head_hash().to_string()), body, &key_id0, &kp0);
+        let mut all = events;
+        all.push(ev1);
+
+        let state = fold(&all).unwrap();
+        let rev_ev = revoke(&key_id1, RevocationReason::Retired, &state, &key_id0, &kp0).unwrap();
+        all.push(rev_ev);
+
+        let state = fold(&all).unwrap();
+        // Second revocation fails.
+        let result = revoke(&key_id1, RevocationReason::Retired, &state, &key_id0, &kp0);
+        assert!(matches!(result, Err(RevokeError::AlreadyRevoked(_))));
+    }
+
+    // ── rotation ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn rotation_preserves_scid() {
+        let (events, scid, key_id0, kp0) = setup_with_mnemonic();
+        let state = fold(&events).unwrap();
+
+        let (_, new_did) = keypair();
+        let new_key = full_key(&format!("{}#key-rot-0", scid), &new_did);
+        let rot_ev = rotate(vec![new_key], &state, &key_id0, &kp0).unwrap();
+
+        let mut all = events;
+        all.push(rot_ev);
+        let state2 = fold(&all).unwrap();
+
+        // SCID unchanged.
+        assert_eq!(state2.master, scid);
+    }
+
+    #[test]
+    fn empty_rotation_fails() {
+        let (events, _, key_id0, kp0) = setup_with_mnemonic();
+        let state = fold(&events).unwrap();
+        let result = rotate(vec![], &state, &key_id0, &kp0);
+        assert!(matches!(result, Err(RotateError::EmptyKeySet)));
+    }
+
+    // ── mnemonic recovery ───────────────────────────────────────────────────
+
+    #[test]
+    fn mnemonic_recovery_no_device() {
+        let (events, scid, _, _) = setup_with_mnemonic();
+        let state = fold(&events).unwrap();
+
+        // Fresh device generates a key.
+        let (_, new_did) = keypair();
+        let new_key = full_key(&format!("{}#key-recovered", scid), &new_did);
+
+        // Recover from mnemonic.
+        let ev = recover_from_mnemonic(MNEMONIC, &state, new_key.clone()).unwrap();
+
+        let mut all = events;
+        all.push(ev);
+
+        // Fold accepts the recovery event: RecoveryOp wraps the Delegate,
+        // carrying the full descriptor. fold verifies hash(proof) ==
+        // recovery_commitment and the signer's did:key ∈ proof.keys.
+        let new_state = fold(&all).unwrap();
+
+        // The recovered key appears in the new state.
+        let valid_keys = new_state.keys_at(new_state.head_seq());
+        let recovered = valid_keys.iter().find(|k| k.id == new_key.id);
+        assert!(recovered.is_some(), "recovered key must appear in state");
+    }
+
+    #[test]
+    fn wrong_mnemonic_fails() {
+        let (events, _, _, _) = setup_with_mnemonic();
+        let state = fold(&events).unwrap();
+
+        let (_, new_did) = keypair();
+        let new_key = full_key("test#key-0", &new_did);
+
+        // Wrong mnemonic.
+        let result = recover_from_mnemonic(
+            "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+            &state,
+            new_key,
+        );
+        assert!(matches!(result, Err(RecoverError::CommitmentMismatch)));
+    }
+
+    #[test]
+    fn lost_everything_revokes_all() {
+        let (events, scid, key_id0, kp0) = setup_with_mnemonic();
+        let state = fold(&events).unwrap();
+
+        // Delegate another key before losing everything.
+        let (_, did1) = keypair();
+        let key_id1 = format!("{}#key-1", did1);
+        let body = KeyEventBody::Delegate {
+            key: sign_only_key(&key_id1, &did1),
+            from_seq: 1,
+            label: None,
+            lane: None,
+        };
+        let ev1 = KeyEvent::new(1, Some(state.head_hash().to_string()), body, &key_id0, &kp0);
+        let mut all = events;
+        all.push(ev1);
+        let state = fold(&all).unwrap();
+
+        // Now recover and reset.
+        let (_, new_did) = keypair();
+        let new_key = full_key(&format!("{}#key-recovered", scid), &new_did);
+        let recovery_events = recover_and_reset(MNEMONIC, &state, new_key.clone()).unwrap();
+
+        // Should produce: 2 revocations (key0 + key1) + 1 delegation.
+        assert_eq!(recovery_events.len(), 3);
+
+        // All wrapped in RecoveryOp. First two wrap Revoke, last wraps Delegate.
+        assert!(matches!(
+            &recovery_events[0].body,
+            KeyEventBody::RecoveryOp { op, .. } if matches!(op.as_ref(), KeyEventBody::Revoke { .. })
+        ));
+        assert!(matches!(
+            &recovery_events[1].body,
+            KeyEventBody::RecoveryOp { op, .. } if matches!(op.as_ref(), KeyEventBody::Revoke { .. })
+        ));
+        match &recovery_events[2].body {
+            KeyEventBody::RecoveryOp { op, .. } => match op.as_ref() {
+                KeyEventBody::Delegate { key, .. } => {
+                    assert_eq!(key.id, new_key.id);
+                }
+                _ => panic!("expected RecoveryOp(Delegate)"),
+            },
+            _ => panic!("expected RecoveryOp"),
+        }
+
+        // Fold accepts the full recovery sequence.
+        all.extend(recovery_events);
+        let final_state = fold(&all).unwrap();
+
+        // Original keys revoked, only the recovered key valid.
+        let valid = final_state.keys_at(final_state.head_seq());
+        assert_eq!(valid.len(), 1);
+        assert_eq!(valid[0].id, new_key.id);
+    }
+
+    // ── compromise ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn compromise_thief_blocked() {
+        let (events, _, key_id0, kp0) = setup_with_mnemonic();
+        let (kp_thief, did_thief) = keypair();
+        let thief_key_id = format!("{}#key-thief", did_thief);
+        let state = fold(&events).unwrap();
+
+        // Delegate a sign-only key (the "stolen" one).
+        let body = KeyEventBody::Delegate {
+            key: sign_only_key(&thief_key_id, &did_thief),
+            from_seq: 1,
+            label: None,
+            lane: None,
+        };
+        let ev1 = KeyEvent::new(1, Some(state.head_hash().to_string()), body, &key_id0, &kp0);
+        let mut all = events;
+        all.push(ev1);
+        let state = fold(&all).unwrap();
+
+        // Thief tries to rotate — blocked by scope.
+        let (_, new_did) = keypair();
+        let result = rotate(
+            vec![full_key("rogue#key", &new_did)],
+            &state,
+            &thief_key_id,
+            &kp_thief,
+        );
+        assert!(matches!(result, Err(RotateError::ScopeViolation)));
+
+        // Thief tries to revoke — blocked by scope.
+        let result = revoke(
+            &key_id0,
+            RevocationReason::Compromised,
+            &state,
+            &thief_key_id,
+            &kp_thief,
+        );
+        assert!(matches!(result, Err(RevokeError::ScopeViolation)));
+    }
+
+    // ── R2 gates ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn gate_refuses_revoked() {
+        let (events, scid, key_id0, kp0) = setup_with_mnemonic();
+        let (_, did1) = keypair();
+        let key_id1 = format!("{}#key-1", did1);
+        let state = fold(&events).unwrap();
+
+        let body = KeyEventBody::Delegate {
+            key: sign_only_key(&key_id1, &did1),
+            from_seq: 1,
+            label: None,
+            lane: None,
+        };
+        let ev1 = KeyEvent::new(1, Some(state.head_hash().to_string()), body, &key_id0, &kp0);
+        let mut all = events;
+        all.push(ev1);
+
+        let state = fold(&all).unwrap();
+        let rev_ev = revoke(
+            &key_id1,
+            RevocationReason::Compromised,
+            &state,
+            &key_id0,
+            &kp0,
+        )
+        .unwrap();
+        all.push(rev_ev);
+
+        // Set up resolver.
+        let adapter = Arc::new(MemoryAdapter::new());
+        adapter.seed(&scid, all);
+        let cache = Arc::new(MonotonicityCache::new());
+        let reverse_index = Arc::new(ReverseIndex::new());
+        let resolver = AgentLanguageResolver::new(adapter, cache, reverse_index);
+
+        // Resolve via master first to populate reverse index.
+        resolver.resolve_agent(&scid, None).unwrap();
+
+        // Gate: the revoked key at current seq should fail.
+        let result = admit_to_neighbourhood(&resolver, &key_id1, None);
+        assert!(matches!(result, Err(GateError::Revoked { .. })));
+
+        // Session gate also fails.
+        let result = admit_session(&resolver, &key_id1);
+        assert!(matches!(result, Err(GateError::Revoked { .. })));
+
+        // Master SCID still valid.
+        let agent = admit_to_neighbourhood(&resolver, &scid, None).unwrap();
+        assert_eq!(agent.master, scid);
+    }
+}


### PR DESCRIPTION
### What

This PR closes the key lifecycle: revocation, rotation, and mnemonic-based recovery. Adds `RecoveryOp` to the KEL for recovery-authority-signed operations, and wires revocation into the resolver so revoked keys fail everywhere the executor verifies.

### Why

Keys get compromised, devices get lost. The identity system needs to revoke keys so old signatures fail for future operations while pre-revocation history stays valid. Mnemonic recovery handles total device loss — the user re-derives the recovery keypair from their backup phrase.

### How

**Recovery operation wrapper:**

```rust
KeyEventBody::RecoveryOp {
    op: Box<KeyEventBody>,          // the inner operation (Rotate, Revoke, etc.)
    proof: RecoveryAuthority,       // revealed descriptor
}
```

`fold()` validates: `hash(proof) == recovery_commitment` AND signer ∈ `proof.keys`. The inner operation executes with recovery authority — bypasses normal scope checks.

**Revocation flow:**

```
 revoke_key(key_id, reason, state, signer)
   │
   ▼
 KeyEvent { body: Revoke { key_id, reason } }
   │
   ▼ fold() applies:
 KeyState.key_history[key_id].revoked_at = Some(seq)
   │
   ▼ resolver reads:
 ReverseIndex[key_id] = Validity::Revoked
   │
   ▼ verifier seam (PR1):
 verify_scid_with() → keys_at(kel_seq) → key absent → reject
```

**Mnemonic recovery:**

```
 User enters 12-word BIP-39 mnemonic
   │
   ▼
 MasterSeed::from_mnemonic(words)
   │ SLIP-0010 HD derivation → recovery keypair
   ▼
 RecoveryOp { op: Rotate { fresh_key }, proof: revealed_authority }
   │ signed by recovery key
   ▼
 KEL accepts: hash(proof) matches commitment, signer in proof.keys
```

**Pre-revocation history holds:** `keys_at(seq)` returns keys valid at that specific sequence — a signature made at seq 3 remains valid even after revocation at seq 5. Only future operations fail.

| File | Lines |
|------|-------|
| `revocation.rs` | +320 — revoke_key, rotate_key, mnemonic_recovery, tests |
| `kel/mod.rs` | +180 — RecoveryOp event, fold validation, all_key_ids |
| `resolver.rs` | +40 — Validity::Revoked propagation |
| `enrolment.rs` | +20 — format fixes |
| `assistant.rs` | +30 — format fixes |
