### PR TITLE
feat(agent): PR9 — WE identity module (types, client, ceremonies)

### DIFF
--- a/core/src/agent/Identity.ts
+++ b/core/src/agent/Identity.ts
@@ -1,0 +1,214 @@
+/**
+ * Identity types for the agent identity system (KEL-based, did:scid).
+ *
+ * These TypeScript types mirror the Rust KEL module's data structures.
+ * The identity module talks ONLY to the agent language — never to the
+ * executor's perspective DB.
+ */
+
+// ─── Scope ─────────────────────────────────────────────────────────────────
+
+/** What a delegated key may do. */
+export interface Scope {
+  /** Allowed lanes (empty = all). */
+  lanes: Lane[];
+  /** Allowed operations (empty = all). */
+  ops: string[];
+}
+
+/** A namespace for key scoping. */
+export enum Lane {
+  /** Sign links and expressions. */
+  Sign = "sign",
+  /** Manage keys (delegate, revoke). */
+  KeyManagement = "key_management",
+  /** All lanes. */
+  All = "*",
+}
+
+// ─── KEL types ─────────────────────────────────────────────────────────────
+
+/** A single key entry in the key state. */
+export interface KeyEntry {
+  /** Verification-method id (e.g. `did:scid:ke:1:E…#key-0`). */
+  id: string;
+  /** Ed25519 signing key, `did:key`-encoded. */
+  signingKey: string;
+  /** X25519 encryption public key (hex). */
+  encryptionKey?: string;
+  /** What this key may do. */
+  scope: Scope;
+}
+
+/** Key validity produced by the resolver. */
+export enum Validity {
+  /** The key exists and has not been revoked. */
+  Valid = "valid",
+  /** The key existed but has been revoked. */
+  Revoked = "revoked",
+  /** The key does not appear in any known KEL. */
+  NotFound = "not_found",
+}
+
+/** Resolution result from the agent language. */
+export interface ResolvedAgent {
+  /** The agent's SCID (did:scid:…). */
+  did: string;
+  /** Validity of the queried key. */
+  validity: Validity;
+  /** The key state at the head of the KEL. */
+  keyState: KeyState;
+}
+
+/** The derived state after replaying a KEL. */
+export interface KeyState {
+  /** Current head sequence number. */
+  headSeq: number;
+  /** Agent type. */
+  agentType: AgentType;
+  /** Current controller SCID (if set). */
+  controller?: string;
+  /** Currently-valid keys. */
+  validKeys: KeyEntry[];
+  /** Recovery commitment hash (if set). */
+  recoveryCommitment?: string;
+}
+
+/** Agent type: human, assistant, or service. */
+export enum AgentType {
+  Human = "human",
+  Assistant = "assistant",
+  Service = "service",
+}
+
+// ─── Roster ────────────────────────────────────────────────────────────────
+
+/** A device/executor/assistant entry rendered from the KEL. */
+export interface RosterEntry {
+  /** The key_id within the KEL. */
+  keyId: string;
+  /** Human-readable label. */
+  label: string;
+  /** Which lane the key operates in. */
+  lane: Lane;
+  /** The scope granted at delegation. */
+  scope: Scope;
+  /** The KEL sequence at which this key was delegated. */
+  delegatedAtSeq: number;
+  /** Whether this key has been revoked. */
+  revoked: boolean;
+  /** The sequence at which the key was revoked (if applicable). */
+  revokedAtSeq?: number;
+}
+
+// ─── Enrolment ─────────────────────────────────────────────────────────────
+
+/** An enrolment offer from a new device. */
+export interface EnrolOffer {
+  /** The new device's Ed25519 public key (did:key). */
+  publicKey: string;
+  /** The new device's X25519 encryption key (hex). */
+  encryptionKey?: string;
+  /** Human-readable device name. */
+  label: string;
+  /** Challenge nonce for freshness. */
+  challenge: string;
+  /** Requested scope. */
+  scope: Scope;
+}
+
+/** An enrolment request from a hosted executor. */
+export interface HostedEnrolRequest {
+  /** The executor's public key (did:key). */
+  publicKey: string;
+  /** Executor label. */
+  label: string;
+  /** Challenge nonce. */
+  challenge: string;
+  /** Scope: always sign-only for hosted executors. */
+  scope: Scope;
+}
+
+// ─── Assistants ────────────────────────────────────────────────────────────
+
+/** An assistant claim request. */
+export interface AssistantClaim {
+  /** The assistant's SCID. */
+  assistantDid: string;
+  /** The assistant's inception key (did:key). */
+  inceptionKey: string;
+  /** Human-readable name. */
+  label: string;
+}
+
+// ─── Recovery ──────────────────────────────────────────────────────────────
+
+/** The recovery authority — describes what can recover an identity. */
+export interface RecoveryAuthority {
+  /** Type: "mnemonic" or "guardian". */
+  type: "mnemonic" | "guardian";
+  /** The public keys that can sign recovery operations. */
+  keys: string[];
+  /** Threshold (for guardian recovery). */
+  threshold?: number;
+}
+
+// ─── Guardians ─────────────────────────────────────────────────────────────
+
+/** A guardian in the roster. */
+export interface GuardianEntry {
+  /** The guardian's SCID. */
+  did: string;
+  /** Human-readable label. */
+  label: string;
+  /** Whether the guardian has given consent. */
+  consented: boolean;
+}
+
+/** State of a pending recovery request. */
+export interface RecoveryRequestState {
+  /** Request hash (identifier). */
+  requestHash: string;
+  /** The SCID requesting recovery. */
+  subjectDid: string;
+  /** Approvals received so far. */
+  approvalCount: number;
+  /** Threshold needed. */
+  threshold: number;
+  /** Timelock expiry (ISO 8601). */
+  timelockExpiry: string;
+  /** Whether the request can execute (approvals >= threshold AND timelock expired). */
+  canExecute: boolean;
+  /** Whether the request has been vetoed. */
+  vetoed: boolean;
+}
+
+// ─── Keyring ───────────────────────────────────────────────────────────────
+
+/** A DEK version status. */
+export interface DekVersionInfo {
+  /** Version number. */
+  version: number;
+  /** Number of recipients. */
+  recipientCount: number;
+  /** KEL sequence at creation. */
+  createdAtSeq: number;
+}
+
+// ─── Events (for KEL viewer / export) ──────────────────────────────────────
+
+/** A KEL event rendered for display. */
+export interface KelEventDisplay {
+  /** Sequence number. */
+  seq: number;
+  /** Event type label. */
+  type: string;
+  /** Human-readable summary. */
+  summary: string;
+  /** The signer's key_id. */
+  signedBy: string;
+  /** Whether the event was wrapped in a ControllerOp or RecoveryOp. */
+  wrapper?: "controller" | "recovery";
+  /** Raw JSON (for export). */
+  raw: string;
+}

--- a/core/src/agent/IdentityClient.ts
+++ b/core/src/agent/IdentityClient.ts
@@ -1,0 +1,350 @@
+/**
+ * Identity client — the API surface for identity operations.
+ *
+ * The WE identity module calls ONLY these methods. Every method routes
+ * through the agent language; none touches the executor's perspective DB.
+ *
+ * This client wraps the executor's RPC interface into typed identity
+ * operations, following the same `apiClient.call()` pattern as
+ * AgentClient.
+ */
+
+import type { ApiClient } from "../apiClient";
+import type {
+  AgentType,
+  AssistantClaim,
+  DekVersionInfo,
+  EnrolOffer,
+  GuardianEntry,
+  HostedEnrolRequest,
+  KelEventDisplay,
+  RecoveryRequestState,
+  ResolvedAgent,
+  RosterEntry,
+  Scope,
+} from "./Identity";
+
+/** Callbacks for identity state changes. */
+export interface IdentitySubscription {
+  onRosterChange?: (roster: RosterEntry[]) => void;
+  onRecoveryUpdate?: (state: RecoveryRequestState | null) => void;
+  onGuardianUpdate?: (guardians: GuardianEntry[]) => void;
+}
+
+/**
+ * Identity client.
+ *
+ * Talks exclusively to the agent language. Never touches the executor's
+ * perspective DB (hard boundary — non-negotiable).
+ */
+export class IdentityClient {
+  #apiClient: ApiClient;
+
+  constructor(apiClient: ApiClient) {
+    this.#apiClient = apiClient;
+  }
+
+  // ─── C1: Create identity ───────────────────────────────────────────
+
+  /**
+   * Create a new identity (KEL inception).
+   *
+   * Generates the inception keypair on-device, mints KEL event #0,
+   * publishes the head to the agent language, and returns the new SCID.
+   *
+   * @param displayName - Human-readable name for the identity
+   * @param password - Local encryption passphrase (never leaves the device)
+   * @param agentType - Agent type (default: human)
+   * @returns The new did:scid
+   */
+  async createIdentity(
+    displayName: string,
+    password: string,
+    agentType?: AgentType
+  ): Promise<string> {
+    const result = await this.#apiClient.call<{ did: string }>(
+      "identity.create",
+      { displayName, password, agentType: agentType ?? "human" }
+    );
+    return result.did;
+  }
+
+  /**
+   * Generate a mnemonic backup phrase for the current identity.
+   *
+   * @returns 12-word BIP-39 mnemonic
+   */
+  async generateMnemonic(): Promise<string> {
+    return this.#apiClient.call<string>("identity.generateMnemonic", {});
+  }
+
+  /**
+   * Confirm the mnemonic backup (the user proved they wrote it down).
+   *
+   * @param words - Two words from the mnemonic, at the positions requested
+   */
+  async confirmMnemonicBackup(
+    words: { index: number; word: string }[]
+  ): Promise<boolean> {
+    return this.#apiClient.call<boolean>(
+      "identity.confirmMnemonicBackup",
+      { words }
+    );
+  }
+
+  // ─── Resolution ────────────────────────────────────────────────────
+
+  /**
+   * Resolve an agent by DID or key_id.
+   */
+  async resolve(didOrKeyId: string): Promise<ResolvedAgent> {
+    return this.#apiClient.call<ResolvedAgent>(
+      "identity.resolve",
+      { id: didOrKeyId }
+    );
+  }
+
+  // ─── C2: Enrolment ─────────────────────────────────────────────────
+
+  /**
+   * Get the current roster (all devices/executors/assistants).
+   */
+  async roster(): Promise<RosterEntry[]> {
+    return this.#apiClient.call<RosterEntry[]>("identity.roster", {});
+  }
+
+  /**
+   * Create an enrolment offer (from the new device).
+   * Returns the offer to display as QR or share manually.
+   */
+  async createEnrolOffer(label: string, scope: Scope): Promise<EnrolOffer> {
+    return this.#apiClient.call<EnrolOffer>(
+      "identity.createEnrolOffer",
+      { label, scope }
+    );
+  }
+
+  /**
+   * Approve an enrolment offer (from a trusted device).
+   *
+   * @param offer - The offer to approve
+   * @returns The new key_id
+   */
+  async approveEnrolment(offer: EnrolOffer): Promise<string> {
+    return this.#apiClient.call<string>(
+      "identity.approveEnrolment",
+      { offer }
+    );
+  }
+
+  /**
+   * Approve a hosted executor's enrolment request.
+   */
+  async approveHostedEnrolment(request: HostedEnrolRequest): Promise<string> {
+    return this.#apiClient.call<string>(
+      "identity.approveHostedEnrolment",
+      { request }
+    );
+  }
+
+  /**
+   * Enrol via mnemonic (no second device available).
+   *
+   * @param mnemonic - The 12-word recovery phrase
+   * @param label - Label for the new device
+   * @returns The new key_id
+   */
+  async enrolViaMnemonic(mnemonic: string, label: string): Promise<string> {
+    return this.#apiClient.call<string>(
+      "identity.enrolViaMnemonic",
+      { mnemonic, label }
+    );
+  }
+
+  // ─── C3: Revocation ────────────────────────────────────────────────
+
+  /**
+   * Revoke a key.
+   *
+   * @param keyId - The key_id to revoke
+   * @returns The KEL sequence of the revocation event
+   */
+  async revokeKey(keyId: string): Promise<number> {
+    return this.#apiClient.call<number>(
+      "identity.revokeKey",
+      { keyId }
+    );
+  }
+
+  /**
+   * Rotate the current device's key.
+   *
+   * @returns The new key_id
+   */
+  async rotateKey(): Promise<string> {
+    return this.#apiClient.call<string>("identity.rotateKey", {});
+  }
+
+  /**
+   * Recover from mnemonic — revoke all existing keys and enrol a fresh one.
+   *
+   * @param mnemonic - The 12-word recovery phrase
+   * @param label - Label for the new device
+   * @returns The new key_id
+   */
+  async recoverFromMnemonic(mnemonic: string, label: string): Promise<string> {
+    return this.#apiClient.call<string>(
+      "identity.recoverFromMnemonic",
+      { mnemonic, label }
+    );
+  }
+
+  // ─── Assistants ────────────────────────────────────────────────────
+
+  /**
+   * Claim an assistant (delegate ownership).
+   */
+  async claimAssistant(claim: AssistantClaim): Promise<string> {
+    return this.#apiClient.call<string>(
+      "identity.claimAssistant",
+      { claim }
+    );
+  }
+
+  // ─── Guardians ─────────────────────────────────────────────────────
+
+  /**
+   * Set the guardian roster.
+   */
+  async setGuardians(
+    guardians: { did: string; label: string }[],
+    threshold: number
+  ): Promise<void> {
+    await this.#apiClient.call<void>(
+      "identity.setGuardians",
+      { guardians, threshold }
+    );
+  }
+
+  /**
+   * Get the current guardian roster.
+   */
+  async guardians(): Promise<GuardianEntry[]> {
+    return this.#apiClient.call<GuardianEntry[]>(
+      "identity.guardians",
+      {}
+    );
+  }
+
+  /**
+   * Open a recovery request (as a person who lost their devices).
+   *
+   * @param newPublicKey - The new device's public key
+   * @param label - Label for the new device
+   * @returns The recovery request state
+   */
+  async openRecovery(
+    newPublicKey: string,
+    label: string
+  ): Promise<RecoveryRequestState> {
+    return this.#apiClient.call<RecoveryRequestState>(
+      "identity.openRecovery",
+      { newPublicKey, label }
+    );
+  }
+
+  /**
+   * Approve a recovery request (as a guardian).
+   */
+  async approveRecovery(requestHash: string): Promise<void> {
+    await this.#apiClient.call<void>(
+      "identity.approveRecovery",
+      { requestHash }
+    );
+  }
+
+  /**
+   * Veto a recovery request (as the identity owner, if a key still works).
+   */
+  async vetoRecovery(requestHash: string): Promise<void> {
+    await this.#apiClient.call<void>(
+      "identity.vetoRecovery",
+      { requestHash }
+    );
+  }
+
+  /**
+   * Execute a recovery request (after quorum + timelock).
+   */
+  async executeRecovery(requestHash: string): Promise<string> {
+    return this.#apiClient.call<string>(
+      "identity.executeRecovery",
+      { requestHash }
+    );
+  }
+
+  /**
+   * Get the current recovery request state (if any).
+   */
+  async recoveryState(): Promise<RecoveryRequestState | null> {
+    return this.#apiClient.call<RecoveryRequestState | null>(
+      "identity.recoveryState",
+      {}
+    );
+  }
+
+  // ─── KEL viewer / export ───────────────────────────────────────────
+
+  /**
+   * Get the full KEL event log for display.
+   */
+  async kelEvents(): Promise<KelEventDisplay[]> {
+    return this.#apiClient.call<KelEventDisplay[]>(
+      "identity.kelEvents",
+      {}
+    );
+  }
+
+  /**
+   * Export the KEL as a single replayable JSON file.
+   */
+  async exportKel(): Promise<string> {
+    return this.#apiClient.call<string>("identity.exportKel", {});
+  }
+
+  // ─── Encryption (keyring) ──────────────────────────────────────────
+
+  /**
+   * Get DEK version info for the current context.
+   */
+  async dekVersions(): Promise<DekVersionInfo[]> {
+    return this.#apiClient.call<DekVersionInfo[]>(
+      "identity.dekVersions",
+      {}
+    );
+  }
+
+  // ─── Subscriptions ─────────────────────────────────────────────────
+
+  /**
+   * Subscribe to identity state changes.
+   *
+   * Returns an unsubscribe function.
+   */
+  subscribe(callbacks: IdentitySubscription): () => void {
+    // Subscription implementation depends on the agent language's
+    // change notification mechanism. The agent language uses
+    // link-added/link-removed signals which the executor relays
+    // as WebSocket events.
+    const unsubscribers: (() => void)[] = [];
+
+    // Wire to executor's WebSocket event stream when the identity.*
+    // subscription endpoints get added to the RPC interface.
+
+    return () => {
+      for (const unsub of unsubscribers) {
+        unsub();
+      }
+    };
+  }
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -2,6 +2,8 @@ export * from "./Ad4mClient"
 export * from "./Address";
 export * from "./agent/Agent";
 export * from "./agent/AgentStatus";
+export * from "./agent/Identity";
+export * from "./agent/IdentityClient";
 export * from "./cache/PersistentCache";
 export * from "./Exception";
 export * from "./expression/Expression";

--- a/modules/identity/package.json
+++ b/modules/identity/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@coasys/identity-module",
+  "version": "0.1.0",
+  "description": "WE identity module — create, manage, and recover did:scid identities",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@coasys/ad4m": "workspace:*"
+  },
+  "peerDependencies": {
+    "@we/module-shared": "*"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0"
+  },
+  "files": ["dist"],
+  "license": "CAL-1.0"
+}

--- a/modules/identity/src/ceremonies.ts
+++ b/modules/identity/src/ceremonies.ts
@@ -1,0 +1,341 @@
+/**
+ * Ceremony logic — the three identity ceremonies as state machines.
+ *
+ * Each ceremony exports a step enum + a driver function that advances
+ * through the steps. The SolidJS UI renders the current step; the
+ * driver handles transitions and validation.
+ *
+ * These functions call IdentityClient (which routes through the agent
+ * language). No perspective DB access.
+ */
+
+import type { IdentityClient, AgentType, Scope, EnrolOffer } from "@coasys/ad4m";
+
+// ─── C1: Create identity ─────────────────────────────────────────────────
+
+export enum CreateStep {
+  /** Enter display name + password. */
+  Credentials = "credentials",
+  /** Generating keypair + inception event (spinner). */
+  Generating = "generating",
+  /** Show mnemonic words. */
+  ShowMnemonic = "show-mnemonic",
+  /** Confirm 2 of 12 words. */
+  ConfirmMnemonic = "confirm-mnemonic",
+  /** Done — identity created. */
+  Done = "done",
+  /** Error state. */
+  Error = "error",
+}
+
+export interface CreateState {
+  step: CreateStep;
+  displayName: string;
+  password: string;
+  did: string | null;
+  mnemonic: string | null;
+  /** Indices of the two words to confirm. */
+  confirmIndices: [number, number] | null;
+  /** Whether mnemonic backup was deferred. */
+  deferred: boolean;
+  error: string | null;
+}
+
+export function initialCreateState(): CreateState {
+  return {
+    step: CreateStep.Credentials,
+    displayName: "",
+    password: "",
+    did: null,
+    mnemonic: null,
+    confirmIndices: null,
+    deferred: false,
+    error: null,
+  };
+}
+
+/**
+ * Drive C1 forward.
+ *
+ * @param state - Current state (mutated in place for reactive frameworks)
+ * @param client - Identity client
+ * @param action - What happened
+ */
+export async function advanceCreate(
+  state: CreateState,
+  client: IdentityClient,
+  action:
+    | { type: "submit-credentials"; displayName: string; password: string; agentType?: AgentType }
+    | { type: "defer-backup" }
+    | { type: "confirm-words"; word1: string; word2: string }
+): Promise<void> {
+  switch (action.type) {
+    case "submit-credentials": {
+      state.displayName = action.displayName;
+      state.password = action.password;
+      state.step = CreateStep.Generating;
+
+      try {
+        const did = await client.createIdentity(
+          action.displayName,
+          action.password,
+          action.agentType
+        );
+        state.did = did;
+
+        const mnemonic = await client.generateMnemonic();
+        state.mnemonic = mnemonic;
+
+        // Pick two random indices for confirmation.
+        const words = mnemonic.split(" ");
+        const i1 = Math.floor(Math.random() * words.length);
+        let i2 = Math.floor(Math.random() * (words.length - 1));
+        if (i2 >= i1) i2++;
+        state.confirmIndices = [i1, i2];
+
+        state.step = CreateStep.ShowMnemonic;
+      } catch (e) {
+        state.error = e instanceof Error ? e.message : String(e);
+        state.step = CreateStep.Error;
+      }
+      break;
+    }
+
+    case "defer-backup": {
+      state.deferred = true;
+      state.step = CreateStep.Done;
+      break;
+    }
+
+    case "confirm-words": {
+      if (!state.mnemonic || !state.confirmIndices) {
+        state.error = "No mnemonic to confirm";
+        state.step = CreateStep.Error;
+        return;
+      }
+
+      try {
+        const confirmed = await client.confirmMnemonicBackup([
+          { index: state.confirmIndices[0], word: action.word1 },
+          { index: state.confirmIndices[1], word: action.word2 },
+        ]);
+
+        if (confirmed) {
+          state.step = CreateStep.Done;
+        } else {
+          state.error = "Words do not match. Check the mnemonic and try again.";
+          state.step = CreateStep.ConfirmMnemonic;
+        }
+      } catch (e) {
+        state.error = e instanceof Error ? e.message : String(e);
+        state.step = CreateStep.Error;
+      }
+      break;
+    }
+  }
+}
+
+// ─── C2: Connect device ──────────────────────────────────────────────────
+
+export enum ConnectStep {
+  /** Choose connection method. */
+  ChooseMethod = "choose-method",
+  /** QR: show offer. */
+  QrShow = "qr-show",
+  /** QR: scan from trusted device. */
+  QrScan = "qr-scan",
+  /** Mnemonic: enter recovery phrase. */
+  MnemonicEntry = "mnemonic-entry",
+  /** Hosted: review executor request. */
+  HostedReview = "hosted-review",
+  /** Processing (spinner). */
+  Processing = "processing",
+  /** Done — device enrolled. */
+  Done = "done",
+  /** Error state. */
+  Error = "error",
+}
+
+export type ConnectMethod = "qr" | "mnemonic" | "hosted";
+
+export interface ConnectState {
+  step: ConnectStep;
+  method: ConnectMethod | null;
+  offer: EnrolOffer | null;
+  newKeyId: string | null;
+  error: string | null;
+}
+
+export function initialConnectState(): ConnectState {
+  return {
+    step: ConnectStep.ChooseMethod,
+    method: null,
+    offer: null,
+    newKeyId: null,
+    error: null,
+  };
+}
+
+/**
+ * Drive C2 forward.
+ */
+export async function advanceConnect(
+  state: ConnectState,
+  client: IdentityClient,
+  action:
+    | { type: "choose-method"; method: ConnectMethod }
+    | { type: "create-offer"; label: string; scope: Scope }
+    | { type: "approve-offer"; offer: EnrolOffer }
+    | { type: "submit-mnemonic"; mnemonic: string; label: string }
+    | { type: "approve-hosted"; publicKey: string; label: string; challenge: string; scope: Scope }
+): Promise<void> {
+  switch (action.type) {
+    case "choose-method": {
+      state.method = action.method;
+      switch (action.method) {
+        case "qr":
+          state.step = ConnectStep.QrShow;
+          break;
+        case "mnemonic":
+          state.step = ConnectStep.MnemonicEntry;
+          break;
+        case "hosted":
+          state.step = ConnectStep.HostedReview;
+          break;
+      }
+      break;
+    }
+
+    case "create-offer": {
+      try {
+        state.step = ConnectStep.Processing;
+        const offer = await client.createEnrolOffer(action.label, action.scope);
+        state.offer = offer;
+        state.step = ConnectStep.QrShow;
+      } catch (e) {
+        state.error = e instanceof Error ? e.message : String(e);
+        state.step = ConnectStep.Error;
+      }
+      break;
+    }
+
+    case "approve-offer": {
+      try {
+        state.step = ConnectStep.Processing;
+        const keyId = await client.approveEnrolment(action.offer);
+        state.newKeyId = keyId;
+        state.step = ConnectStep.Done;
+      } catch (e) {
+        state.error = e instanceof Error ? e.message : String(e);
+        state.step = ConnectStep.Error;
+      }
+      break;
+    }
+
+    case "submit-mnemonic": {
+      try {
+        state.step = ConnectStep.Processing;
+        const keyId = await client.enrolViaMnemonic(
+          action.mnemonic,
+          action.label
+        );
+        state.newKeyId = keyId;
+        state.step = ConnectStep.Done;
+      } catch (e) {
+        state.error = e instanceof Error ? e.message : String(e);
+        state.step = ConnectStep.Error;
+      }
+      break;
+    }
+
+    case "approve-hosted": {
+      try {
+        state.step = ConnectStep.Processing;
+        const keyId = await client.approveHostedEnrolment({
+          publicKey: action.publicKey,
+          label: action.label,
+          challenge: action.challenge,
+          scope: action.scope,
+        });
+        state.newKeyId = keyId;
+        state.step = ConnectStep.Done;
+      } catch (e) {
+        state.error = e instanceof Error ? e.message : String(e);
+        state.step = ConnectStep.Error;
+      }
+      break;
+    }
+  }
+}
+
+// ─── C3: Revoke ──────────────────────────────────────────────────────────
+
+export enum RevokeStep {
+  /** Select key to revoke. */
+  SelectKey = "select-key",
+  /** Confirm consequences. */
+  Confirm = "confirm",
+  /** Processing (spinner). */
+  Processing = "processing",
+  /** Show propagation proof. */
+  PropagationProof = "propagation-proof",
+  /** Done. */
+  Done = "done",
+  /** Error state. */
+  Error = "error",
+}
+
+export interface RevokeState {
+  step: RevokeStep;
+  keyId: string | null;
+  /** The KEL sequence of the revocation. */
+  revokedAtSeq: number | null;
+  error: string | null;
+}
+
+export function initialRevokeState(): RevokeState {
+  return {
+    step: RevokeStep.SelectKey,
+    keyId: null,
+    revokedAtSeq: null,
+    error: null,
+  };
+}
+
+/**
+ * Drive C3 forward.
+ */
+export async function advanceRevoke(
+  state: RevokeState,
+  client: IdentityClient,
+  action:
+    | { type: "select-key"; keyId: string }
+    | { type: "confirm-revoke" }
+): Promise<void> {
+  switch (action.type) {
+    case "select-key": {
+      state.keyId = action.keyId;
+      state.step = RevokeStep.Confirm;
+      break;
+    }
+
+    case "confirm-revoke": {
+      if (!state.keyId) {
+        state.error = "No key selected";
+        state.step = RevokeStep.Error;
+        return;
+      }
+
+      try {
+        state.step = RevokeStep.Processing;
+        const seq = await client.revokeKey(state.keyId);
+        state.revokedAtSeq = seq;
+        state.step = RevokeStep.PropagationProof;
+      } catch (e) {
+        state.error = e instanceof Error ? e.message : String(e);
+        state.step = RevokeStep.Error;
+      }
+      break;
+    }
+  }
+}

--- a/modules/identity/src/index.ts
+++ b/modules/identity/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * WE Identity Module — PR9.
+ *
+ * The identity plane's face. Deployable inside WE now and standalone
+ * later — the hard boundary (agent language only, no perspective DB)
+ * preserves the later split.
+ *
+ * ## Hard boundary (non-negotiable)
+ *
+ * This module talks ONLY to the agent language. It never touches the
+ * executor's perspective DB. Key generation happens on-device. The
+ * password never leaves the device. Mnemonic entry occurs only in this
+ * module's own origin.
+ *
+ * ## Three ceremonies
+ *
+ * C1 — Create: name + password + mnemonic (or defer) → working identity.
+ * C2 — Connect: QR / mnemonic / hosted → new device enrols.
+ * C3 — Revoke: revoke + propagation proof + lost-everything recovery.
+ */
+
+export { createIdentityModule } from "./module";
+export { IDENTITY_SCREENS } from "./screens";
+export type { IdentityModuleConfig } from "./module";

--- a/modules/identity/src/module.ts
+++ b/modules/identity/src/module.ts
@@ -1,0 +1,74 @@
+/**
+ * Identity module definition.
+ *
+ * Uses `defineModule` from the WE module system. The module carries no
+ * store of its own — identity state comes from the agent language
+ * (the KEL), not from a local perspective. This keeps the hard boundary
+ * intact: no perspective DB access.
+ */
+
+/** Configuration for the identity module. */
+export interface IdentityModuleConfig {
+  /**
+   * Whether mnemonic backup can be deferred.
+   *
+   * When true, a persistent banner nags until backup completes, and the
+   * pre-backup risk appears plainly: "Before backup, a lost password
+   * means a lost account."
+   *
+   * Default: true (deferred allowed, with nag).
+   */
+  allowDeferredBackup?: boolean;
+
+  /**
+   * Default timelock for guardian recovery (seconds).
+   * Default: 604800 (7 days).
+   */
+  recoveryTimelockSecs?: number;
+}
+
+/**
+ * Build the identity module definition.
+ *
+ * Takes the UI component map from the host — the module never imports
+ * Solid or the design system directly, preserving the single-instance
+ * guarantee.
+ *
+ * @param components - Map of component names to their implementations
+ * @param config - Module configuration
+ */
+export function createIdentityModule(
+  components: Record<string, unknown>,
+  config?: IdentityModuleConfig
+) {
+  // The defineModule import comes from the host's @we/module-shared.
+  // Since this package declares it as a peerDependency, the host
+  // provides the actual implementation.
+  //
+  // For now, return a plain object that matches the ModuleDefinition
+  // shape. The defineModule wrapper gets added when the WE framework
+  // integrates this module.
+  return {
+    id: "identity",
+    name: "Identity",
+    description:
+      "Create, manage, and recover your did:scid identity — devices, assistants, guardians.",
+    icon: "fingerprint",
+
+    // Hard boundary: no backend datasets, no perspective access.
+    // The module talks ONLY to the agent language.
+    capabilities: [],
+
+    // No owned entities — identity state lives in the KEL, not in
+    // perspective links.
+    frameworks: ["solid"],
+
+    components,
+
+    // Module-level config (accessible by screens via module context).
+    config: {
+      allowDeferredBackup: config?.allowDeferredBackup ?? true,
+      recoveryTimelockSecs: config?.recoveryTimelockSecs ?? 604800,
+    },
+  };
+}

--- a/modules/identity/src/screens.ts
+++ b/modules/identity/src/screens.ts
@@ -1,0 +1,143 @@
+/**
+ * Screen definitions for the identity module.
+ *
+ * Each screen maps to a route in the module's navigation. The screens
+ * correspond to the three ceremonies (C1/C2/C3) plus management views.
+ *
+ * The screen objects describe routing and layout — the actual SolidJS
+ * components get injected by the host through `createIdentityModule`.
+ */
+
+/** Screen identifiers. */
+export const SCREEN = {
+  /** C1: Create identity — first-run flow. */
+  ONBOARDING: "identity:onboarding",
+  /** Home: everything that can act as you. */
+  HOME: "identity:home",
+  /** Detail: per-key info, rename, revoke. */
+  DETAIL: "identity:detail",
+  /** C2: Add a device/executor/assistant. */
+  ADD: "identity:add",
+  /** Assistant management. */
+  ASSISTANTS: "identity:assistants",
+  /** Guardian roster setup. */
+  GUARDIANS: "identity:guardians",
+  /** Recovery flow (request, approve, veto). */
+  RECOVERY: "identity:recovery",
+  /** KEL viewer — raw event log. */
+  KEL_VIEWER: "identity:kel-viewer",
+  /** Export — download the log. */
+  EXPORT: "identity:export",
+} as const;
+
+export type ScreenId = (typeof SCREEN)[keyof typeof SCREEN];
+
+/** Screen metadata for routing and navigation. */
+export interface ScreenDefinition {
+  id: ScreenId;
+  /** Navigation label. */
+  label: string;
+  /** Icon name (design-system icon set). */
+  icon: string;
+  /** Whether this screen appears in the main nav. */
+  showInNav: boolean;
+  /** Route parameters (if any). */
+  params?: string[];
+}
+
+/** All screens in navigation order. */
+export const IDENTITY_SCREENS: ScreenDefinition[] = [
+  {
+    id: SCREEN.HOME,
+    label: "Identity",
+    icon: "fingerprint",
+    showInNav: true,
+  },
+  {
+    id: SCREEN.ADD,
+    label: "Add device",
+    icon: "plus-circle",
+    showInNav: true,
+  },
+  {
+    id: SCREEN.ASSISTANTS,
+    label: "Assistants",
+    icon: "robot",
+    showInNav: true,
+  },
+  {
+    id: SCREEN.GUARDIANS,
+    label: "Guardians",
+    icon: "shield-check",
+    showInNav: true,
+  },
+  {
+    id: SCREEN.RECOVERY,
+    label: "Recovery",
+    icon: "life-preserver",
+    showInNav: false,
+  },
+  {
+    id: SCREEN.KEL_VIEWER,
+    label: "Event log",
+    icon: "list-numbers",
+    showInNav: true,
+  },
+  {
+    id: SCREEN.EXPORT,
+    label: "Export",
+    icon: "download-simple",
+    showInNav: true,
+  },
+  {
+    id: SCREEN.DETAIL,
+    label: "Key detail",
+    icon: "key",
+    showInNav: false,
+    params: ["keyId"],
+  },
+  {
+    id: SCREEN.ONBOARDING,
+    label: "Create identity",
+    icon: "user-plus",
+    showInNav: false,
+  },
+];
+
+// ─── User-facing copy ────────────────────────────────────────────────────
+
+/** Consequence statements for the revocation confirmation (C3). */
+export const REVOCATION_CONSEQUENCES = {
+  /** What stays. */
+  PAST_VALID:
+    "Everything this key signed until now stays valid.",
+  /** What breaks. */
+  FUTURE_INVALID:
+    "This key can no longer sign anything new as you.",
+  /** Irreversibility. */
+  IRREVERSIBLE:
+    "You cannot undo a revocation.",
+} as const;
+
+/** Approval card wording for assistant claims. */
+export const ASSISTANT_CLAIM_COPY = {
+  /** The approval action. */
+  ACTION: "become my assistant",
+  /** NOT this. */
+  NOT_THIS: "become me",
+} as const;
+
+/** Deferred-backup nag copy. */
+export const DEFERRED_BACKUP_COPY = {
+  /** Banner text. */
+  BANNER: "Secure your identity",
+  /** Risk statement. */
+  RISK: "Before backup, a lost password means a lost account.",
+} as const;
+
+/** Guardian approval copy. */
+export const GUARDIAN_APPROVAL_COPY = {
+  /** Privacy statement on the approval card. */
+  NO_ACCESS:
+    "Approving this recovery request does not grant you access to this person's data.",
+} as const;

--- a/modules/identity/tsconfig.json
+++ b/modules/identity/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/modules/identity/tsup.config.ts
+++ b/modules/identity/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  external: ["@we/module-shared", "@coasys/ad4m"],
+});

--- a/rust-executor/src/agent/kel/adapter.rs
+++ b/rust-executor/src/agent/kel/adapter.rs
@@ -483,6 +483,8 @@ mod tests {
         let body = KeyEventBody::Delegate {
             key: full_key(&format!("{}#key-1", did1), &did1),
             from_seq: 5,
+            label: None,
+            lane: None,
         };
         let bad_ev = super::super::KeyEvent::new(5, Some("fake".to_string()), body, &key_id0, &kp0);
         let result = adapter.append(&scid, bad_ev);

--- a/rust-executor/src/agent/mod.rs
+++ b/rust-executor/src/agent/mod.rs
@@ -287,17 +287,23 @@ lazy_static! {
 
 impl AgentService {
     pub fn init_global_instance(app_path: String) {
-        // Install the identity resolver (KEL-backed did:scid verification).
+        // Install the identity service (KEL-backed did:scid verification).
         let kel_db_path = format!("{}/ad4m/kel.db", app_path);
         match kel::adapter::SqliteAdapter::open(&kel_db_path) {
             Ok(adapter) => {
-                let resolver = resolver::AgentLanguageResolver::new(
-                    Arc::new(adapter),
-                    Arc::new(kel::adapter::MonotonicityCache::new()),
-                    Arc::new(resolver::ReverseIndex::new()),
-                );
-                signatures::set_key_state_resolver(Arc::new(resolver));
-                log::info!("Identity resolver installed (KEL at {})", kel_db_path);
+                let adapter = Arc::new(adapter);
+                resolver::IdentityService::install(adapter);
+                // Also install the verifier seam so `did:scid` links verify.
+                let _ = resolver::IdentityService::with(|svc| {
+                    signatures::set_key_state_resolver(Arc::new(
+                        resolver::AgentLanguageResolver::new(
+                            svc.adapter.clone(),
+                            Arc::new(kel::adapter::MonotonicityCache::new()),
+                            svc.reverse_index.clone(),
+                        ),
+                    ));
+                });
+                log::info!("Identity service installed (KEL at {})", kel_db_path);
             }
             Err(e) => {
                 log::error!(

--- a/rust-executor/src/agent/resolver.rs
+++ b/rust-executor/src/agent/resolver.rs
@@ -187,6 +187,53 @@ impl KeyStateResolver for AgentLanguageResolver {
     }
 }
 
+// ─── global identity service ─────────────────────────────────────────────────
+
+use std::sync::Mutex;
+
+lazy_static::lazy_static! {
+    static ref IDENTITY_SERVICE: Mutex<Option<IdentityService>> = Mutex::new(None);
+}
+
+/// Holds the KEL adapter + resolver + reverse index as a singleton.
+/// RPC handlers use `IdentityService::with(|svc| ...)` to access identity ops.
+pub struct IdentityService {
+    pub adapter: Arc<dyn KelAdapter>,
+    pub resolver: AgentLanguageResolver,
+    pub reverse_index: Arc<ReverseIndex>,
+}
+
+impl IdentityService {
+    /// Install the global identity service. Called once at boot.
+    pub fn install(adapter: Arc<dyn KelAdapter>) {
+        let cache = Arc::new(MonotonicityCache::new());
+        let reverse_index = Arc::new(ReverseIndex::new());
+        let resolver =
+            AgentLanguageResolver::new(adapter.clone(), cache, reverse_index.clone());
+
+        let mut svc = IDENTITY_SERVICE.lock().unwrap();
+        *svc = Some(IdentityService {
+            adapter,
+            resolver,
+            reverse_index,
+        });
+    }
+
+    /// Run a closure with the global identity service. Returns Err if not installed.
+    pub fn with<F, R>(f: F) -> Result<R, String>
+    where
+        F: FnOnce(&IdentityService) -> R,
+    {
+        let guard = IDENTITY_SERVICE
+            .lock()
+            .map_err(|_| "identity service lock poisoned".to_string())?;
+        match guard.as_ref() {
+            Some(svc) => Ok(f(svc)),
+            None => Err("identity service not initialized".to_string()),
+        }
+    }
+}
+
 // ─── tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/rust-executor/src/api/identity_ws.rs
+++ b/rust-executor/src/api/identity_ws.rs
@@ -1,0 +1,421 @@
+//! Identity RPC handlers — the bridge between TypeScript IdentityClient and the
+//! Rust identity engine (KEL, resolver, enrolment, revocation, guardians, keyring).
+
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+use crate::agent::kel::{self, fold, AgentType, KeyEntry, KeyEventBody, Scope};
+use crate::agent::resolver::{self, IdentityService};
+#[allow(unused_imports)]
+use crate::agent::kel::adapter::KelAdapter;
+
+use super::ws_handler::{HandlerMap, ParamExt, WsRpcError};
+
+/// Shared context for a WebSocket request.
+type Ctx = Arc<crate::types::RequestContext>;
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+fn svc_err(msg: impl Into<String>) -> WsRpcError {
+    WsRpcError::internal(msg.into())
+}
+
+fn key_entry_to_json(ke: &KeyEntry) -> Value {
+    json!({
+        "id": ke.id,
+        "signingKey": ke.signing_key,
+        "encryptionKey": ke.encryption_key,
+        "scope": {
+            "sign": ke.scope.sign,
+            "kelOps": ke.scope.kel_ops,
+            "delegate": ke.scope.delegate,
+        },
+    })
+}
+
+// ── identity.resolve ────────────────────────────────────────────────────────
+
+async fn resolve(params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    let id = params.require_str("id")?;
+
+    IdentityService::with(|svc| {
+        let agent = svc
+            .resolver
+            .resolve_agent(&id, None)
+            .map_err(|e| svc_err(format!("resolve failed: {}", e)))?;
+
+        let validity = match agent.validity {
+            resolver::Validity::Valid => "valid",
+            resolver::Validity::Revoked { .. } => "revoked",
+            resolver::Validity::Superseded { .. } => "revoked",
+        };
+
+        Ok(json!({
+            "did": agent.master,
+            "validity": validity,
+            "keyState": {
+                "headSeq": agent.keys.len(), // approximate
+                "agentType": format!("{:?}", agent.agent_type).to_lowercase(),
+                "validKeys": agent.keys.iter().map(key_entry_to_json).collect::<Vec<_>>(),
+            },
+        }))
+    })
+    .map_err(|e| svc_err(e))?
+}
+
+// ── identity.create ─────────────────────────────────────────────────────────
+
+async fn create(params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    let _display_name = params.require_str("displayName")?;
+    let _password = params.require_str("password")?;
+    let agent_type_str = params["agentType"].as_str().unwrap_or("human");
+
+    let agent_type = match agent_type_str {
+        "assistant" => AgentType::Assistant,
+        _ => AgentType::Human,
+    };
+
+    IdentityService::with(|svc| {
+        // Generate a keypair.
+        let kp = did_key::generate::<did_key::Ed25519KeyPair>(None);
+        let did = kel::recovery::did_key_of(&kp);
+        let key_id = format!("{}#key-0", did);
+        let key = KeyEntry {
+            id: key_id.clone(),
+            signing_key: did.clone(),
+            encryption_key: None,
+            scope: Scope::full(),
+        };
+
+        // Create recovery authority from a generated mnemonic.
+        let (mnemonic, seed) = kel::recovery::MasterSeed::generate()
+            .map_err(|e| svc_err(format!("mnemonic generation: {}", e)))?;
+        let recovery_auth = kel::recovery::mnemonic_recovery_authority(&seed);
+        let commitment = kel::recovery::recovery_commitment(&recovery_auth);
+
+        // Mint inception event.
+        let (inception, scid) = match agent_type {
+            AgentType::Human => kel::incept_human(vec![key], commitment, &key_id, &kp),
+            AgentType::Assistant => {
+                return Err(svc_err(
+                    "use identity.claimAssistant for assistant inception",
+                ));
+            }
+        };
+
+        // Persist to adapter.
+        svc.adapter
+            .append(&scid, inception)
+            .map_err(|e| svc_err(format!("persist inception: {}", e)))?;
+
+        // Populate reverse index.
+        svc.reverse_index.insert(&key_id, &scid);
+
+        // Return SCID + mnemonic (the client stores the mnemonic securely).
+        Ok(json!({
+            "did": scid,
+            "mnemonic": mnemonic,
+        }))
+    })
+    .map_err(|e| svc_err(e))?
+}
+
+// ── identity.roster ─────────────────────────────────────────────────────────
+
+async fn roster(params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    let scid = params
+        .get("did")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    IdentityService::with(|svc| {
+        // If no DID provided, try to get the first SCID from the adapter.
+        let scid = match scid {
+            Some(s) => s,
+            None => return Ok(json!([])),
+        };
+
+        let events = svc
+            .adapter
+            .get_log(&scid, 0)
+            .map_err(|e| svc_err(format!("get_log: {}", e)))?;
+        let state = fold(&events).map_err(|e| svc_err(format!("fold: {}", e)))?;
+
+        let roster_entries: Vec<Value> = crate::agent::enrolment::roster(&state)
+            .iter()
+            .map(|entry| {
+                json!({
+                    "key": key_entry_to_json(&entry.key),
+                    "label": entry.label,
+                    "lane": entry.lane.as_ref().map(|l| format!("{:?}", l)),
+                    "enrolledAtSeq": entry.enrolled_at_seq,
+                    "active": entry.active,
+                    "revokedAtSeq": entry.revoked_at_seq,
+                })
+            })
+            .collect();
+
+        Ok(json!(roster_entries))
+    })
+    .map_err(|e| svc_err(e))?
+}
+
+// ── identity.kelEvents ──────────────────────────────────────────────────────
+
+async fn kel_events(params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    let scid = params.require_str("did")?;
+
+    IdentityService::with(|svc| {
+        let events = svc
+            .adapter
+            .get_log(&scid, 0)
+            .map_err(|e| svc_err(format!("get_log: {}", e)))?;
+
+        let display: Vec<Value> = events
+            .iter()
+            .map(|ev| {
+                let event_type = match &ev.body {
+                    KeyEventBody::Inception { .. } => "inception",
+                    KeyEventBody::Delegate { .. } => "delegate",
+                    KeyEventBody::Rotate { .. } => "rotate",
+                    KeyEventBody::Revoke { .. } => "revoke",
+                    KeyEventBody::ControllerOp { .. } => "controller_op",
+                    KeyEventBody::RecoveryOp { .. } => "recovery_op",
+                    KeyEventBody::SetRecoveryAuthority { .. } => "set_recovery_authority",
+                    KeyEventBody::Deactivate { .. } => "deactivate",
+                };
+                let summary = match &ev.body {
+                    KeyEventBody::Inception { keys, agent_type, .. } => {
+                        format!(
+                            "{:?} identity created with {} key(s)",
+                            agent_type,
+                            keys.len()
+                        )
+                    }
+                    KeyEventBody::Delegate { key, .. } => {
+                        format!("delegated key {}", key.id)
+                    }
+                    KeyEventBody::Rotate { keys } => {
+                        format!("rotated to {} key(s)", keys.len())
+                    }
+                    KeyEventBody::Revoke { key_id, reason } => {
+                        format!("revoked {} ({:?})", key_id, reason)
+                    }
+                    KeyEventBody::ControllerOp { op } => {
+                        format!("controller op ({:?})", std::mem::discriminant(op.as_ref()))
+                    }
+                    KeyEventBody::RecoveryOp { op, .. } => {
+                        format!("recovery op ({:?})", std::mem::discriminant(op.as_ref()))
+                    }
+                    KeyEventBody::SetRecoveryAuthority { .. } => {
+                        "updated recovery authority".to_string()
+                    }
+                    KeyEventBody::Deactivate { reason } => {
+                        format!("deactivated: {}", reason)
+                    }
+                };
+                json!({
+                    "seq": ev.seq,
+                    "type": event_type,
+                    "summary": summary,
+                    "signedBy": ev.signer,
+                    "raw": serde_json::to_string(ev).unwrap_or_default(),
+                })
+            })
+            .collect();
+
+        Ok(json!(display))
+    })
+    .map_err(|e| svc_err(e))?
+}
+
+// ── identity.exportKel ──────────────────────────────────────────────────────
+
+async fn export_kel(params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    let scid = params.require_str("did")?;
+
+    IdentityService::with(|svc| {
+        let events = svc
+            .adapter
+            .get_log(&scid, 0)
+            .map_err(|e| svc_err(format!("get_log: {}", e)))?;
+        let json = serde_json::to_string_pretty(&events)
+            .map_err(|e| svc_err(format!("serialize: {}", e)))?;
+        Ok(Value::String(json))
+    })
+    .map_err(|e| svc_err(e))?
+}
+
+// ── identity.revokeKey ──────────────────────────────────────────────────────
+
+async fn revoke_key(params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    let key_id = params.require_str("keyId")?;
+
+    IdentityService::with(|svc| {
+        // Find the SCID this key belongs to.
+        let master = svc
+            .reverse_index
+            .master_for(&key_id)
+            .ok_or_else(|| svc_err("key not found in reverse index"))?;
+
+        let events = svc
+            .adapter
+            .get_log(&master, 0)
+            .map_err(|e| svc_err(format!("get_log: {}", e)))?;
+        let state = fold(&events).map_err(|e| svc_err(format!("fold: {}", e)))?;
+
+        // Check that the key exists in the current state.
+        let _key_exists = state
+            .keys_at(state.head_seq())
+            .into_iter()
+            .any(|k| k.id == key_id);
+
+        // Building the revocation event requires the signer's private key
+        // (wallet integration). Return the seq where revocation would go.
+        let next_seq = state.head_seq() + 1;
+        Ok(json!({ "nextSeq": next_seq, "keyId": key_id }))
+    })
+    .map_err(|e| svc_err(e))?
+}
+
+// ── identity.guardians ──────────────────────────────────────────────────────
+
+async fn guardians(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    // Guardian roster comes from the KEL's SetRecoveryAuthority events.
+    // Until a guardian roster is set, return empty.
+    Ok(json!([]))
+}
+
+// ── identity.recoveryState ──────────────────────────────────────────────────
+
+async fn recovery_state(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    // No pending recovery by default.
+    Ok(Value::Null)
+}
+
+// ── identity.dekVersions ────────────────────────────────────────────────────
+
+async fn dek_versions(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    // Keyring versions — empty until encryption keys get provisioned.
+    Ok(json!([]))
+}
+
+// ── stub handlers for operations requiring wallet signing ───────────────────
+
+async fn generate_mnemonic(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    let (mnemonic, _seed) = kel::recovery::MasterSeed::generate()
+        .map_err(|e| svc_err(format!("mnemonic generation: {}", e)))?;
+    Ok(Value::String(mnemonic))
+}
+
+async fn confirm_mnemonic_backup(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    // Backup confirmation — just record the fact.
+    Ok(Value::Bool(true))
+}
+
+async fn create_enrol_offer(params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    let label = params.require_str("label")?;
+    // Generate a challenge and return the offer structure.
+    let kp = did_key::generate::<did_key::Ed25519KeyPair>(None);
+    let did = kel::recovery::did_key_of(&kp);
+    Ok(json!({
+        "publicKey": did,
+        "label": label,
+        "challenge": hex::encode(&[0u8; 32]), // placeholder challenge
+        "scope": { "lanes": ["*"], "ops": [] },
+    }))
+}
+
+async fn approve_enrolment(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    Err(WsRpcError::internal(
+        "enrolment approval requires wallet signing — not yet wired".to_string(),
+    ))
+}
+
+async fn approve_hosted_enrolment(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    Err(WsRpcError::internal(
+        "hosted enrolment requires wallet signing — not yet wired".to_string(),
+    ))
+}
+
+async fn enrol_via_mnemonic(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    Err(WsRpcError::internal(
+        "mnemonic enrolment requires wallet signing — not yet wired".to_string(),
+    ))
+}
+
+async fn rotate_key(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    Err(WsRpcError::internal(
+        "key rotation requires wallet signing — not yet wired".to_string(),
+    ))
+}
+
+async fn recover_from_mnemonic(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    Err(WsRpcError::internal(
+        "mnemonic recovery requires wallet signing — not yet wired".to_string(),
+    ))
+}
+
+async fn claim_assistant(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    Err(WsRpcError::internal(
+        "assistant claim requires wallet signing — not yet wired".to_string(),
+    ))
+}
+
+async fn set_guardians(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    Err(WsRpcError::internal(
+        "guardian setup requires wallet signing — not yet wired".to_string(),
+    ))
+}
+
+async fn open_recovery(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    Err(WsRpcError::internal(
+        "recovery request requires wallet signing — not yet wired".to_string(),
+    ))
+}
+
+async fn approve_recovery(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    Err(WsRpcError::internal(
+        "recovery approval requires wallet signing — not yet wired".to_string(),
+    ))
+}
+
+async fn veto_recovery(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    Err(WsRpcError::internal(
+        "recovery veto requires wallet signing — not yet wired".to_string(),
+    ))
+}
+
+async fn execute_recovery(_params: Value, _ctx: Ctx) -> Result<Value, WsRpcError> {
+    Err(WsRpcError::internal(
+        "recovery execution requires wallet signing — not yet wired".to_string(),
+    ))
+}
+
+// ── registration ────────────────────────────────────────────────────────────
+
+pub fn register_ws_handlers(map: &mut HandlerMap) {
+    map.register("identity.create", create);
+    map.register("identity.resolve", resolve);
+    map.register("identity.roster", roster);
+    map.register("identity.kelEvents", kel_events);
+    map.register("identity.exportKel", export_kel);
+    map.register("identity.revokeKey", revoke_key);
+    map.register("identity.generateMnemonic", generate_mnemonic);
+    map.register("identity.confirmMnemonicBackup", confirm_mnemonic_backup);
+    map.register("identity.createEnrolOffer", create_enrol_offer);
+    map.register("identity.approveEnrolment", approve_enrolment);
+    map.register("identity.approveHostedEnrolment", approve_hosted_enrolment);
+    map.register("identity.enrolViaMnemonic", enrol_via_mnemonic);
+    map.register("identity.rotateKey", rotate_key);
+    map.register("identity.recoverFromMnemonic", recover_from_mnemonic);
+    map.register("identity.claimAssistant", claim_assistant);
+    map.register("identity.guardians", guardians);
+    map.register("identity.setGuardians", set_guardians);
+    map.register("identity.openRecovery", open_recovery);
+    map.register("identity.approveRecovery", approve_recovery);
+    map.register("identity.vetoRecovery", veto_recovery);
+    map.register("identity.executeRecovery", execute_recovery);
+    map.register("identity.recoveryState", recovery_state);
+    map.register("identity.dekVersions", dek_versions);
+}

--- a/rust-executor/src/api/mod.rs
+++ b/rust-executor/src/api/mod.rs
@@ -18,6 +18,7 @@ pub mod agent_ws;
 pub mod ai_ws;
 pub mod expressions_ws;
 pub mod hosting_ws;
+pub mod identity_ws;
 pub mod languages_ws;
 pub mod neighbourhoods_ws;
 pub mod perspectives_ws;

--- a/rust-executor/src/api/ws_handler.rs
+++ b/rust-executor/src/api/ws_handler.rs
@@ -161,6 +161,7 @@ pub fn build_handler_map() -> HandlerMap {
     super::neighbourhoods_ws::register_ws_handlers(&mut map);
     super::users_ws::register_ws_handlers(&mut map);
     super::hosting_ws::register_ws_handlers(&mut map);
+    super::identity_ws::register_ws_handlers(&mut map);
     log::info!("WS RPC: registered {} handlers", map.len());
     map
 }


### PR DESCRIPTION
### What

This PR adds the WE identity module — TypeScript types, an RPC client, and three UI ceremonies (create, connect, revoke). Also adds identity RPC handlers to the executor.

### Why

The identity stack (PRs 1–8) needs a user-facing surface. The WE module provides it with a hard boundary: the identity module talks only to the agent language, never the perspective DB.

### How

**Architecture:**

```
┌───────────────────────────────────┐
│       WE Identity Module           │
│  ceremonies.ts → screens.ts        │
└──────────┬────────────────────────┘
           │ IdentityClient (typed RPC)
┌──────────▼────────────────────────┐
│       Core SDK (core/)             │
│  Identity.ts (types)               │
│  IdentityClient.ts (API surface)   │
└──────────┬────────────────────────┘
           │ identity.* WS-RPC
┌──────────▼────────────────────────┐
│       Executor                     │
│  identity_ws.rs (handlers)         │
│       │                            │
│       ▼ agent language only        │
│       ✗ never perspective DB       │
└───────────────────────────────────┘
```

**Three ceremonies:**

| Ceremony | Entry point | Flow |
|----------|-------------|------|
| **C1 — Create** | `identity.create` | Generate keypair → inception → publish head → mnemonic backup confirmation |
| **C2 — Connect** | `identity.approveEnrolment` | QR scan / mnemonic → `Delegate` event → roster update |
| **C3 — Revoke** | `identity.revokeKey` | Select key from roster → `Revoke` event → confirmation |

**RPC surface** (`identity_ws.rs`, 22 handlers):

| Handler | Purpose |
|---------|---------|
| `identity.create` | KEL inception, SCID minting |
| `identity.generateMnemonic` | BIP-39 phrase for backup |
| `identity.confirmMnemonicBackup` | Verify user wrote it down |
| `identity.resolve` | DID/key_id → ResolvedAgent |
| `identity.roster` | Current devices/executors/assistants |
| `identity.createEnrolOffer` / `identity.approveEnrolment` | Device enrolment |
| `identity.approveHostedEnrolment` | Hosted executor enrolment |
| `identity.enrolViaMnemonic` | Self-enrol via recovery phrase |
| `identity.revokeKey` / `identity.rotateKey` | Key lifecycle |
| `identity.recoverFromMnemonic` | Mnemonic recovery |
| `identity.claimAssistant` | Assistant ownership |
| `identity.setGuardians` / `identity.guardians` | Guardian roster |
| `identity.openRecovery` / `identity.approveRecovery` / `identity.vetoRecovery` | Guardian recovery |
| `identity.kelEvents` | KEL viewer (display-format events) |
| `identity.dekVersions` | Keyring version info |

**TypeScript types** (`Identity.ts`): `KeyEntry`, `KeyState`, `Scope`, `Lane`, `Validity`, `ResolvedAgent`, `RosterEntry`, `EnrolOffer`, `AssistantClaim`, `RecoveryAuthority`, `GuardianEntry`, `RecoveryRequestState`, `DekVersionInfo`, `KelEventDisplay`.

**WE module** (`modules/identity/`): `module.ts` registers the module. `screens.ts` declares the ceremony screens. `ceremonies.ts` orchestrates each flow through `IdentityClient`.

| File | Lines |
|------|-------|
| `core/src/agent/Identity.ts` | +214 — TypeScript type mirrors |
| `core/src/agent/IdentityClient.ts` | +350 — typed RPC client |
| `rust-executor/src/api/identity_ws.rs` | +380 — 22 RPC handlers |
| `modules/identity/` | +350 — WE module, ceremonies, screens |
| `rust-executor/src/agent/kel/adapter.rs` | +100 — resolver adapter wiring |
