### PR TITLE
feat: add subjectClassTargetClasses() for bulk presence check

### DIFF
--- a/core/src/perspectives/PerspectiveProxy.test.ts
+++ b/core/src/perspectives/PerspectiveProxy.test.ts
@@ -529,3 +529,65 @@ describe('QuerySubscriptionProxy', () => {
     expect(liveCallbacks).toBe(0);
   });
 });
+
+describe('PerspectiveProxy.subjectClassTargetClasses', () => {
+  function mockLink(source: string) {
+    return { data: { source, predicate: 'rdf://type', target: 'ad4m://SubjectClass' } };
+  }
+
+  function proxyWithLinks(links: any[]): PerspectiveProxy {
+    const mockClient: any = {
+      ...createMockPerspectiveClient(),
+      queryLinks: jest.fn().mockResolvedValue(links),
+    };
+    return createProxy(mockClient);
+  }
+
+  it('returns full URIs, not stripped names', async () => {
+    const proxy = proxyWithLinks([
+      mockLink('we://Space'),
+      mockLink('flux://Channel'),
+      mockLink('recipe://Recipe'),
+    ]);
+
+    const result = await proxy.subjectClassTargetClasses();
+
+    expect(result).toContain('we://Space');
+    expect(result).toContain('flux://Channel');
+    expect(result).toContain('recipe://Recipe');
+    expect(result).toHaveLength(3);
+  });
+
+  it('deduplicates URIs', async () => {
+    const proxy = proxyWithLinks([
+      mockLink('we://Space'),
+      mockLink('we://Space'),
+    ]);
+
+    expect(await proxy.subjectClassTargetClasses()).toEqual(['we://Space']);
+  });
+
+  it('filters out empty sources', async () => {
+    const proxy = proxyWithLinks([
+      mockLink('we://Space'),
+      mockLink(''),
+    ]);
+
+    expect(await proxy.subjectClassTargetClasses()).toEqual(['we://Space']);
+  });
+
+  it('returns an empty array when no classes are registered', async () => {
+    const proxy = proxyWithLinks([]);
+    expect(await proxy.subjectClassTargetClasses()).toEqual([]);
+  });
+
+  it('returns an empty array on error', async () => {
+    const mockClient: any = {
+      ...createMockPerspectiveClient(),
+      queryLinks: jest.fn().mockRejectedValue(new Error('network error')),
+    };
+    const proxy = createProxy(mockClient);
+
+    expect(await proxy.subjectClassTargetClasses()).toEqual([]);
+  });
+});

--- a/core/src/perspectives/PerspectiveProxy.ts
+++ b/core/src/perspectives/PerspectiveProxy.ts
@@ -1767,6 +1767,38 @@ export class PerspectiveProxy {
         }
     }
 
+    /**
+     * Return the full target-class URIs of every registered SubjectClass.
+     *
+     * Unlike {@link subjectClasses}, which strips the namespace and returns bare
+     * names (`"Space"`, `"Channel"`), this method returns the complete URIs
+     * (`"we://Space"`, `"flux://Channel"`).  The full URI is the key that
+     * `load_shape` resolves against, so it is the only collision-safe identifier
+     * — two apps can both declare a class called `"Template"` under different
+     * namespaces, and the bare name cannot distinguish them.
+     *
+     * Callers that need to check whether a *set* of models are already
+     * registered should call this once and test membership against the returned
+     * set, rather than issuing one `queryLinks` per model.
+     *
+     * One `queryLinks` round trip, no executor-side changes.
+     */
+    async subjectClassTargetClasses(): Promise<string[]> {
+        try {
+            const classLinks = await this.get(new LinkQuery({
+                predicate: "rdf://type",
+                target: "ad4m://SubjectClass"
+            }));
+            const uris = classLinks
+                .map(l => l.data.source)
+                .filter(source => source.length > 0);
+            return [...new Set(uris)];
+        } catch (e) {
+            console.warn('subjectClassTargetClasses: lookup failed:', e);
+            return [];
+        }
+    }
+
     async stringOrTemplateObjectToSubjectClassName<T>(subjectClass: T): Promise<string> {
         if(typeof subjectClass === "string")
             return subjectClass


### PR DESCRIPTION
## What this does

Adds `PerspectiveProxy.subjectClassTargetClasses()` — returns the full target-class URIs of every registered SubjectClass on a perspective.

## Why

The existing `subjectClasses()` strips namespaces (`we://Space` → `Space`), which loses the collision-safe key that `load_shape` resolves against.  Two apps that both declare a class called `Template` under different namespaces become indistinguishable.

Clients that check whether a set of models exist (e.g. during a space switch) can call this once and test membership against the returned set, instead of issuing one `queryLinks` per model.  On a remote executor with 300 ms RTT, 16 models save ~4.5 s of wall-clock time.

## Changes

- `core/src/perspectives/PerspectiveProxy.ts` — new method, single `queryLinks` call, no executor changes
- `core/src/perspectives/PerspectiveProxy.test.ts` — 5 test cases (full URIs, dedup, empty source, empty list, error recovery)

## Test results

594 tests pass (no regressions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to the full target-class URIs for registered subject classes.
  * Results are deduplicated and exclude empty entries.

* **Bug Fixes**
  * Subject-class lookup now safely returns an empty result when no classes are registered or the lookup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->